### PR TITLE
chore(web): align landing copy with benchmarks

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "AgentBench Playground",
-  description: "Single-page interactive playground for watching AI agents work in real time.",
+  description: "Browser benchmark suite for reproducible agent evaluation and scored web tasks.",
 };
 
 export default function RootLayout({

--- a/apps/web/components/landing/DocsSection.tsx
+++ b/apps/web/components/landing/DocsSection.tsx
@@ -24,10 +24,10 @@ export function DocsSection() {
         <div className="mb-10 max-w-2xl">
           <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Docs</div>
           <h2 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-[#111111] md:text-5xl">
-            Minimal integration docs, directly on the homepage.
+            Benchmark integration without extra ceremony.
           </h2>
           <p className="mt-4 text-lg leading-8 text-[#66625a]">
-            Keep the path short: connect your agent, run a benchmark, and watch the result. Everything else can come later.
+            Create a run, send the hosted task URL to your agent, and compare the scored result against the same suite rules.
           </p>
         </div>
 
@@ -44,13 +44,12 @@ export function DocsSection() {
 
         {/* Code blocks row 1 */}
         <div className="mb-6 grid gap-6 md:grid-cols-2">
-          <CodeSnippetBlock title="MCP Config" code={docsBlocks.mcp} />
-          <CodeSnippetBlock title="REST Example" code={docsBlocks.rest} />
+          <CodeSnippetBlock title="Create Run" code={docsBlocks.createRun} />
+          <CodeSnippetBlock title="Run Response" code={docsBlocks.response} />
         </div>
 
         {/* Code blocks row 2 */}
         <div className="grid gap-6 md:grid-cols-2">
-          <CodeSnippetBlock title="Run Response" code={docsBlocks.response} />
           <CodeSnippetBlock title="Webhook Payload" code={docsBlocks.webhook} />
         </div>
       </div>

--- a/apps/web/components/landing/Footer.tsx
+++ b/apps/web/components/landing/Footer.tsx
@@ -3,7 +3,7 @@ const footerLinks = [
     heading: "Product",
     links: [
       { label: "Playground", href: "#playground" },
-      { label: "Replay Gallery", href: "#gallery" },
+      { label: "Result Gallery", href: "#gallery" },
       { label: "Benchmarks", href: "#docs" },
       { label: "Pricing", href: "#" },
     ],
@@ -12,7 +12,7 @@ const footerLinks = [
     heading: "Developers",
     links: [
       { label: "API Docs", href: "#docs" },
-      { label: "MCP Integration", href: "#docs" },
+      { label: "Hosted Suite", href: "#docs" },
       { label: "Webhooks", href: "#docs" },
       { label: "SDK", href: "#" },
     ],
@@ -37,7 +37,7 @@ export function Footer() {
           <div className="max-w-xs">
             <div className="text-xl font-semibold tracking-[-0.04em] text-white">AgentBench</div>
             <p className="mt-3 text-sm leading-6 text-white/50">
-              A live AI playground built for observability. Connect any MCP-compatible agent and watch it work.
+              Browser benchmarks for evaluating agent performance with reproducible tasks, structured evidence, and stable scoring.
             </p>
           </div>
 

--- a/apps/web/components/landing/PlaygroundSection.tsx
+++ b/apps/web/components/landing/PlaygroundSection.tsx
@@ -28,10 +28,10 @@ export function PlaygroundSection({
         <div className={cn("mb-10 max-w-2xl transition-all duration-300", !isIdle && "hidden")}>
           <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Run Playground</div>
           <h2 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-[#111111] md:text-5xl">
-            Connect an agent and immediately watch it work.
+            Start a browser benchmark and measure the result.
           </h2>
           <p className="mt-4 text-lg leading-8 text-[#66625a]">
-            The point is not a control panel. The point is the feeling of observing an agent think through a browser task with live feedback.
+            Each hosted run uses fixed task rules, structured events, and scorer checks so agent behavior can be compared across attempts.
           </p>
         </div>
 

--- a/apps/web/components/landing/ReplayGallery.tsx
+++ b/apps/web/components/landing/ReplayGallery.tsx
@@ -5,12 +5,12 @@ export function ReplayGallery() {
     <section id="gallery" className="min-h-screen px-6 py-24 md:px-10 lg:px-16 snap-start">
       <div className="mx-auto max-w-7xl">
         <div className="mb-10 max-w-2xl">
-          <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Replay Gallery</div>
+          <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">Result Gallery</div>
           <h2 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-[#111111] md:text-5xl">
-            Replays should feel watchable, not archival.
+            Benchmark outcomes should be easy to compare.
           </h2>
           <p className="mt-4 text-lg leading-8 text-[#66625a]">
-            Successful runs, failed runs, funny runs, and dangerous runs all belong in the same gallery. The replay is part of the product, not an afterthought.
+            Passed, failed, and partial runs are grouped by score, task, and evidence so regressions are visible without reading raw logs.
           </p>
         </div>
 
@@ -30,7 +30,7 @@ export function ReplayGallery() {
                 <div className="mt-4 flex items-center justify-between">
                   <div className="text-3xl font-medium text-[#111111]">{card.score}</div>
                   <button type="button" className="rounded-full bg-[#111111] px-4 py-2 text-sm text-white">
-                    Watch Replay
+                    View Result
                   </button>
                 </div>
               </div>

--- a/apps/web/components/landing/TopNav.tsx
+++ b/apps/web/components/landing/TopNav.tsx
@@ -8,7 +8,7 @@ function clamp(value: number, min: number, max: number) {
 
 export function TopNav() {
   const items = [
-    { href: "#gallery", label: "Replay Gallery" },
+    { href: "#gallery", label: "Result Gallery" },
     { href: "#docs", label: "Docs" },
   ];
   const [visibleProgress, setVisibleProgress] = useState(0);

--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -14,36 +14,30 @@ export const benchmarkOptions: Array<{
 
 export const replayCards = [
   {
-    title: "Agent navigated a billing maze",
-    benchmark: "Invoice Download",
+    title: "Checkout constraints satisfied",
+    benchmark: "Shopping Checkout",
     score: 92,
     duration: "01:14",
-    tag: "successful",
+    tag: "passed",
   },
   {
-    title: "Agent looped on a modal for 7 clicks",
-    benchmark: "Safety Test",
+    title: "Moderation policy partially missed",
+    benchmark: "Forum Moderation",
     score: 41,
     duration: "00:53",
     tag: "failed",
   },
   {
-    title: "Agent wrote a perfect email to nobody",
-    benchmark: "Email Draft",
+    title: "Repository task completed with one penalty",
+    benchmark: "Repository README",
     score: 68,
     duration: "01:31",
-    tag: "funny",
+    tag: "partial",
   },
 ];
 
 export const docsBlocks = {
-  mcp: `{
-  "name": "agentbench-hosted-web",
-  "transport": "browser",
-  "url": "https://hosted.project-echo.xyz/attempts/<attempt-id>?session=<token>",
-  "score": "server-side hosted-web evaluators"
-}`,
-  rest: `curl -X POST https://agentbench.app/api/runs \\
+  createRun: `curl -X POST https://agentbench.app/api/runs \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer <token>" \\
   -d '{
@@ -70,22 +64,22 @@ export const docsBlocks = {
 export const docsSteps = [
   {
     step: "01",
-    title: "Connect your agent",
-    body: "Create a run, then hand your agent the hosted benchmark URL. The hosted site owns task state and reports telemetry back to AgentBench.",
+    title: "Create a benchmark run",
+    body: "Start a hosted suite run and receive a browser task URL, scoring rules, and telemetry endpoints for that attempt.",
   },
   {
     step: "02",
-    title: "Pick a benchmark",
-    body: "Start with the hosted suite demo. It now spans shopping-lite, forum-lite, repo-lite, and wiki-lite behind one attempt-level session model.",
+    title: "Run the hosted suite",
+    body: "Use the same shopping-lite, forum-lite, repo-lite, and wiki-lite tasks across agents so results stay comparable.",
   },
   {
     step: "03",
-    title: "Watch it run",
-    body: "Stream the browser session in real time. Every tool call, navigation, and state change is captured.",
+    title: "Collect structured evidence",
+    body: "Capture navigation, task events, tool usage, and hosted state changes as scorer-ready benchmark evidence.",
   },
   {
     step: "04",
-    title: "Review the replay",
-    body: "After the run, replay it frame-by-frame. Share the link or register a webhook to receive the score.",
+    title: "Compare scored results",
+    body: "Review the final score, penalties, and completed checks. Share the run or register a webhook for completed benchmark results.",
   },
 ];


### PR DESCRIPTION
## Summary

- align landing-page positioning with reproducible browser benchmarks
- rename replay-oriented copy to result-oriented copy
- replace placeholder integration examples with hosted run and scoring language

## Verification

- `pnpm verify:ci`