### PR TITLE
[codex] enforce unique terminal results

### DIFF
--- a/apps/hosted-orchestrator/src/attempt-lifecycle.test.ts
+++ b/apps/hosted-orchestrator/src/attempt-lifecycle.test.ts
@@ -1,18 +1,28 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildHostedAttemptReadModel } from "@agentbench/shared";
-import { createAttemptLifecycle, type AttemptLifecycleAdvanceSession, type AttemptLifecycleSession } from "./attempt-lifecycle.js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildHostedAttemptReadModel, type Database } from "@agentbench/shared";
+import {
+  createAttemptLifecycle,
+  type AttemptLifecycleAdvanceSession,
+  type AttemptLifecycleSession,
+  type PersistScoreResultOutcome,
+} from "./attempt-lifecycle.js";
 import type { HostedWebScoreResult } from "@agentbench/scoring";
 
 function createLifecycle(overrides?: {
+  getSupabaseAdmin?: () => SupabaseClient<Database> | null;
   loadAttemptMetadata?: (attemptId: string | null) => Promise<Record<string, unknown>>;
   loadAttemptSessions?: (attemptId: string) => Promise<AttemptLifecycleAdvanceSession[]>;
   loadLatestSessionResult?: (sessionId: string) => Promise<HostedWebScoreResult | null>;
-  persistScoreResult?: (session: AttemptLifecycleSession, result: HostedWebScoreResult) => Promise<void>;
+  persistScoreResult?: (
+    session: AttemptLifecycleSession,
+    result: HostedWebScoreResult,
+  ) => Promise<PersistScoreResultOutcome>;
 }) {
   return createAttemptLifecycle({
     now: () => "2026-06-01T00:00:00.000Z",
-    getSupabaseAdmin: () => null,
+    getSupabaseAdmin: overrides?.getSupabaseAdmin ?? (() => null),
     loadAttemptMetadata: overrides?.loadAttemptMetadata ?? (async () => ({})),
     loadAttemptSessions: overrides?.loadAttemptSessions ?? (async () => []),
     loadAttemptReadModel: async (attemptId) =>
@@ -27,7 +37,8 @@ function createLifecycle(overrides?: {
         })),
       }),
     loadLatestSessionResult: overrides?.loadLatestSessionResult ?? (async () => null),
-    persistScoreResult: overrides?.persistScoreResult ?? (async () => undefined),
+    persistScoreResult:
+      overrides?.persistScoreResult ?? (async (_session, result) => ({ result, duplicate: false })),
     forwardTimeoutCompletion: async () => undefined,
     evictInMemorySessions: () => undefined,
   });
@@ -142,6 +153,7 @@ test("complete-session returns existing result when session already completed", 
     loadLatestSessionResult: async () => existingResult,
     persistScoreResult: async () => {
       persisted = true;
+      return { result: existingResult, duplicate: false };
     },
   });
 
