### PR TITLE
ci: tune Dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,56 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/London
     target-branch: develop
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    rebase-strategy: disabled
     groups:
-      development-dependencies:
-        dependency-type: development
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+        update-types:
+          - minor
+          - patch
+      routine-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/London
     target-branch: develop
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    rebase-strategy: disabled
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary

- cap npm and GitHub Actions version-update PRs at two each
- group React and routine minor/patch updates
- group GitHub Actions minor/patch updates
- disable automatic rebases and automatic major-version PRs
- schedule checks for Monday mornings in Europe/London

This PR intentionally changes only the default-branch Dependabot configuration. Dependency package updates remain on `develop` in PR #17.