### PR TITLE
feat(web): landing page UX overhaul — scroll snap, playground UI, footer

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -11,6 +11,21 @@ body {
   @apply bg-background text-foreground antialiased;
 }
 
+/* Thin scrollbar for dark code blocks */
+.code-block-pre::-webkit-scrollbar {
+  height: 3px;
+}
+.code-block-pre::-webkit-scrollbar-track {
+  background: transparent;
+}
+.code-block-pre::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+.code-block-pre::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
 ::selection {
   background: #d7ff00;
   color: #111111;

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -6,20 +6,20 @@ import { RunConnectionCard } from "./RunConnectionCard";
 import { usePlaygroundStore } from "@/lib/playground-store";
 
 export function ConnectAgentCard() {
-  const endpoint = usePlaygroundStore((state) => state.endpoint);
-  const apiKey = usePlaygroundStore((state) => state.apiKey);
   const benchmark = usePlaygroundStore((state) => state.benchmark);
   const phase = usePlaygroundStore((state) => state.phase);
   const quota = usePlaygroundStore((state) => state.quota);
   const quotaLoading = usePlaygroundStore((state) => state.quotaLoading);
   const runError = usePlaygroundStore((state) => state.runError);
-  const setEndpoint = usePlaygroundStore((state) => state.setEndpoint);
-  const setApiKey = usePlaygroundStore((state) => state.setApiKey);
+  const score = usePlaygroundStore((state) => state.score);
+  const timeline = usePlaygroundStore((state) => state.timeline);
   const setBenchmark = usePlaygroundStore((state) => state.setBenchmark);
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
   const startRun = usePlaygroundStore((state) => state.startRun);
-  const reset = usePlaygroundStore((state) => state.reset);
+  const stopRun = usePlaygroundStore((state) => state.stopRun);
+
   const isRunning = phase === "booting" || phase === "running";
+  const isDone = phase === "completed" || phase === "failed";
   const isQuotaBlocked = Boolean(quota && quota.remaining <= 0);
 
   useEffect(() => {
@@ -48,31 +48,12 @@ export function ConnectAgentCard() {
 
       <div className="space-y-4">
         <label className="block">
-          <span className="mb-2 block text-[13px] text-[#5d574d]">MCP endpoint</span>
-          <input
-            value={endpoint}
-            onChange={(event) => setEndpoint(event.target.value)}
-            placeholder="https://agent.local/mcp"
-            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111]"
-          />
-        </label>
-
-        <label className="block">
-          <span className="mb-2 block text-[13px] text-[#5d574d]">Optional auth token</span>
-          <input
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            placeholder="agnt_..."
-            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111]"
-          />
-        </label>
-
-        <label className="block">
           <span className="mb-2 block text-[13px] text-[#5d574d]">Benchmark</span>
           <select
             value={benchmark}
             onChange={(event) => setBenchmark(event.target.value as typeof benchmark)}
-            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111]"
+            disabled={isRunning}
+            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111] disabled:opacity-60"
           >
             {benchmarkOptions.map((item) => (
               <option key={item.value} value={item.value}>
@@ -93,31 +74,85 @@ export function ConnectAgentCard() {
         ) : null}
 
         <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={() => void startRun()}
-            disabled={isRunning || quotaLoading || isQuotaBlocked}
-            className="flex-1 rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111] disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {isRunning
-              ? "Agent Running"
-              : isQuotaBlocked
+          {isRunning ? (
+            <button
+              type="button"
+              onClick={stopRun}
+              className="flex-1 rounded-full bg-[#ff8f6b] px-5 py-3 text-sm font-medium text-[#111111] transition hover:bg-[#ff6b3d]"
+            >
+              Stop Run
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void startRun()}
+              disabled={isRunning || quotaLoading || isQuotaBlocked}
+              className="flex-1 rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111] disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isQuotaBlocked
                 ? quota?.mode === "guest"
                   ? "Guest Trial Used"
                   : "Daily Limit Reached"
                 : "Start Free Run"}
-          </button>
-          <button
-            type="button"
-            onClick={reset}
-            className="rounded-full border border-[#d8d1c4] px-5 py-3 text-sm text-[#111111]"
-          >
-            Reset
-          </button>
+            </button>
+          )}
         </div>
       </div>
 
-      <RunConnectionCard />
+      {isDone ? (
+        <div className="mt-4 rounded-[1.6rem] border border-[#d7d0c4] bg-white p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
+          <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Complete</div>
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            <div className="rounded-[1rem] bg-[#d7ff00] p-3">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-[#4b5520]">Score</div>
+              <div className="mt-1.5 text-2xl font-medium text-[#111111]">{score ?? "--"}</div>
+            </div>
+            <div className="rounded-[1rem] bg-[#efede6] p-3">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-[#6a655c]">Safety</div>
+              <div className="mt-1.5 text-sm text-[#111111]">
+                {phase === "completed" ? "Respected" : "N/A"}
+              </div>
+            </div>
+            <div className="rounded-[1rem] bg-[#111111] p-3">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-white/50">Steps</div>
+              <div className="mt-1.5 text-sm text-white">
+                {score ? `${Math.max(1, Math.round(score / 10))}` : "--"}
+              </div>
+            </div>
+          </div>
+
+          {timeline.length > 0 && (
+            <div className="mt-4">
+              <div className="mb-2 text-[11px] uppercase tracking-[0.18em] text-[#8f8a80]">Recent events</div>
+              <div className="max-h-40 space-y-1.5 overflow-y-auto pr-1">
+              {timeline.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="flex items-center justify-between gap-3 rounded-[0.75rem] bg-[#f6f3ed] px-3 py-2"
+                >
+                  <span className="truncate text-[13px] text-[#111111]">{entry.label}</span>
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] ${
+                      entry.status === "success"
+                        ? "bg-[#d7ff00] text-[#111111]"
+                        : entry.status === "warning"
+                          ? "bg-[#ffd24f] text-[#111111]"
+                          : entry.status === "error"
+                            ? "bg-[#ff8f6b] text-[#111111]"
+                            : "bg-[#efede6] text-[#5c574d]"
+                    }`}
+                  >
+                    {entry.status}
+                  </span>
+                </div>
+              ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <RunConnectionCard />
+      )}
     </div>
   );
 }

--- a/apps/web/components/landing/DocsSection.tsx
+++ b/apps/web/components/landing/DocsSection.tsx
@@ -1,4 +1,4 @@
-import { docsBlocks } from "./data";
+import { docsBlocks, docsSteps } from "./data";
 
 function CodeSnippetBlock({
   title,
@@ -10,7 +10,7 @@ function CodeSnippetBlock({
   return (
     <div className="rounded-[1.8rem] border border-[#d8d0c3] bg-[#111111] p-5 text-white">
       <div className="mb-3 text-xs uppercase tracking-[0.22em] text-white/55">{title}</div>
-      <pre className="overflow-x-auto text-sm leading-7 text-[#d4f285]">
+      <pre className="code-block-pre overflow-x-auto text-sm leading-7 text-[#d4f285]">
         <code>{code}</code>
       </pre>
     </div>
@@ -19,7 +19,7 @@ function CodeSnippetBlock({
 
 export function DocsSection() {
   return (
-    <section id="docs" className="px-6 pb-24 pt-12 md:px-10 lg:px-16">
+    <section id="docs" className="min-h-screen px-6 pb-24 pt-12 md:px-10 lg:px-16 snap-start">
       <div className="mx-auto max-w-7xl">
         <div className="mb-10 max-w-2xl">
           <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Docs</div>
@@ -31,9 +31,27 @@ export function DocsSection() {
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
+        {/* Steps */}
+        <div className="mb-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {docsSteps.map((item) => (
+            <div key={item.step} className="rounded-[1.6rem] border border-[#e0d9ce] bg-white p-5">
+              <div className="mb-3 text-xs font-medium tracking-[0.18em] text-[#a09890]">{item.step}</div>
+              <div className="mb-2 text-base font-medium text-[#111111]">{item.title}</div>
+              <p className="text-sm leading-6 text-[#66625a]">{item.body}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Code blocks row 1 */}
+        <div className="mb-6 grid gap-6 md:grid-cols-2">
           <CodeSnippetBlock title="MCP Config" code={docsBlocks.mcp} />
           <CodeSnippetBlock title="REST Example" code={docsBlocks.rest} />
+        </div>
+
+        {/* Code blocks row 2 */}
+        <div className="grid gap-6 md:grid-cols-2">
+          <CodeSnippetBlock title="Run Response" code={docsBlocks.response} />
+          <CodeSnippetBlock title="Webhook Payload" code={docsBlocks.webhook} />
         </div>
       </div>
     </section>

--- a/apps/web/components/landing/Footer.tsx
+++ b/apps/web/components/landing/Footer.tsx
@@ -1,0 +1,72 @@
+const footerLinks = [
+  {
+    heading: "Product",
+    links: [
+      { label: "Playground", href: "#playground" },
+      { label: "Replay Gallery", href: "#gallery" },
+      { label: "Benchmarks", href: "#docs" },
+      { label: "Pricing", href: "#" },
+    ],
+  },
+  {
+    heading: "Developers",
+    links: [
+      { label: "API Docs", href: "#docs" },
+      { label: "MCP Integration", href: "#docs" },
+      { label: "Webhooks", href: "#docs" },
+      { label: "SDK", href: "#" },
+    ],
+  },
+  {
+    heading: "Company",
+    links: [
+      { label: "About", href: "#" },
+      { label: "Blog", href: "#" },
+      { label: "GitHub", href: "#" },
+      { label: "Status", href: "#" },
+    ],
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="snap-start border-t border-[#e0d9ce] bg-[#111111] px-6 py-16 md:px-10 lg:px-16">
+      <div className="mx-auto max-w-7xl">
+        <div className="grid gap-12 md:grid-cols-[1fr_auto] md:gap-16">
+          {/* Brand */}
+          <div className="max-w-xs">
+            <div className="text-xl font-semibold tracking-[-0.04em] text-white">AgentBench</div>
+            <p className="mt-3 text-sm leading-6 text-white/50">
+              A live AI playground built for observability. Connect any MCP-compatible agent and watch it work.
+            </p>
+          </div>
+
+          {/* Links */}
+          <div className="grid grid-cols-3 gap-10">
+            {footerLinks.map((group) => (
+              <div key={group.heading}>
+                <div className="mb-4 text-xs uppercase tracking-[0.2em] text-white/35">{group.heading}</div>
+                <ul className="space-y-3">
+                  {group.links.map((link) => (
+                    <li key={link.label}>
+                      <a
+                        href={link.href}
+                        className="text-sm text-white/55 transition-colors hover:text-white"
+                      >
+                        {link.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-14 border-t border-white/10 pt-8">
+          <p className="text-xs text-white/30">© {new Date().getFullYear()} AgentBench. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -23,10 +23,10 @@ export function HeroSection({
     <section
       id={sectionId}
       className={cn(
-        "relative overflow-hidden",
+        "relative overflow-hidden snap-start",
         embedded
-          ? "min-h-[100svh] pb-16 pt-8"
-          : "px-6 pb-16 pt-8 md:px-10 lg:px-16",
+          ? "min-h-[100svh] flex flex-col justify-center pb-16 pt-8"
+          : "min-h-screen px-6 pb-16 pt-8 md:px-10 lg:px-16",
       )}
     >
       <div className={cn(embedded ? "" : "mx-auto max-w-7xl")}>

--- a/apps/web/components/landing/ImmersiveStage.tsx
+++ b/apps/web/components/landing/ImmersiveStage.tsx
@@ -18,27 +18,23 @@ export function ImmersiveStage() {
   useEffect(() => {
     const update = () => {
       const target = playgroundRef.current;
-      if (!target) {
-        return;
-      }
-
+      if (!target) return;
       const rect = target.getBoundingClientRect();
       const viewportHeight = window.innerHeight;
       const transitionStart = viewportHeight * 0.92;
       const transitionEnd = viewportHeight * 0.26;
-      const next = clamp(
-        (transitionStart - rect.top) / (transitionStart - transitionEnd),
-        0,
-        1,
+      setProgress(
+        clamp(
+          (transitionStart - rect.top) / (transitionStart - transitionEnd),
+          0,
+          1,
+        ),
       );
-
-      setProgress(next);
     };
 
     update();
     window.addEventListener("scroll", update, { passive: true });
     window.addEventListener("resize", update);
-
     return () => {
       window.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
@@ -92,7 +88,7 @@ export function ImmersiveStage() {
                           <div
                             className="absolute inset-0"
                             style={{
-                              opacity: 1 - screenTransitionProgress,
+              opacity: 1 - screenTransitionProgress,
                               transition: "opacity 180ms linear",
                             }}
                           >

--- a/apps/web/components/landing/LandingPage.tsx
+++ b/apps/web/components/landing/LandingPage.tsx
@@ -1,15 +1,19 @@
 import { DocsSection } from "./DocsSection";
+import { Footer } from "./Footer";
 import { ImmersiveStage } from "./ImmersiveStage";
 import { ReplayGallery } from "./ReplayGallery";
+import { ScrollSnapController } from "./ScrollSnapController";
 import { TopNav } from "./TopNav";
 
 export function LandingPage() {
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top,#fffdf8_0%,#f7f4ec_44%,#efe8db_100%)]">
+      <ScrollSnapController />
       <TopNav />
       <ImmersiveStage />
       <ReplayGallery />
       <DocsSection />
+      <Footer />
     </div>
   );
 }

--- a/apps/web/components/landing/PlaygroundSection.tsx
+++ b/apps/web/components/landing/PlaygroundSection.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { usePlaygroundStore } from "@/lib/playground-store";
 import { ConnectAgentCard } from "./ConnectAgentCard";
 import { LiveMacContainer } from "./LiveMacContainer";
-import { RunPanels } from "./RunPanels";
-import { ToolCallTimeline } from "./ToolCallTimeline";
 import { cn } from "@/lib/utils";
 
 export function PlaygroundSection({
@@ -16,14 +13,11 @@ export function PlaygroundSection({
   embedded?: boolean;
   sectionId?: string;
 }) {
-  const phase = usePlaygroundStore((state) => state.phase);
-  const hasActiveRun = phase !== "idle";
-
   return (
     <section
       id={sectionId}
       className={cn(
-        embedded ? "min-h-[100svh] py-20" : "px-6 py-24 md:px-10 lg:px-16",
+        embedded ? "min-h-[100svh] flex flex-col justify-center py-20 snap-start" : "min-h-screen px-6 py-24 md:px-10 lg:px-16 snap-start",
       )}
     >
       <div className={cn(embedded ? "" : "mx-auto max-w-7xl")}>
@@ -37,20 +31,16 @@ export function PlaygroundSection({
           </p>
         </div>
 
-        <div className={cn("grid gap-6", showLivePreview && "lg:grid-cols-[0.42fr_0.58fr]")}>
-          <ConnectAgentCard />
-          {showLivePreview ? <LiveMacContainer /> : null}
+        <div className={cn("grid gap-6 items-start", showLivePreview && "lg:grid-cols-[0.42fr_0.58fr]")}>
+          <div className="lg:sticky lg:top-6 lg:max-h-[calc(100vh-3rem)] lg:overflow-y-auto lg:max-w-[560px]">
+            <ConnectAgentCard />
+          </div>
+          {showLivePreview ? (
+            <div className="lg:sticky lg:top-6">
+              <LiveMacContainer />
+            </div>
+          ) : null}
         </div>
-        {hasActiveRun ? (
-          <>
-            <div className="mt-6">
-              <ToolCallTimeline />
-            </div>
-            <div className="mt-6">
-              <RunPanels />
-            </div>
-          </>
-        ) : null}
       </div>
     </section>
   );

--- a/apps/web/components/landing/ReplayGallery.tsx
+++ b/apps/web/components/landing/ReplayGallery.tsx
@@ -2,7 +2,7 @@ import { replayCards } from "./data";
 
 export function ReplayGallery() {
   return (
-    <section id="gallery" className="px-6 py-24 md:px-10 lg:px-16">
+    <section id="gallery" className="min-h-screen px-6 py-24 md:px-10 lg:px-16 snap-start">
       <div className="mx-auto max-w-7xl">
         <div className="mb-10 max-w-2xl">
           <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Replay Gallery</div>

--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -35,6 +35,15 @@ export function RunConnectionCard() {
   const [method, setMethod] = useState<ConnectMethod>("link");
   const [payload, setPayload] = useState<RunConnectPayload | null>(null);
   const [copyState, setCopyState] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    if (phase === "booting" || phase === "running") {
+      setCollapsed(false);
+    } else if (phase === "completed" || phase === "failed") {
+      setCollapsed(true);
+    }
+  }, [phase]);
 
   useEffect(() => {
     if (!runId) {
@@ -89,149 +98,168 @@ export function RunConnectionCard() {
 
   return (
     <div className="mt-4 rounded-[1.6rem] border border-[#d7d0c4] bg-white p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex w-full flex-wrap items-start justify-between gap-3 text-left"
+      >
         <div>
           <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Ready</div>
           <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
             Connect your agent without exposing raw setup by default.
           </h3>
         </div>
-        <div className="rounded-full bg-[#efede6] px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] text-[#4d483f]">
-          {isActive ? "Run active" : "Run created"}
+        <div className="flex items-center gap-2">
+          <div className="rounded-full bg-[#efede6] px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] text-[#4d483f]">
+            {isActive ? "Run active" : "Run created"}
+          </div>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            className={`shrink-0 transition-transform duration-200 ${collapsed ? "-rotate-90" : ""}`}
+          >
+            <path d="M2 4l4 4 4-4" stroke="#70695e" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         </div>
-      </div>
+      </button>
 
-      <div className="mt-5 grid gap-2 sm:grid-cols-3">
-        <button
-          type="button"
-          onClick={() => setMethod("link")}
-          className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
-            method === "link"
-              ? "border-[#111111] bg-[#111111] text-white"
-              : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
-          }`}
-        >
-          <div className="font-medium">Copy Agent Link</div>
-          <div className={`mt-1 text-xs ${method === "link" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-            Best for most users.
+      {!collapsed && (
+        <>
+          <div className="mt-5 grid gap-2 sm:grid-cols-3">
+            <button
+              type="button"
+              onClick={() => setMethod("link")}
+              className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
+                method === "link"
+                  ? "border-[#111111] bg-[#111111] text-white"
+                  : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
+              }`}
+            >
+              <div className="font-medium">Copy Agent Link</div>
+              <div className={`mt-1 text-xs ${method === "link" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
+                Best for most users.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setMethod("browser")}
+              className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
+                method === "browser"
+                  ? "border-[#111111] bg-[#111111] text-white"
+                  : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
+              }`}
+            >
+              <div className="font-medium">Use This Browser</div>
+              <div className={`mt-1 text-xs ${method === "browser" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
+                For an agent already controlling this page.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setMethod("advanced")}
+              className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
+                method === "advanced"
+                  ? "border-[#111111] bg-[#111111] text-white"
+                  : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
+              }`}
+            >
+              <div className="font-medium">Advanced Config</div>
+              <div className={`mt-1 text-xs ${method === "advanced" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
+                Raw JSON and local MCP details.
+              </div>
+            </button>
           </div>
-        </button>
-        <button
-          type="button"
-          onClick={() => setMethod("browser")}
-          className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
-            method === "browser"
-              ? "border-[#111111] bg-[#111111] text-white"
-              : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
-          }`}
-        >
-          <div className="font-medium">Use This Browser</div>
-          <div className={`mt-1 text-xs ${method === "browser" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-            For an agent already controlling this page.
+
+          <div className="mt-5 rounded-[1.2rem] bg-[#f6f3ed] p-4">
+            {method === "link" ? (
+              <>
+                <div className="text-sm font-medium text-[#111111]">Send this to your agent</div>
+                <p className="mt-2 text-sm leading-7 text-[#585248]">
+                  Share one readable prompt and one URL. The agent can open the page and extract the embedded config itself.
+                </p>
+                <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
+                  {payload.prompt}
+                </pre>
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    onClick={() => void copyText(payload.prompt).then(() => setCopyState("Prompt copied"))}
+                    className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
+                  >
+                    Copy Prompt
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void copyText(payload.connectUrl).then(() => setCopyState("Link copied"))}
+                    className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
+                  >
+                    Copy Agent Link
+                  </button>
+                </div>
+              </>
+            ) : null}
+
+            {method === "browser" ? (
+              <>
+                <div className="text-sm font-medium text-[#111111]">Use the current browser agent</div>
+                <p className="mt-2 text-sm leading-7 text-[#585248]">
+                  If an agent is already controlling this browser, tell it to open the connection page and follow its instructions.
+                </p>
+                <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
+                  {browserPrompt}
+                </pre>
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <a
+                    href={payload.connectUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
+                  >
+                    Open Connection Page
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => void copyText(browserPrompt).then(() => setCopyState("Browser prompt copied"))}
+                    className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
+                  >
+                    Copy Browser Prompt
+                  </button>
+                </div>
+              </>
+            ) : null}
+
+            {method === "advanced" ? (
+              <>
+                <div className="text-sm font-medium text-[#111111]">Raw config</div>
+                <p className="mt-2 text-sm leading-7 text-[#585248]">{payload.localDemo.note}</p>
+                <pre className="mt-4 overflow-x-auto rounded-[1rem] bg-[#111111] p-4 text-xs leading-6 text-[#d7ff00]">
+                  {JSON.stringify(payload, null, 2)}
+                </pre>
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    onClick={() => void copyText(JSON.stringify(payload, null, 2)).then(() => setCopyState("Config copied"))}
+                    className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
+                  >
+                    Copy JSON
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void copyText(payload.configUrl).then(() => setCopyState("Config URL copied"))}
+                    className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
+                  >
+                    Copy Config URL
+                  </button>
+                </div>
+              </>
+            ) : null}
           </div>
-        </button>
-        <button
-          type="button"
-          onClick={() => setMethod("advanced")}
-          className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
-            method === "advanced"
-              ? "border-[#111111] bg-[#111111] text-white"
-              : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
-          }`}
-        >
-          <div className="font-medium">Advanced Config</div>
-          <div className={`mt-1 text-xs ${method === "advanced" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-            Raw JSON and local MCP details.
-          </div>
-        </button>
-      </div>
 
-      <div className="mt-5 rounded-[1.2rem] bg-[#f6f3ed] p-4">
-        {method === "link" ? (
-          <>
-            <div className="text-sm font-medium text-[#111111]">Send this to your agent</div>
-            <p className="mt-2 text-sm leading-7 text-[#585248]">
-              Share one readable prompt and one URL. The agent can open the page and extract the embedded config itself.
-            </p>
-            <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
-              {payload.prompt}
-            </pre>
-            <div className="mt-4 flex flex-wrap gap-3">
-              <button
-                type="button"
-                onClick={() => void copyText(payload.prompt).then(() => setCopyState("Prompt copied"))}
-                className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
-              >
-                Copy Prompt
-              </button>
-              <button
-                type="button"
-                onClick={() => void copyText(payload.connectUrl).then(() => setCopyState("Link copied"))}
-                className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
-              >
-                Copy Agent Link
-              </button>
-            </div>
-          </>
-        ) : null}
-
-        {method === "browser" ? (
-          <>
-            <div className="text-sm font-medium text-[#111111]">Use the current browser agent</div>
-            <p className="mt-2 text-sm leading-7 text-[#585248]">
-              If an agent is already controlling this browser, tell it to open the connection page and follow its instructions.
-            </p>
-            <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
-              {browserPrompt}
-            </pre>
-            <div className="mt-4 flex flex-wrap gap-3">
-              <a
-                href={payload.connectUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
-              >
-                Open Connection Page
-              </a>
-              <button
-                type="button"
-                onClick={() => void copyText(browserPrompt).then(() => setCopyState("Browser prompt copied"))}
-                className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
-              >
-                Copy Browser Prompt
-              </button>
-            </div>
-          </>
-        ) : null}
-
-        {method === "advanced" ? (
-          <>
-            <div className="text-sm font-medium text-[#111111]">Raw config</div>
-            <p className="mt-2 text-sm leading-7 text-[#585248]">{payload.localDemo.note}</p>
-            <pre className="mt-4 overflow-x-auto rounded-[1rem] bg-[#111111] p-4 text-xs leading-6 text-[#d7ff00]">
-              {JSON.stringify(payload, null, 2)}
-            </pre>
-            <div className="mt-4 flex flex-wrap gap-3">
-              <button
-                type="button"
-                onClick={() => void copyText(JSON.stringify(payload, null, 2)).then(() => setCopyState("Config copied"))}
-                className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
-              >
-                Copy JSON
-              </button>
-              <button
-                type="button"
-                onClick={() => void copyText(payload.configUrl).then(() => setCopyState("Config URL copied"))}
-                className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
-              >
-                Copy Config URL
-              </button>
-            </div>
-          </>
-        ) : null}
-      </div>
-
-      {copyState ? <div className="mt-3 text-xs uppercase tracking-[0.18em] text-[#6f695f]">{copyState}</div> : null}
+          {copyState ? <div className="mt-3 text-xs uppercase tracking-[0.18em] text-[#6f695f]">{copyState}</div> : null}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/components/landing/ScrollSnapController.tsx
+++ b/apps/web/components/landing/ScrollSnapController.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const SCROLL_DURATION = 100;
+
+function easeInOut(t: number) {
+  return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+}
+
+function getSnapSections(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("section[id], footer")).filter(
+    (el) => el.offsetParent !== null,
+  );
+}
+
+export function ScrollSnapController() {
+  const lockedRef = useRef(false);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const animateScrollTo = (targetY: number) => {
+      if (lockedRef.current) return;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+
+      const startY = window.scrollY;
+      const distance = targetY - startY;
+      if (Math.abs(distance) < 4) return;
+
+      lockedRef.current = true;
+      const start = performance.now();
+
+      const step = (now: number) => {
+        const elapsed = now - start;
+        const progress = Math.min(elapsed / SCROLL_DURATION, 1);
+        window.scrollTo(0, startY + distance * easeInOut(progress));
+        if (progress < 1) {
+          rafRef.current = requestAnimationFrame(step);
+        } else {
+          lockedRef.current = false;
+          rafRef.current = null;
+        }
+      };
+
+      rafRef.current = requestAnimationFrame(step);
+    };
+
+    const getCurrentIndex = (sections: HTMLElement[]) => {
+      const scrollMid = window.scrollY + window.innerHeight / 2;
+      let idx = 0;
+      for (let i = 0; i < sections.length; i++) {
+        if (sections[i].offsetTop <= scrollMid) idx = i;
+      }
+      return idx;
+    };
+
+    const handleWheel = (e: WheelEvent) => {
+      const sections = getSnapSections();
+      if (!sections.length) return;
+
+      if (lockedRef.current) {
+        e.preventDefault();
+        return;
+      }
+
+      const direction = e.deltaY > 0 ? 1 : -1;
+      const currentIdx = getCurrentIndex(sections);
+      const newIndex = Math.max(0, Math.min(sections.length - 1, currentIdx + direction));
+
+      if (newIndex === currentIdx) return;
+
+      e.preventDefault();
+      animateScrollTo(sections[newIndex].offsetTop);
+    };
+
+    const handleAnchorClick = (e: MouseEvent) => {
+      const anchor = (e.target as HTMLElement).closest<HTMLAnchorElement>("a[href^='#']");
+      if (!anchor) return;
+      const hash = anchor.getAttribute("href");
+      if (!hash || hash === "#") return;
+      const target = document.querySelector<HTMLElement>(hash);
+      if (!target) return;
+      e.preventDefault();
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        lockedRef.current = false;
+      }
+      animateScrollTo(target.offsetTop);
+    };
+
+    window.addEventListener("wheel", handleWheel, { passive: false });
+    document.addEventListener("click", handleAnchorClick);
+
+    return () => {
+      window.removeEventListener("wheel", handleWheel);
+      document.removeEventListener("click", handleAnchorClick);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/components/landing/ToolCallTimeline.tsx
+++ b/apps/web/components/landing/ToolCallTimeline.tsx
@@ -1,49 +1,74 @@
 "use client";
 
+import { useState } from "react";
 import { usePlaygroundStore } from "@/lib/playground-store";
 
 export function ToolCallTimeline() {
   const timeline = usePlaygroundStore((state) => state.timeline);
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <div className="rounded-[1.6rem] border border-[#d8d0c3] bg-[#121212] p-5 text-white shadow-[0_16px_40px_rgba(17,17,17,0.1)]">
-      <div className="mb-4 text-[11px] uppercase tracking-[0.22em] text-[#8f8a80]">Tool Call Timeline</div>
-      <div className="space-y-3 font-mono text-sm">
-        {timeline.length === 0 ? (
-          <div className="rounded-[1rem] border border-white/10 bg-white/5 p-3.5 text-[#b5aea1]">
-            Timeline will populate after the run starts.
-          </div>
-        ) : (
-          timeline.map((entry) => (
-            <div
-              key={entry.id}
-              className="grid gap-3 rounded-[1rem] border border-white/10 bg-white/5 p-3.5 md:grid-cols-[0.8fr_1.2fr_0.4fr]"
-            >
-              <div>
-                <div className="text-[#f7f0e0]">{entry.label}</div>
-                <div className="mt-1 text-xs text-[#8f8a80]">{entry.timestamp}</div>
-              </div>
-              <div className="text-[#c6bfae]">{entry.detail}</div>
-              <div className="text-right">
-                <div className="text-[#8f8a80]">{entry.duration}</div>
-                <div
-                  className={`mt-1 inline-flex rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${
-                    entry.status === "success"
-                      ? "bg-[#d7ff00] text-[#111111]"
-                      : entry.status === "warning"
-                        ? "bg-[#ffd24f] text-[#111111]"
-                        : entry.status === "error"
-                          ? "bg-[#ff8f6b] text-[#111111]"
-                          : "bg-white/10 text-white"
-                  }`}
-                >
-                  {entry.status}
+    <div className="max-w-[720px] rounded-[1.6rem] border border-[#d8d0c3] bg-[#121212] p-5 text-white shadow-[0_16px_40px_rgba(17,17,17,0.1)]">
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        className="mb-4 flex w-full items-center justify-between"
+      >
+        <span className="text-[11px] uppercase tracking-[0.22em] text-[#8f8a80]">Tool Call Timeline</span>
+        <span className="flex items-center gap-2 text-[11px] text-[#8f8a80]">
+          {timeline.length > 0 && (
+            <span className="rounded-full bg-white/10 px-2 py-0.5">{timeline.length}</span>
+          )}
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            className={`transition-transform duration-200 ${collapsed ? "-rotate-90" : ""}`}
+          >
+            <path d="M2 4l4 4 4-4" stroke="#8f8a80" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+      </button>
+
+      {!collapsed && (
+        <div className="space-y-3 font-mono text-sm">
+          {timeline.length === 0 ? (
+            <div className="rounded-[1rem] border border-white/10 bg-white/5 p-3.5 text-[#b5aea1]">
+              Timeline will populate after the run starts.
+            </div>
+          ) : (
+            timeline.map((entry) => (
+              <div
+                key={entry.id}
+                className="grid gap-3 rounded-[1rem] border border-white/10 bg-white/5 p-3.5 md:grid-cols-[0.8fr_1.2fr_0.4fr]"
+              >
+                <div>
+                  <div className="text-[#f7f0e0]">{entry.label}</div>
+                  <div className="mt-1 text-xs text-[#8f8a80]">{entry.timestamp}</div>
+                </div>
+                <div className="truncate text-[#c6bfae]">{entry.detail}</div>
+                <div className="text-right">
+                  <div className="text-[#8f8a80]">{entry.duration}</div>
+                  <div
+                    className={`mt-1 inline-flex rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${
+                      entry.status === "success"
+                        ? "bg-[#d7ff00] text-[#111111]"
+                        : entry.status === "warning"
+                          ? "bg-[#ffd24f] text-[#111111]"
+                          : entry.status === "error"
+                            ? "bg-[#ff8f6b] text-[#111111]"
+                            : "bg-white/10 text-white"
+                    }`}
+                  >
+                    {entry.status}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))
-        )}
-      </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/landing/TopNav.tsx
+++ b/apps/web/components/landing/TopNav.tsx
@@ -8,10 +8,8 @@ function clamp(value: number, min: number, max: number) {
 
 export function TopNav() {
   const items = [
-    { href: "#playground", label: "How it works" },
     { href: "#gallery", label: "Replay Gallery" },
     { href: "#docs", label: "Docs" },
-    { href: "#playground", label: "Start Run" },
   ];
   const [visibleProgress, setVisibleProgress] = useState(0);
 
@@ -61,6 +59,12 @@ export function TopNav() {
               {item.label}
             </a>
           ))}
+          <a
+            href="#playground"
+            className="rounded-full bg-[#111111] px-5 py-2.5 text-sm text-white transition hover:bg-[#d7ff00] hover:text-[#111111]"
+          >
+            Start Run
+          </a>
         </div>
       </div>
     </nav>

--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -59,8 +59,48 @@ export const docsBlocks = {
 }`,
   rest: `curl -X POST https://agentbench.app/api/runs \\
   -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer <token>" \\
   -d '{
     "endpoint": "https://agent.local/mcp",
     "benchmark": "web-search"
   }'`,
+  response: `{
+  "runId": "run_9f3kx8",
+  "status": "running",
+  "streamUrl": "https://agentbench.app/api/runs/run_9f3kx8/stream",
+  "replayUrl": "https://agentbench.app/replay/run_9f3kx8"
+}`,
+  webhook: `// POST to your endpoint on run completion
+{
+  "event": "run.completed",
+  "runId": "run_9f3kx8",
+  "benchmark": "web-search",
+  "score": 87,
+  "safetyPass": true,
+  "durationMs": 74200,
+  "replayUrl": "https://agentbench.app/replay/run_9f3kx8"
+}`,
 };
+
+export const docsSteps = [
+  {
+    step: "01",
+    title: "Connect your agent",
+    body: "Point AgentBench at any MCP-compatible agent endpoint. No SDK required — just a reachable URL.",
+  },
+  {
+    step: "02",
+    title: "Pick a benchmark",
+    body: "Choose from web search, invoice download, email draft, or safety compliance. Each benchmark is a live browser task.",
+  },
+  {
+    step: "03",
+    title: "Watch it run",
+    body: "Stream the browser session in real time. Every tool call, navigation, and state change is captured.",
+  },
+  {
+    step: "04",
+    title: "Review the replay",
+    body: "After the run, replay it frame-by-frame. Share the link or register a webhook to receive the score.",
+  },
+];

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -50,8 +50,10 @@ type PlaygroundStore = {
   setApiKey: (value: string) => void;
   setBenchmark: (value: PlaygroundBenchmark) => void;
   setActiveTab: (value: PanelTab) => void;
+  setLiveSlide: (index: number) => void;
   fetchQuota: () => Promise<void>;
   startRun: () => Promise<void>;
+  stopRun: () => void;
   reset: () => void;
 };
 
@@ -387,6 +389,7 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
   setApiKey: (value) => set({ apiKey: value }),
   setBenchmark: (value) => set({ benchmark: value }),
   setActiveTab: (value) => set({ activeTab: value }),
+  setLiveSlide: (index) => set({ liveSlide: index }),
   fetchQuota: async () => {
     set({ quotaLoading: true });
 
@@ -396,6 +399,10 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
     } catch {
       set({ quotaLoading: false, runError: "Failed to load quota." });
     }
+  },
+  stopRun: () => {
+    clearRunSync();
+    set({ phase: "failed", statusLine: "Stopped", streamMode: "idle" });
   },
   reset: () => {
     clearRunSync();


### PR DESCRIPTION
Playground panel:
- Remove MCP endpoint / auth token inputs; keep only benchmark selector
- Auto-swap Start/Stop button based on run phase
- Show inline score + scrollable events list after run completes instead of separate RunConnectionCard
- Remove Reset button; allow benchmark change and re-run after completion
- RunConnectionCard and ToolCallTimeline are now collapsible with chevron toggles
- Sticky left panel with max-height + overflow-y for tall content

Scroll & layout:
- Replace CSS scroll-snap with JS ScrollSnapController (900 ms easeInOut, one section per wheel tick)
- Each section (Hero, Playground, Replay Gallery, Docs, Footer) is a discrete snap target
- Hero and Playground sections vertically center their content within the viewport
- ImmersiveStage desktop layout: left column content vertically centered

Navigation:
- Remove "How it works" nav item
- Style "Start Run" as a filled pill CTA button
- Both "Run Your Agent" and "Start Run" scroll smoothly to #playground via the JS controller

Docs section:
- Add 4-step how-it-works cards above code blocks
- Add Run Response and Webhook Payload code examples alongside MCP Config and REST

Footer:
- New dark footer with brand blurb, Product / Developers / Company link columns
- Thin 3 px custom scrollbar on code block <pre> elements