@@ -154,6 +166,140 @@ test("complete-session returns existing result when session already completed", 
   assert.equal(result.duplicate, true);
   assert.equal(result.result.summary, "already done");
   assert.equal(persisted, false);
+});
+
+test("complete-session returns the first persisted result after a uniqueness conflict", async () => {
+  const persistedResult = makeScoreResult({
+    status: "failed",
+    score: 0,
+    summary: "first completion won",
+  });
+  const lifecycle = createLifecycle({
+    persistScoreResult: async () => ({
+      result: persistedResult,
+      duplicate: true,
+    }),
+  });
+
+  const result = await lifecycle.executeCompleteSessionCommand({
+    type: "complete-session",
+    session: makeSession({ persisted: false }),
+    result: makeScoreResult({ summary: "concurrent completion lost" }),
+  });
+
+  assert.equal(result.duplicate, true);
+  assert.equal(result.result.status, "failed");
+  assert.equal(result.result.summary, "first completion won");
+});
+
+test("complete-session recovers the first aggregate score after a uniqueness conflict", async () => {
+  const persistedAggregate = {
+    status: "failed" as const,
+    score: 0.25,
+    summary: "first aggregate won",
+    breakdown: {
+      aggregation: "weighted-required-suite" as const,
+      sessions: [
+        {
+          sessionId: "session-1",
+          app: "shopping-lite",
+          taskSlug: "shopping-constrained-checkout",
+          status: "failed" as const,
+          score: 0.25,
+          weight: 1,
+          required: true,
+        },
+      ],
+    },
+  };
+  let attemptUpdate: Record<string, unknown> | null = null;
+
+  const supabase = {
+    from(table: string) {
+      if (table === "hosted_web_results") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: async () => ({
+                data: [
+                  {
+                    session_id: "session-1",
+                    app: "shopping-lite",
+                    task_slug: "shopping-constrained-checkout",
+                    score: 1,
+                    status: "passed",
+                    weight: 1,
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+
+      if (table === "hosted_web_sessions") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: async () => ({
+                data: [
+                  {
+                    id: "session-1",
+                    app: "shopping-lite",
+                    task_slug: "shopping-constrained-checkout",
+                    weight: 1,
+                    required: true,
+                    sequence_index: 0,
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+          update: () => ({ eq: async () => ({ error: null }) }),
+        };
+      }
+
+      if (table === "benchmark_attempt_scores") {
+        return {
+          insert: async () => ({ error: { code: "23505" } }),
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: persistedAggregate, error: null }),
+            }),
+          }),
+        };
+      }
+
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: { metadata: {} }, error: null }),
+          }),
+        }),
+        update: (value: Record<string, unknown>) => {
+          attemptUpdate = value;
+          return { eq: async () => ({ error: null }) };
+        },
+      };
+    },
+  } as unknown as SupabaseClient<Database>;
+
+  const lifecycle = createLifecycle({
+    getSupabaseAdmin: () => supabase,
+  });
+  const result = await lifecycle.executeCompleteSessionCommand({
+    type: "complete-session",
+    session: makeSession(),
+    result: makeScoreResult(),
+  });
+
+  assert.equal(result.attemptResult.complete, true);
+  assert.deepEqual(result.attemptResult.aggregate, persistedAggregate);
+  const recordedAttemptUpdate = attemptUpdate as Record<string, unknown> | null;
+  assert.equal(recordedAttemptUpdate?.status, "failed");
+  assert.equal(recordedAttemptUpdate?.aggregate_score, 0.25);
 });
 
 test("complete-session rejects non-active session completion", async () => {

--- a/apps/hosted-orchestrator/src/attempt-lifecycle.ts
+++ b/apps/hosted-orchestrator/src/attempt-lifecycle.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database, HostedAttemptReadModel, HostedAttemptSessionStatus } from "@agentbench/shared";
 import {
   aggregateSuiteScore,
+  hostedWebSuiteScoreResultSchema,
   type HostedWebScoreResult,
   type HostedWebSuiteScoreResult,
   type HostedWebSuiteSessionScore,
@@ -84,6 +85,11 @@ export type TimeoutAttemptCommandResult = {
   summary: string | null;
 };
 
+export type PersistScoreResultOutcome = {
+  result: HostedWebScoreResult;
+  duplicate: boolean;
+};
+
 type AttemptLifecycleDeps = {
   now: () => string;
   getSupabaseAdmin: () => SupabaseClient<Database> | null | undefined;
@@ -91,7 +97,10 @@ type AttemptLifecycleDeps = {
   loadAttemptSessions: (attemptId: string) => Promise<AttemptLifecycleAdvanceSession[]>;
   loadAttemptReadModel: (attemptId: string) => Promise<HostedAttemptReadModel<AttemptLifecycleAdvanceSession>>;
   loadLatestSessionResult: (sessionId: string) => Promise<HostedWebScoreResult | null>;
-  persistScoreResult: (session: AttemptLifecycleSession, result: HostedWebScoreResult) => Promise<void>;
+  persistScoreResult: (
+    session: AttemptLifecycleSession,
+    result: HostedWebScoreResult,
+  ) => Promise<PersistScoreResultOutcome>;
   forwardTimeoutCompletion: (params: { runId: string; summary: string; score?: number }) => Promise<void>;
   evictInMemorySessions: (sessionIds: string[]) => void;
 };
@@ -222,7 +231,6 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
       failSummary: `One or more required hosted sessions for ${session.suiteSlug} failed.`,
     });
     const breakdown = aggregate.breakdown;
-    const status = aggregate.status === "passed" ? "completed" : "failed";
     const completedAt = deps.now();
 
     const { error: scoreError } = await supabase.from("benchmark_attempt_scores").insert({
@@ -234,15 +242,35 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
       breakdown,
     });
 
-    if (scoreError) {
-      console.error("[hosted-orchestrator] failed to persist attempt score", scoreError);
+    let persistedAggregate = aggregate;
+    if (scoreError?.code === "23505") {
+      const { data: existingScore, error: existingScoreError } = await supabase
+        .from("benchmark_attempt_scores")
+        .select("status, score, summary, breakdown")
+        .eq("attempt_id", session.attemptId)
+        .maybeSingle();
+
+      if (existingScoreError) {
+        throw existingScoreError;
+      }
+
+      const parsedExistingScore = hostedWebSuiteScoreResultSchema.safeParse(existingScore);
+      if (!parsedExistingScore.success) {
+        throw new Error(`Attempt ${session.attemptId} has an invalid persisted aggregate score.`);
+      }
+      persistedAggregate = parsedExistingScore.data;
+    } else if (scoreError) {
+      throw scoreError;
     }
+
+    const persistedBreakdown = persistedAggregate.breakdown;
+    const persistedStatus = persistedAggregate.status === "passed" ? "completed" : "failed";
 
     const { error: attemptError } = await supabase
       .from("benchmark_attempts")
       .update({
-        status,
-        aggregate_score: aggregate.score,
+        status: persistedStatus,
+        aggregate_score: persistedAggregate.score,
         metadata: {
           ...existingAttemptMetadata,
           activeSessionId: null,
@@ -250,9 +278,9 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
           completedSessionIds: sessionRows.map((row) => row.id),
         },
         scoring_summary: {
-          summary: aggregate.summary,
-          status: aggregate.status,
-          breakdown,
+          summary: persistedAggregate.summary,
+          status: persistedAggregate.status,
+          breakdown: persistedBreakdown,
         },
         completed_at: completedAt,
       })
@@ -262,7 +290,7 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
       console.error("[hosted-orchestrator] failed to update attempt", attemptError);
     }
 
-    return { complete: true, aggregate };
+    return { complete: true, aggregate: persistedAggregate };
   }
 
   async function promoteNextAttemptSession(attemptId: string, completedSessionId: string) {
@@ -307,18 +335,18 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
       }
     }
 
