### PR TITLE
feat(web): three-phase connect card, scroll fixes, copy polish

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -11,6 +11,21 @@ body {
   @apply bg-background text-foreground antialiased;
 }
 
+/* Thin scrollbar for light panels */
+.scroll-panel::-webkit-scrollbar {
+  width: 3px;
+}
+.scroll-panel::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scroll-panel::-webkit-scrollbar-thumb {
+  background: rgba(17, 17, 17, 0.12);
+  border-radius: 999px;
+}
+.scroll-panel::-webkit-scrollbar-thumb:hover {
+  background: rgba(17, 17, 17, 0.25);
+}
+
 /* Thin scrollbar for dark code blocks */
 .code-block-pre::-webkit-scrollbar {
   height: 3px;

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -17,6 +17,7 @@ export function ConnectAgentCard() {
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
   const startRun = usePlaygroundStore((state) => state.startRun);
   const stopRun = usePlaygroundStore((state) => state.stopRun);
+  const reset = usePlaygroundStore((state) => state.reset);
 
   const isRunning = phase === "booting" || phase === "running";
   const isDone = phase === "completed" || phase === "failed";
@@ -34,72 +35,65 @@ export function ConnectAgentCard() {
         : `${Math.max(quota.remaining, 0)} of ${quota.limit} runs left`
       : "Quota unavailable";
 
-  return (
-    <div className="rounded-[1.6rem] border border-[#d7d0c4] bg-[#f9f7f1] p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
-      <div className="mb-5 flex items-center justify-between">
-        <div>
-          <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Connect Agent</div>
-          <h3 className="mt-1.5 text-[1.35rem] font-medium text-[#111111]">Start a benchmark run</h3>
+  /* ── RUNNING phase ── */
+  if (isRunning) {
+    return (
+      <div className="rounded-[1.6rem] border border-[#d7d0c4] bg-[#f9f7f1] p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Connect Agent</div>
+            <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
+              {benchmarkOptions.find((b) => b.value === benchmark)?.label ?? "Running"}
+            </h3>
+          </div>
+          <div className="rounded-full bg-[#d7ff00] px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-[#111111]">
+            {quotaBadge}
+          </div>
         </div>
-        <div className="rounded-full bg-[#d7ff00] px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-[#111111]">
-          {quotaBadge}
-        </div>
+
+        <button
+          type="button"
+          onClick={stopRun}
+          className="w-full rounded-full bg-[#ff8f6b] px-5 py-3 text-sm font-medium text-[#111111] transition hover:bg-[#ff6b3d]"
+        >
+          Stop Run
+        </button>
+
+        <RunConnectionCard />
       </div>
+    );
+  }
 
-      <div className="space-y-4">
-        <label className="block">
-          <span className="mb-2 block text-[13px] text-[#5d574d]">Benchmark</span>
-          <select
-            value={benchmark}
-            onChange={(event) => setBenchmark(event.target.value as typeof benchmark)}
-            disabled={isRunning}
-            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111] disabled:opacity-60"
-          >
-            {benchmarkOptions.map((item) => (
-              <option key={item.value} value={item.value}>
-                {item.label}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
-          {benchmarkOptions.find((item) => item.value === benchmark)?.description}
+  /* ── DONE phase ── */
+  if (isDone) {
+    return (
+      <div className="rounded-[1.6rem] border border-[#d7d0c4] bg-[#f9f7f1] p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Connect Agent</div>
+            <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
+              {benchmarkOptions.find((b) => b.value === benchmark)?.label ?? "Run complete"}
+            </h3>
+          </div>
+          <div className="rounded-full bg-[#d7ff00] px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-[#111111]">
+            {quotaBadge}
+          </div>
         </div>
+
+        <button
+          type="button"
+          onClick={reset}
+          className="w-full rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111]"
+        >
+          Start Again
+        </button>
 
         {runError ? (
-          <div className="rounded-[1rem] border border-[#ead2ca] bg-[#fff0eb] p-3 text-[13px] leading-6 text-[#8a4334]">
+          <div className="mt-3 rounded-[1rem] border border-[#ead2ca] bg-[#fff0eb] p-3 text-[13px] leading-6 text-[#8a4334]">
             {runError}
           </div>
         ) : null}
 
-        <div className="flex gap-3">
-          {isRunning ? (
-            <button
-              type="button"
-              onClick={stopRun}
-              className="flex-1 rounded-full bg-[#ff8f6b] px-5 py-3 text-sm font-medium text-[#111111] transition hover:bg-[#ff6b3d]"
-            >
-              Stop Run
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => void startRun()}
-              disabled={isRunning || quotaLoading || isQuotaBlocked}
-              className="flex-1 rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111] disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {isQuotaBlocked
-                ? quota?.mode === "guest"
-                  ? "Guest Trial Used"
-                  : "Daily Limit Reached"
-                : "Start Free Run"}
-            </button>
-          )}
-        </div>
-      </div>
-
-      {isDone ? (
         <div className="mt-4 rounded-[1.6rem] border border-[#d7d0c4] bg-white p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
           <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Complete</div>
           <div className="mt-3 grid grid-cols-3 gap-2">
@@ -121,38 +115,105 @@ export function ConnectAgentCard() {
             </div>
           </div>
 
-          {timeline.length > 0 && (
+          {timeline.length > 0 ? (
             <div className="mt-4">
               <div className="mb-2 text-[11px] uppercase tracking-[0.18em] text-[#8f8a80]">Recent events</div>
-              <div className="max-h-40 space-y-1.5 overflow-y-auto pr-1">
-              {timeline.map((entry) => (
-                <div
-                  key={entry.id}
-                  className="flex items-center justify-between gap-3 rounded-[0.75rem] bg-[#f6f3ed] px-3 py-2"
-                >
-                  <span className="truncate text-[13px] text-[#111111]">{entry.label}</span>
-                  <span
-                    className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] ${
-                      entry.status === "success"
-                        ? "bg-[#d7ff00] text-[#111111]"
-                        : entry.status === "warning"
-                          ? "bg-[#ffd24f] text-[#111111]"
-                          : entry.status === "error"
-                            ? "bg-[#ff8f6b] text-[#111111]"
-                            : "bg-[#efede6] text-[#5c574d]"
-                    }`}
+              <div className="scroll-panel max-h-40 space-y-1.5 overflow-y-auto pr-1">
+                {timeline.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="flex items-center justify-between gap-3 rounded-[0.75rem] bg-[#f6f3ed] px-3 py-2"
                   >
-                    {entry.status}
-                  </span>
+                    <span className="truncate text-[13px] text-[#111111]">{entry.label}</span>
+                    <span
+                      className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] ${
+                        entry.status === "success"
+                          ? "bg-[#d7ff00] text-[#111111]"
+                          : entry.status === "warning"
+                            ? "bg-[#ffd24f] text-[#111111]"
+                            : entry.status === "error"
+                              ? "bg-[#ff8f6b] text-[#111111]"
+                              : "bg-[#efede6] text-[#5c574d]"
+                      }`}
+                    >
+                      {entry.status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="mt-4 space-y-2">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[#8f8a80]">Tips</div>
+              {[
+                "Connect a real agent endpoint to see live tool calls and a score.",
+                'Use "Agent Link" to send your agent a self-contained prompt — no manual config needed.',
+                "Each benchmark has a specific goal. The agent is scored on task completion and safety.",
+              ].map((tip) => (
+                <div key={tip} className="flex gap-2.5 rounded-[0.85rem] bg-[#f6f3ed] px-3 py-2.5">
+                  <span className="mt-0.5 shrink-0 text-[#a09890]">→</span>
+                  <span className="text-[13px] leading-5 text-[#5c574d]">{tip}</span>
                 </div>
               ))}
-              </div>
             </div>
           )}
         </div>
-      ) : (
-        <RunConnectionCard />
-      )}
+      </div>
+    );
+  }
+
+  /* ── IDLE phase ── */
+  return (
+    <div className="rounded-[1.6rem] border border-[#d7d0c4] bg-[#f9f7f1] p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
+      <div className="mb-5 flex items-center justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Connect Agent</div>
+          <h3 className="mt-1.5 text-[1.35rem] font-medium text-[#111111]">Start a benchmark run</h3>
+        </div>
+        <div className="rounded-full bg-[#d7ff00] px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-[#111111]">
+          {quotaBadge}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <label className="block">
+          <span className="mb-2 block text-[13px] text-[#5d574d]">Benchmark</span>
+          <select
+            value={benchmark}
+            onChange={(event) => setBenchmark(event.target.value as typeof benchmark)}
+            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111]"
+          >
+            {benchmarkOptions.map((item) => (
+              <option key={item.value} value={item.value}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
+          {benchmarkOptions.find((item) => item.value === benchmark)?.description}
+        </div>
+
+        {runError ? (
+          <div className="rounded-[1rem] border border-[#ead2ca] bg-[#fff0eb] p-3 text-[13px] leading-6 text-[#8a4334]">
+            {runError}
+          </div>
+        ) : null}
+
+        <button
+          type="button"
+          onClick={() => void startRun()}
+          disabled={quotaLoading || isQuotaBlocked}
+          className="w-full rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isQuotaBlocked
+            ? quota?.mode === "guest"
+              ? "Guest Trial Used"
+              : "Daily Limit Reached"
+            : "Start Free Run"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/landing/PlaygroundSection.tsx
+++ b/apps/web/components/landing/PlaygroundSection.tsx
@@ -3,6 +3,7 @@
 import { ConnectAgentCard } from "./ConnectAgentCard";
 import { LiveMacContainer } from "./LiveMacContainer";
 import { cn } from "@/lib/utils";
+import { usePlaygroundStore } from "@/lib/playground-store";
 
 export function PlaygroundSection({
   showLivePreview = true,
@@ -13,6 +14,9 @@ export function PlaygroundSection({
   embedded?: boolean;
   sectionId?: string;
 }) {
+  const phase = usePlaygroundStore((state) => state.phase);
+  const isIdle = phase === "idle";
+
   return (
     <section
       id={sectionId}
@@ -21,7 +25,7 @@ export function PlaygroundSection({
       )}
     >
       <div className={cn(embedded ? "" : "mx-auto max-w-7xl")}>
-        <div className="mb-10 max-w-2xl">
+        <div className={cn("mb-10 max-w-2xl transition-all duration-300", !isIdle && "hidden")}>
           <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Run Playground</div>
           <h2 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-[#111111] md:text-5xl">
             Connect an agent and immediately watch it work.
@@ -32,7 +36,7 @@ export function PlaygroundSection({
         </div>
 
         <div className={cn("grid gap-6 items-start", showLivePreview && "lg:grid-cols-[0.42fr_0.58fr]")}>
-          <div className="lg:sticky lg:top-6 lg:max-h-[calc(100vh-3rem)] lg:overflow-y-auto lg:max-w-[560px]">
+          <div className="scroll-panel lg:sticky lg:top-6 lg:max-h-[calc(100vh-3rem)] lg:overflow-y-auto lg:max-w-[560px]">
             <ConnectAgentCard />
           </div>
           {showLivePreview ? (

--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -90,8 +90,20 @@ export function RunConnectionCard() {
     ].join("\n");
   }, [payload]);
 
-  if (!runId || !payload) {
+  if (!runId) {
     return null;
+  }
+
+  if (!payload) {
+    return (
+      <div className="mt-4 rounded-[1.6rem] border border-[#d7d0c4] bg-white p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">
+        <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Ready</div>
+        <div className="mt-3 space-y-2">
+          <div className="h-4 w-3/4 animate-pulse rounded-full bg-[#efede6]" />
+          <div className="h-4 w-1/2 animate-pulse rounded-full bg-[#efede6]" />
+        </div>
+      </div>
+    );
   }
 
   const isActive = phase === "booting" || phase === "running";
@@ -106,7 +118,7 @@ export function RunConnectionCard() {
         <div>
           <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Ready</div>
           <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
-            Connect your agent without exposing raw setup by default.
+            Connect your agent.
           </h3>
         </div>
         <div className="flex items-center gap-2">
@@ -137,9 +149,9 @@ export function RunConnectionCard() {
                   : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
               }`}
             >
-              <div className="font-medium">Copy Agent Link</div>
+              <div className="font-medium">Agent Link</div>
               <div className={`mt-1 text-xs ${method === "link" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-                Best for most users.
+                Recommended
               </div>
             </button>
             <button
@@ -151,9 +163,9 @@ export function RunConnectionCard() {
                   : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
               }`}
             >
-              <div className="font-medium">Use This Browser</div>
+              <div className="font-medium">This Browser</div>
               <div className={`mt-1 text-xs ${method === "browser" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-                For an agent already controlling this page.
+                Agent controls page
               </div>
             </button>
             <button
@@ -165,9 +177,9 @@ export function RunConnectionCard() {
                   : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
               }`}
             >
-              <div className="font-medium">Advanced Config</div>
+              <div className="font-medium">Advanced</div>
               <div className={`mt-1 text-xs ${method === "advanced" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-                Raw JSON and local MCP details.
+                Raw JSON + MCP
               </div>
             </button>
           </div>
@@ -175,9 +187,9 @@ export function RunConnectionCard() {
           <div className="mt-5 rounded-[1.2rem] bg-[#f6f3ed] p-4">
             {method === "link" ? (
               <>
-                <div className="text-sm font-medium text-[#111111]">Send this to your agent</div>
+                <div className="text-sm font-medium text-[#111111]">Send to your agent</div>
                 <p className="mt-2 text-sm leading-7 text-[#585248]">
-                  Share one readable prompt and one URL. The agent can open the page and extract the embedded config itself.
+                  One prompt, one URL. The agent opens the page and self-configures.
                 </p>
                 <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
                   {payload.prompt}
@@ -203,9 +215,9 @@ export function RunConnectionCard() {
 
             {method === "browser" ? (
               <>
-                <div className="text-sm font-medium text-[#111111]">Use the current browser agent</div>
+                <div className="text-sm font-medium text-[#111111]">Browser agent</div>
                 <p className="mt-2 text-sm leading-7 text-[#585248]">
-                  If an agent is already controlling this browser, tell it to open the connection page and follow its instructions.
+                  Tell the agent controlling this browser to open the connection page.
                 </p>
                 <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
                   {browserPrompt}
@@ -233,7 +245,7 @@ export function RunConnectionCard() {
             {method === "advanced" ? (
               <>
                 <div className="text-sm font-medium text-[#111111]">Raw config</div>
-                <p className="mt-2 text-sm leading-7 text-[#585248]">{payload.localDemo.note}</p>
+                <p className="mt-2 text-sm leading-7 text-[#585248]">Full JSON payload for direct MCP wiring.</p>
                 <pre className="mt-4 overflow-x-auto rounded-[1rem] bg-[#111111] p-4 text-xs leading-6 text-[#d7ff00]">
                   {JSON.stringify(payload, null, 2)}
                 </pre>

--- a/apps/web/components/landing/ScrollSnapController.tsx
+++ b/apps/web/components/landing/ScrollSnapController.tsx
@@ -54,7 +54,23 @@ export function ScrollSnapController() {
       return idx;
     };
 
+    const isInsideScrollable = (target: EventTarget | null, deltaY: number): boolean => {
+      let node = target as HTMLElement | null;
+      while (node && node !== document.documentElement) {
+        const { overflowY } = window.getComputedStyle(node);
+        if (overflowY === "auto" || overflowY === "scroll") {
+          const canScrollDown = deltaY > 0 && node.scrollTop < node.scrollHeight - node.clientHeight - 1;
+          const canScrollUp = deltaY < 0 && node.scrollTop > 0;
+          if (canScrollDown || canScrollUp) return true;
+        }
+        node = node.parentElement;
+      }
+      return false;
+    };
+
     const handleWheel = (e: WheelEvent) => {
+      if (isInsideScrollable(e.target, e.deltaY)) return;
+
       const sections = getSnapSections();
       if (!sections.length) return;
 


### PR DESCRIPTION
ConnectAgentCard — three distinct phases:
- Idle: full form (benchmark selector + description + Start Free Run)
- Running: compact header + Stop Run + RunConnectionCard below
- Done: compact header + Start Again (resets to idle via store.reset()) + score card; tips shown when no timeline events

PlaygroundSection: hides the section heading during running/done phases

ScrollSnapController: back-off when wheel target is inside a scrollable child (fixes inner card scroll triggering page snap)

Scrollbars: .scroll-panel utility class (3 px thumb, light bg) applied to events list and sticky left panel

RunConnectionCard: shorter copy throughout — heading, tab labels, and method descriptions all tightened