### PR TITLE
chore(web): ignore generated Next type declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 # build outputs
 .next/
 .next-dev/
+apps/web/next-env.d.ts
 dist/
 build/
 coverage/

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference path="./.next-dev/types/routes.d.ts" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- stop tracking the generated `apps/web/next-env.d.ts` file
- add the exact path to `.gitignore`
- prevent `next dev` (`.next-dev`) and `next build` (`.next`) from repeatedly changing the tracked reference

## Verification

- removed `next-env.d.ts` before verification
- `pnpm verify:ci` passed from that state
- Next.js production build regenerated the file automatically
- regenerated file is ignored and no longer appears in the Git worktree

Next.js documentation recommends that `next-env.d.ts` not be tracked by version control.