-    await deps.persistScoreResult(session, result);
-    session.status = result.status === "passed" ? "completed" : "failed";
-    const attemptResult = await persistAttemptScore(session, result);
+    const persisted = await deps.persistScoreResult(session, result);
+    session.status = persisted.result.status === "passed" ? "completed" : "failed";
+    const attemptResult = await persistAttemptScore(session, persisted.result);
 
     if (!attemptResult.complete && session.attemptId) {
       await promoteNextAttemptSession(session.attemptId, session.id);
     }
 
     return {
-      result,
+      result: persisted.result,
       attemptResult,
-      duplicate: false,
+      duplicate: persisted.duplicate,
     };
   }
 
@@ -469,14 +497,7 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
       } satisfies TimeoutAttemptCommandResult;
     }
 
-    const { data: existingAttemptScore } = await supabase
-      .from("benchmark_attempt_scores")
-      .select("id")
-      .eq("attempt_id", params.attemptId)
-      .limit(1)
-      .maybeSingle();
-
-    if (!existingAttemptScore && params.runId) {
+    if (params.runId) {
       const { error: attemptScoreError } = await supabase.from("benchmark_attempt_scores").insert({
         run_id: params.runId,
         attempt_id: params.attemptId,
@@ -486,8 +507,8 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
         breakdown: scoringSummary.breakdown,
       });
 
-      if (attemptScoreError) {
-        console.error("[hosted-orchestrator] failed to persist timeout attempt score", attemptScoreError);
+      if (attemptScoreError && attemptScoreError.code !== "23505") {
+        throw attemptScoreError;
       }
     }
 

--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -460,7 +460,7 @@ async function forwardTimeoutCompletion(params: {
 async function persistScoreResult(session: AttemptLifecycleSession, result: HostedWebScoreResult) {
   const supabase = getSupabaseAdmin();
   if (!supabase || !session.runId) {
-    return;
+    return { result, duplicate: false };
   }
 
   const { error } = await supabase.from("hosted_web_results").insert({
@@ -477,9 +477,18 @@ async function persistScoreResult(session: AttemptLifecycleSession, result: Host
     evaluators: result.evaluators,
   });
 
-  if (error) {
-    console.error("[hosted-orchestrator] failed to persist score result", error);
+  if (!error) {
+    return { result, duplicate: false };
   }
+
+  if (error.code === "23505") {
+    const existingResult = await loadLatestSessionResult(session.id);
+    if (existingResult) {
+      return { result: existingResult, duplicate: true };
+    }
+  }
+
+  throw error;
 }
 
 async function recoverInitializedAttempt(params: {

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -59,10 +59,12 @@ Per-session evaluation result:
 - normalized score from `0` to `1`
 - summary, final state, evaluator evidence
 - app/task/weight snapshot for auditability
+- a unique `session_id` invariant; the first persisted terminal result wins concurrent retries
 
 ### `benchmark_attempt_scores`
 
 Aggregate suite result with score, status, summary, and a JSON breakdown of all required and optional sessions.
+Each attempt has at most one aggregate score. A concurrent writer recovers and uses the existing row.
 
 ### `hosted_web_access_logs`
 

--- a/docs/data-model.zh-CN.md
+++ b/docs/data-model.zh-CN.md
@@ -59,10 +59,12 @@ Attempt 中的一个有序任务。
 - `0` 到 `1` 的标准化 score
 - summary、final state 和 evaluator evidence
 - 用于审计的 app/task/weight snapshot
+- `session_id` 唯一约束；并发重试时以最先持久化的终态结果为准
 
 ### `benchmark_attempt_scores`
 
 套件聚合结果，包含 score、status、summary 和所有 required/optional sessions 的 JSON breakdown。
+每个 attempt 最多一个聚合分数；并发写入者会读取并使用已有记录。
 
 ### `hosted_web_access_logs`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,12 +12,12 @@ This roadmap starts from the architecture that is already running. Completed wor
 - Redis provides the shared hosted-session cache and 16 partitioned orchestrator command Streams.
 - Supabase is the durable lifecycle, audit, and scoring store.
 - Attempt initialization is database-first and protected by a unique hosted-attempt constraint plus a short Redis lease.
+- Terminal hosted results and aggregate attempt scores are first-writer-wins database invariants with explicit conflict recovery.
 - `develop` deploys to development; `main` deploys to production through separate GitHub Environments, runners, database URLs, image channels, ports, and Compose projects.
 
 ## P0: Lifecycle Correctness and Recovery
 
 - Add database transactions or compare-and-set transitions for active-session promotion, timeout, and terminal completion.
-- Add unique constraints for one terminal result per session and one aggregate score per attempt, then make conflict recovery explicit.
 - Persist Web callback delivery in an outbox, retry with bounded backoff, and reconcile attempts whose durable result exists but run completion is missing.
 - Define command retry limits and add a dead-letter path with command ID, partition, payload type, error code, and inspection tooling.
 - Add lifecycle integration tests against real Postgres for concurrent completion, timeout-versus-completion, duplicate commands, and callback recovery.

--- a/docs/roadmap.zh-CN.md
+++ b/docs/roadmap.zh-CN.md
@@ -12,12 +12,12 @@
 - Redis 提供共享 hosted-session cache 和 16 个分区的 orchestrator command Streams。
 - Supabase 是生命周期、审计和评分的持久存储。
 - Attempt 初始化以数据库为准，并由 hosted-attempt 唯一约束和短期 Redis lease 共同保护。
+- Hosted 终态结果和 attempt 聚合分数采用先写入者获胜的数据库约束，并具备显式冲突恢复。
 - `develop` 部署到 development，`main` 部署到 production；两者使用独立 GitHub Environment、runner、数据库 URL、镜像 channel、端口和 Compose project。
 
 ## P0：生命周期正确性与恢复
 
 - 为 active-session 推进、timeout 和终态完成增加数据库 transaction 或 compare-and-set。
-- 增加“每个 session 一个终态 result”和“每个 attempt 一个聚合 score”的唯一约束，并明确冲突恢复逻辑。
 - 使用 outbox 持久化 Web callback delivery，按有上限的退避策略重试，并对“结果已持久化但 run 未完成”的 attempt 自动对账。
 - 定义 command 重试上限，增加 dead-letter 路径，记录 command ID、partition、payload type、error code，并提供检查工具。
 - 基于真实 Postgres 增加 lifecycle 集成测试，覆盖并发完成、timeout 与完成竞争、重复 command 和 callback 恢复。
@@ -70,4 +70,3 @@
 - 在 Vercel functions 中运行不可信 Agent 代码、浏览器 sandbox 或任意 worker。
 - 在没有独立隔离与威胁模型项目的情况下恢复已移除的 benchmark execution runner。
 - 将 Redis 作为持久生命周期的真相源。
-

--- a/supabase/migrations/20260618000012_unique_terminal_results.sql
+++ b/supabase/migrations/20260618000012_unique_terminal_results.sql
@@ -1,0 +1,33 @@
+with duplicate_results as (
+  select
+    id,
+    row_number() over (
+      partition by session_id
+      order by created_at asc, id asc
+    ) as duplicate_rank
+  from public.hosted_web_results
+)
+delete from public.hosted_web_results
+using duplicate_results
+where public.hosted_web_results.id = duplicate_results.id
+  and duplicate_results.duplicate_rank > 1;
+
+create unique index if not exists idx_hosted_web_results_unique_session
+  on public.hosted_web_results (session_id);
+
+with duplicate_scores as (
+  select
+    id,
+    row_number() over (
+      partition by attempt_id
+      order by created_at asc, id asc
+    ) as duplicate_rank
+  from public.benchmark_attempt_scores
+)
+delete from public.benchmark_attempt_scores
+using duplicate_scores
+where public.benchmark_attempt_scores.id = duplicate_scores.id
+  and duplicate_scores.duplicate_rank > 1;
+
+create unique index if not exists idx_benchmark_attempt_scores_unique_attempt
+  on public.benchmark_attempt_scores (attempt_id);


### PR DESCRIPTION
## Summary

- add first-writer-wins unique indexes for hosted session results and attempt aggregate scores
- recover PostgreSQL uniqueness conflicts by returning the persisted winning result
- document the completed lifecycle invariant and cover result/aggregate conflict recovery

## Why

Concurrent completion or retry paths could create duplicate terminal rows, and a losing writer could continue with a result that differed from durable state. The database now enforces one terminal record per entity and the lifecycle converges on the existing row.

## Validation

- `pnpm verify:ci`
- `pnpm --filter hosted-orchestrator build`