### PR TITLE
ci: exclude risky Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,13 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Pre-1.0 minor releases may contain breaking API changes.
+      - dependency-name: "@supabase/ssr"
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: lucide-react
+        update-types:
+          - version-update:semver-minor
 
   - package-ecosystem: github-actions
     directory: /
@@ -57,3 +64,5 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Dependabot misclassified a breaking Node.js runtime change as minor.
+      - dependency-name: pnpm/action-setup


### PR DESCRIPTION
## Summary

- exclude pre-1.0 minor updates for Supabase SSR and lucide-react
- exclude pnpm/action-setup after a breaking Node.js runtime change was misclassified as minor
- keep these upgrades on dedicated manual migration paths

This changes only default-branch Dependabot policy; dependency package updates remain on `develop`.