### PR TITLE
[codex] remove hosted smoke install dependency

### DIFF
--- a/.github/workflows/deploy-hosted-sites.yml
+++ b/.github/workflows/deploy-hosted-sites.yml
@@ -357,17 +357,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Run development lifecycle smoke
         env:

--- a/apps/hosted-sites/scripts/orchestrator-smoke.sh
+++ b/apps/hosted-sites/scripts/orchestrator-smoke.sh
@@ -76,18 +76,13 @@ curl -fsS "${ORCHESTRATOR_BASE_URL}/health" >/dev/null
 SMOKE_MODE="${SMOKE_MODE}" \
 HOSTED_BASE_URL="${HOSTED_BASE_URL}" \
 ORCHESTRATOR_BASE_URL="${ORCHESTRATOR_BASE_URL}" \
-pnpm --filter hosted-sites exec node <<'NODE'
-const { createClient } = require("@supabase/supabase-js");
-
+node <<'NODE'
 const smokeMode = process.env.SMOKE_MODE;
 const hostedBaseUrl = process.env.HOSTED_BASE_URL;
 const orchestratorBaseUrl = process.env.ORCHESTRATOR_BASE_URL;
 const runnerSecret = process.env.RUNNER_SHARED_SECRET;
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY,
-  { auth: { persistSession: false } },
-);
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 async function checkedFetch(url, init = {}) {
   const response = await fetch(url, init);
@@ -108,6 +103,37 @@ async function orchestratorRequest(path, init = {}) {
       "x-runner-secret": runnerSecret,
     },
   });
+}
+
+async function supabaseRequest(table, searchParams, init = {}) {
+  const query = new URLSearchParams(searchParams);
+  return checkedFetch(`${supabaseUrl}/rest/v1/${table}?${query}`, {
+    ...init,
+    headers: {
+      apikey: supabaseServiceRoleKey,
+      Authorization: `Bearer ${supabaseServiceRoleKey}`,
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+  });
+}
+
+async function selectRows(table, searchParams) {
+  return (await supabaseRequest(table, searchParams)).json();
+}
+
+async function insertRow(table, value) {
+  const rows = await (
+    await supabaseRequest(table, { select: "id" }, {
+      method: "POST",
+      headers: { Prefer: "return=representation" },
+      body: JSON.stringify(value),
+    })
+  ).json();
+  if (!Array.isArray(rows) || rows.length !== 1) {
+    throw new Error(`Expected one inserted ${table} row.`);
+  }
+  return rows[0];
 }
 
 async function postForm(path, token, values) {
@@ -274,28 +300,22 @@ async function loadAttemptState(attemptId) {
 }
 
 async function main() {
-  const { data: benchmarkCase, error: caseError } = await supabase
-    .from("benchmark_cases")
-    .select("id, slug, title, description, metadata")
-    .eq("slug", "shopping-constrained-checkout")
-    .single();
-  if (caseError || !benchmarkCase) {
-    throw caseError ?? new Error("benchmark case not found");
+  const benchmarkCases = await selectRows("benchmark_cases", {
+    select: "id,slug,title,description,metadata",
+    slug: "eq.shopping-constrained-checkout",
+    limit: "1",
+  });
+  if (!Array.isArray(benchmarkCases) || benchmarkCases.length !== 1) {
+    throw new Error("benchmark case not found");
   }
+  const benchmarkCase = benchmarkCases[0];
   const suite = normalizedSessions(benchmarkCase);
 
-  const { data: run, error: runError } = await supabase
-    .from("benchmark_runs")
-    .insert({
+  const run = await insertRow("benchmark_runs", {
       case_id: benchmarkCase.id,
       execution_mode: "external-agent",
       status: "queued",
-    })
-    .select("id")
-    .single();
-  if (runError || !run) {
-    throw runError ?? new Error("run creation failed");
-  }
+  });
 
   const initialized = await (
     await orchestratorRequest("/api/attempts/init", {
@@ -394,13 +414,10 @@ async function main() {
     }
   }
 
-  const { data: resultRows, error: resultError } = await supabase
-    .from("hosted_web_results")
-    .select("session_id")
-    .eq("attempt_id", initialized.attemptId);
-  if (resultError || !resultRows) {
-    throw resultError ?? new Error("Unable to verify hosted results.");
-  }
+  const resultRows = await selectRows("hosted_web_results", {
+    select: "session_id",
+    attempt_id: `eq.${initialized.attemptId}`,
+  });
   if (
     resultRows.length !== completedSessions.length ||
     new Set(resultRows.map((row) => row.session_id)).size !== resultRows.length
@@ -408,13 +425,10 @@ async function main() {
     throw new Error("Hosted result rows are not unique per completed session.");
   }
 
-  const { data: scoreRows, error: scoreError } = await supabase
-    .from("benchmark_attempt_scores")
-    .select("id")
-    .eq("attempt_id", initialized.attemptId);
-  if (scoreError || !scoreRows) {
-    throw scoreError ?? new Error("Unable to verify attempt scores.");
-  }
+  const scoreRows = await selectRows("benchmark_attempt_scores", {
+    select: "id",
+    attempt_id: `eq.${initialized.attemptId}`,
+  });
   if (scoreRows.length !== 1) {
     throw new Error(`Expected one aggregate attempt score, got ${scoreRows.length}.`);
   }


### PR DESCRIPTION
## Summary

- replace the smoke driver Supabase client dependency with authenticated REST requests
- run the remote smoke with Node directly
- remove pnpm setup and dependency installation from the post-deploy job

## Why

The first development smoke job stalled in `pnpm install` on the self-hosted runner. The smoke only needs HTTP access, so installing the workspace is unnecessary and makes deployment completion depend on pnpm store state.

## Validation

- Bash and embedded Node syntax checks
- deployment classifier tests
- `pnpm verify:ci`