### PR TITLE
ci: restrict production pull request sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
       REDIS_TEST_URL: redis://127.0.0.1:6379
       ORCHESTRATOR_REDIS_URL: redis://127.0.0.1:6379
     steps:
+      - name: Validate production pull request source
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "${HEAD_REF}" in
+            develop | hotfix/*)
+              ;;
+            *)
+              echo "Pull requests to main must come from develop or hotfix/*; received ${HEAD_REF}." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:


### PR DESCRIPTION
## Summary

- reject pull requests to `main` unless they originate from `develop` or `hotfix/*`
- keep the validation inside the existing required `build-and-typecheck` check
- fail before checkout and dependency installation

## Verification

- YAML syntax parsed successfully
- branch predicate allows `develop` and `hotfix/urgent-fix`
- branch predicate rejects `feature/direct-main` and `chore/config`
- `git diff --check` passes