### PR TITLE
ci: restrict production pull request sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,20 @@ jobs:
       REDIS_TEST_URL: redis://127.0.0.1:6379
       ORCHESTRATOR_REDIS_URL: redis://127.0.0.1:6379
     steps:
+      - name: Validate production pull request source
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "${HEAD_REF}" in
+            develop | hotfix/*)
+              ;;
+            *)
+              echo "Pull requests to main must come from develop or hotfix/*; received ${HEAD_REF}." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:


### PR DESCRIPTION
## Summary

- enforce the documented production branch flow in the existing required CI check
- allow only `develop` and `hotfix/*` pull requests to target `main`
- reject direct feature, fix, chore, and dependency branches before dependency installation

## Reason for hotfix path

This CI hardening must exist on `main` to protect future production pull requests. The same change is already merged into `develop` as #24; using a focused `hotfix/*` branch avoids releasing unrelated dependency updates currently present only on `develop`.

## Verification

- #24 passed the full repository CI and both Vercel preview checks
- YAML syntax parsed successfully
- predicate accepts `develop` and `hotfix/urgent-fix`
- predicate rejects `feature/direct-main` and `chore/config`