### PR TITLE
feat(web): improve benchmark leaderboard results

### DIFF
--- a/apps/web/app/results/[runId]/page.tsx
+++ b/apps/web/app/results/[runId]/page.tsx
@@ -1,0 +1,74 @@
+import { notFound } from "next/navigation";
+import { getPublicBenchmarkResult } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+function formatDuration(startedAt: string | null, completedAt: string | null) {
+  if (!startedAt || !completedAt) return "Not recorded";
+  const totalSeconds = Math.max(0, Math.round((new Date(completedAt).getTime() - new Date(startedAt).getTime()) / 1000));
+  return `${Math.floor(totalSeconds / 60)}m ${totalSeconds % 60}s`;
+}
+
+export default async function PublicResultPage({ params }: { params: Promise<{ runId: string }> }) {
+  const { runId } = await params;
+  const result = await getPublicBenchmarkResult(runId);
+  if (!result) notFound();
+
+  const { run, benchmark, suite, tasks } = result;
+  return (
+    <main className="min-h-screen bg-[#111111] px-6 py-12 text-[#f7f2e7] md:px-10 md:py-20">
+      <div className="mx-auto max-w-5xl">
+        <a href="/#leaderboard" className="text-xs uppercase tracking-[0.2em] text-[#d7ff00]">Back to leaderboard</a>
+        <div className="mt-8 grid gap-8 border-b border-white/10 pb-10 lg:grid-cols-[1fr_auto] lg:items-end">
+          <div>
+            <div className="text-xs uppercase tracking-[0.2em] text-white/40">Public benchmark result</div>
+            <h1 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-white md:text-6xl">{benchmark.title}</h1>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-white/55">{benchmark.description}</p>
+          </div>
+          <div className="text-left lg:text-right">
+            <div className="text-7xl font-medium tracking-[-0.07em] text-[#d7ff00]">{Math.round((run.score ?? 0) * 100)}</div>
+            <div className="text-xs uppercase tracking-[0.2em] text-white/40">Aggregate score</div>
+          </div>
+        </div>
+
+        <section className="grid gap-px bg-white/10 sm:grid-cols-2 lg:grid-cols-4">
+          {[
+            ["Agent", run.agent ? `${run.agent.name} ${run.agent.version}` : "Unreported"],
+            ["Base model", run.agent?.baseModel ?? "Unreported"],
+            ["Environment", [run.browserEnvironment?.browser, run.browserEnvironment?.platform].filter(Boolean).join(" · ") || "Unknown"],
+            ["Duration", formatDuration(run.startedAt, run.completedAt)],
+          ].map(([label, value]) => (
+            <div key={label} className="bg-[#171715] p-5">
+              <div className="text-[10px] uppercase tracking-[0.2em] text-white/35">{label}</div>
+              <div className="mt-2 text-sm text-white/85">{value}</div>
+            </div>
+          ))}
+        </section>
+
+        <section className="mt-12">
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <div className="text-xs uppercase tracking-[0.2em] text-white/40">Task breakdown</div>
+              <h2 className="mt-2 text-2xl font-medium text-white">{suite ? `${suite.slug} · ${suite.version}` : "Hosted suite"}</h2>
+            </div>
+            <div className="text-sm text-white/45">Completed {run.completedAt ? new Date(run.completedAt).toLocaleString("en-GB", { timeZone: "UTC" }) : "--"} UTC</div>
+          </div>
+          <div className="mt-6 divide-y divide-white/10 border-y border-white/10">
+            {tasks.map((task, index) => (
+              <article key={`${task.app}:${task.taskSlug}`} className="grid gap-3 py-6 md:grid-cols-[48px_1fr_auto] md:items-center">
+                <div className="text-xl text-white/30">{String(index + 1).padStart(2, "0")}</div>
+                <div>
+                  <div className="text-lg font-medium text-white">{task.app}</div>
+                  <div className="mt-1 text-sm text-white/45">{task.summary}</div>
+                </div>
+                <div className={task.status === "passed" ? "text-2xl text-[#d7ff00]" : "text-2xl text-[#ff8d7a]"}>
+                  {Math.round(task.score * 100)}%
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/landing/Leaderboard.tsx
+++ b/apps/web/components/landing/Leaderboard.tsx
@@ -1,25 +1,22 @@
-import { listPublicLeaderboard } from "@/lib/db";
+import { listPublicLeaderboard, listPublicLeaderboardVersions } from "@/lib/db";
+import { LeaderboardRanking, type LeaderboardBoard } from "./LeaderboardRanking";
 
-function formatDuration(durationMs: number | null) {
-  if (durationMs === null) return "--";
-  const totalSeconds = Math.round(durationMs / 1000);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
-function formatCompletedAt(value: string) {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(value));
+async function loadBoards(): Promise<LeaderboardBoard[]> {
+  const versions = await listPublicLeaderboardVersions();
+  if (versions.length === 0) {
+    return [{ version: "all", entries: await listPublicLeaderboard(20) }];
+  }
+
+  return Promise.all(versions.map(async (version) => ({
+    version,
+    entries: await listPublicLeaderboard(20, version),
+  })));
 }
 
 export async function Leaderboard() {
-  const entries = await listPublicLeaderboard(20).catch((error) => {
+  const boards = await loadBoards().catch((error) => {
     console.error("[web] failed to load public leaderboard", error);
-    return [];
+    return [{ version: "all", entries: [] }];
   });
 
   return (
@@ -33,73 +30,11 @@ export async function Leaderboard() {
             </h2>
           </div>
           <p className="max-w-xl text-base leading-7 text-[#66625a] lg:justify-self-end">
-            Completed public runs are ordered by score. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
+            Completed public runs are ranked within the same benchmark version. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
           </p>
         </div>
 
-        <div className="overflow-hidden rounded-[2rem] border border-[#d8d0c2] bg-[#111111] shadow-[0_32px_90px_rgba(77,63,36,0.16)]">
-          <div className="hidden grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] gap-4 border-b border-white/10 px-6 py-4 text-[10px] uppercase tracking-[0.2em] text-white/40 lg:grid">
-            <span>Rank</span>
-            <span>Agent / model</span>
-            <span>Benchmark</span>
-            <span>Browser</span>
-            <span>Completed</span>
-            <span className="text-right">Score</span>
-          </div>
-
-          {entries.length === 0 ? (
-            <div className="px-6 py-20 text-center">
-              <div className="text-2xl font-medium tracking-[-0.03em] text-white">No published results yet.</div>
-              <p className="mx-auto mt-3 max-w-md text-sm leading-7 text-white/50">
-                Complete a public hosted benchmark with agent metadata to establish the first leaderboard entry.
-              </p>
-              <a href="#playground" className="mt-7 inline-flex rounded-full bg-[#d7ff00] px-5 py-2.5 text-sm font-medium text-[#111111]">
-                Start a benchmark
-              </a>
-            </div>
-          ) : (
-            <div>
-              {entries.map((entry) => (
-                <a
-                  key={entry.runId}
-                  href={`/runs/${entry.runId}/live`}
-                  className="group grid gap-5 border-b border-white/10 px-5 py-6 transition-colors last:border-b-0 hover:bg-white/[0.045] lg:grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] lg:items-center lg:gap-4 lg:px-6"
-                >
-                  <div className="flex items-center justify-between lg:block">
-                    <span className="text-[10px] uppercase tracking-[0.2em] text-white/35 lg:hidden">Rank</span>
-                    <span className={entry.rank <= 3 ? "text-3xl font-medium text-[#d7ff00]" : "text-2xl text-white/45"}>
-                      {entry.rank.toString().padStart(2, "0")}
-                    </span>
-                  </div>
-                  <div className="min-w-0">
-                    <div className="truncate text-lg font-medium text-white">{entry.agentName}</div>
-                    <div className="mt-1 truncate text-xs text-white/45">
-                      {entry.agentVersion} · {entry.baseModel}
-                    </div>
-                  </div>
-                  <div className="min-w-0">
-                    <div className="truncate text-sm text-white/85">{entry.benchmark}</div>
-                    <div className="mt-1 text-xs text-white/40">
-                      {entry.suiteVersion ?? "suite version unavailable"} · {formatDuration(entry.durationMs)}
-                    </div>
-                  </div>
-                  <div className="text-sm text-white/70">
-                    {entry.browser ?? "Unknown browser"}
-                    <div className="mt-1 text-xs text-white/35">{entry.platform ?? "Unknown platform"}</div>
-                  </div>
-                  <div className="text-sm text-white/70">{formatCompletedAt(entry.completedAt)}</div>
-                  <div className="flex items-end justify-between lg:block lg:text-right">
-                    <span className="text-[10px] uppercase tracking-[0.2em] text-white/35 lg:hidden">Score</span>
-                    <span className="text-3xl font-medium tracking-[-0.04em] text-white group-hover:text-[#d7ff00]">
-                      {Math.round(entry.score * 100)}
-                    </span>
-                    <span className="ml-1 text-xs text-white/35">%</span>
-                  </div>
-                </a>
-              ))}
-            </div>
-          )}
-        </div>
+        <LeaderboardRanking boards={boards} />
       </div>
     </section>
   );

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import type { LeaderboardEntry } from "@/lib/db";
+import { LEADERBOARD_MAX_ENTRIES, LEADERBOARD_PAGE_SIZE, paginateLeaderboard } from "@/lib/leaderboard-pagination";
+
+export type LeaderboardBoard = {
+  version: string;
+  entries: LeaderboardEntry[];
+};
+
+function formatDuration(durationMs: number | null) {
+  if (durationMs === null) return "--";
+  const totalSeconds = Math.round(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function formatCompletedAt(value: string) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}
+
+function PlaceholderRow({ position }: { position: number }) {
+  return (
+    <div className="grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_52px] items-center gap-3 border-b border-white/10 px-4 py-4 last:border-b-0 lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6">
+      <span className="text-xl text-white/20 lg:text-2xl">{position.toString().padStart(2, "0")}</span>
+      <div className="lg:col-span-4">
+        <div className="h-2.5 w-28 rounded-full bg-white/[0.07] lg:h-3 lg:w-36" />
+        <div className="mt-2 truncate text-[10px] uppercase tracking-[0.14em] text-white/25 lg:mt-3 lg:text-xs lg:tracking-[0.16em]">
+          Awaiting benchmark result
+        </div>
+      </div>
+      <div className="text-right text-xl text-white/15 lg:text-2xl">--</div>
+    </div>
+  );
+}
+
+export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
+  const [activeVersion, setActiveVersion] = useState(boards[0]?.version ?? "all");
+  const [page, setPage] = useState(1);
+  const activeBoard = boards.find((board) => board.version === activeVersion) ?? boards[0];
+  const pagination = paginateLeaderboard(activeBoard?.entries ?? [], page);
+  const { entries, page: currentPage, pageCount, pageEntries, placeholderPositions } = pagination;
+
+  function selectVersion(version: string) {
+    setActiveVersion(version);
+    setPage(1);
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-wrap gap-2" role="tablist" aria-label="Benchmark version">
+          {boards.map((board) => {
+            const active = board.version === activeVersion;
+            return (
+              <button
+                key={board.version}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => selectVersion(board.version)}
+                className={active
+                  ? "rounded-full bg-[#111111] px-4 py-2 text-xs font-medium text-white"
+                  : "rounded-full border border-[#d8d0c2] bg-white/55 px-4 py-2 text-xs text-[#625c52] transition-colors hover:border-[#111111] hover:text-[#111111]"}
+              >
+                {board.version === "all" ? "All versions" : `Suite ${board.version}`}
+              </button>
+            );
+          })}
+        </div>
+        <div className="text-xs uppercase tracking-[0.16em] text-[#8a8378]">
+          Top {Math.min(entries.length, LEADERBOARD_MAX_ENTRIES)} · {LEADERBOARD_PAGE_SIZE} per page
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-[1.5rem] border border-[#d8d0c2] bg-[#111111] shadow-[0_32px_90px_rgba(77,63,36,0.16)] lg:rounded-[2rem]">
+        <div className="hidden grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] gap-4 border-b border-white/10 px-6 py-4 text-[10px] uppercase tracking-[0.2em] text-white/40 lg:grid">
+          <span>Rank</span>
+          <span>Agent / model</span>
+          <span>Benchmark</span>
+          <span>Browser</span>
+          <span>Completed</span>
+          <span className="text-right">Score</span>
+        </div>
+
+        <div role="tabpanel">
+          {pageEntries.map((entry) => (
+            <a
+              key={entry.runId}
+              href={`/results/${entry.runId}`}
+              className="group grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_64px] items-center gap-3 border-b border-white/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-white/[0.045] lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6"
+            >
+              <span className={entry.rank <= 3 ? "text-xl font-medium text-[#d7ff00] lg:text-3xl" : "text-xl text-white/45 lg:text-2xl"}>
+                {entry.rank.toString().padStart(2, "0")}
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-white lg:text-lg">{entry.agentName}</div>
+                <div className="mt-1 truncate text-[11px] text-white/45 lg:text-xs">
+                  <span className="lg:hidden">{entry.baseModel}</span>
+                  <span className="hidden lg:inline">{entry.agentVersion} · {entry.baseModel}</span>
+                </div>
+              </div>
+              <div className="hidden min-w-0 lg:block">
+                <div className="truncate text-sm text-white/85">{entry.benchmark}</div>
+                <div className="mt-1 text-xs text-white/40">
+                  {entry.suiteVersion ?? "suite version unavailable"} · {formatDuration(entry.durationMs)}
+                </div>
+              </div>
+              <div className="hidden text-sm text-white/70 lg:block">
+                {entry.browser ?? "Unknown browser"}
+                <div className="mt-1 text-xs text-white/35">{entry.platform ?? "Unknown platform"}</div>
+              </div>
+              <div className="hidden text-sm text-white/70 lg:block">{formatCompletedAt(entry.completedAt)}</div>
+              <div className="text-right">
+                <span className="text-2xl font-medium tracking-[-0.04em] text-white group-hover:text-[#d7ff00] lg:text-3xl">
+                  {Math.round(entry.score * 100)}
+                </span>
+                <span className="ml-0.5 text-[10px] text-white/35 lg:ml-1 lg:text-xs">%</span>
+              </div>
+            </a>
+          ))}
+          {placeholderPositions.map((position) => <PlaceholderRow key={position} position={position} />)}
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-[#777064]">
+          {entries.length === 0
+            ? "No published results for this benchmark version yet."
+            : `Showing ${(currentPage - 1) * LEADERBOARD_PAGE_SIZE + 1}-${Math.min(currentPage * LEADERBOARD_PAGE_SIZE, entries.length)} of ${entries.length}`}
+        </p>
+        <div className="flex items-center gap-2" aria-label="Leaderboard pagination">
+          <button
+            type="button"
+            disabled={currentPage === 1}
+            onClick={() => setPage((value) => Math.max(1, value - 1))}
+            className="rounded-full border border-[#d8d0c2] bg-white/55 px-3 py-2 text-xs text-[#403b33] disabled:cursor-not-allowed disabled:opacity-35"
+          >
+            <span className="hidden sm:inline">Previous</span>
+            <span className="sm:hidden">Prev</span>
+          </button>
+          {Array.from({ length: pageCount }, (_, index) => index + 1).map((pageNumber) => (
+            <button
+              key={pageNumber}
+              type="button"
+              aria-current={pageNumber === currentPage ? "page" : undefined}
+              onClick={() => setPage(pageNumber)}
+              className={pageNumber === currentPage
+                ? "h-8 w-8 rounded-full bg-[#d7ff00] text-xs font-medium text-[#111111]"
+                : "h-8 w-8 rounded-full border border-[#d8d0c2] bg-white/55 text-xs text-[#625c52]"}
+            >
+              {pageNumber}
+            </button>
+          ))}
+          <button
+            type="button"
+            disabled={currentPage === pageCount}
+            onClick={() => setPage((value) => Math.min(pageCount, value + 1))}
+            className="rounded-full border border-[#d8d0c2] bg-white/55 px-3 py-2 text-xs text-[#403b33] disabled:cursor-not-allowed disabled:opacity-35"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { createSupabaseAdminClient } from "./supabase/admin";
 import { mockStore } from "./mock-store";
-import { parseBrowserEnvironment } from "./run-metadata";
+import { buildRunMetadataUpdate, parseBrowserEnvironment } from "./run-metadata";
 
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
 const DEVELOPMENT_GUEST_RUN_LIMIT = 10;
@@ -553,7 +553,7 @@ export async function submitBenchmarkRunMetadata(
     return null;
   }
 
-  const existing = await supabase.from("benchmark_runs").select("metadata, status").eq("id", runId).maybeSingle();
+  const existing = await supabase.from("benchmark_runs").select("metadata, status, started_at").eq("id", runId).maybeSingle();
   if (existing.error) {
     throw existing.error;
   }
@@ -567,21 +567,31 @@ export async function submitBenchmarkRunMetadata(
   const currentMetadata = existing.data.metadata && typeof existing.data.metadata === "object" && !Array.isArray(existing.data.metadata)
     ? existing.data.metadata
     : {};
+  const now = new Date().toISOString();
+  const wasWaiting = existing.data.status === "waiting_for_agent";
   const { data, error } = await supabase
     .from("benchmark_runs")
-    .update({
-      agent_name: input.name,
-      agent_version: input.version,
-      base_model: input.baseModel,
-      browser_environment: browserEnvironment,
-      metadata: { ...currentMetadata, ...input.metadata, identityReportedAt: new Date().toISOString() },
-    })
+    .update(buildRunMetadataUpdate({
+      currentMetadata,
+      currentStatus: existing.data.status,
+      startedAt: existing.data.started_at,
+      input,
+      browserEnvironment,
+      now,
+    }))
     .eq("id", runId)
     .select(benchmarkRunSelect)
     .maybeSingle();
 
   if (error) {
     throw error;
+  }
+  if (data && wasWaiting) {
+    await supabase.from("run_events").insert({
+      run_id: runId,
+      type: "agent.connected",
+      payload: { agentName: input.name, agentVersion: input.version, baseModel: input.baseModel },
+    });
   }
   return data ? mapRunRow(data) : null;
 }
@@ -601,21 +611,134 @@ export type LeaderboardEntry = {
   platform: string | null;
 };
 
-export async function listPublicLeaderboard(limit = 20): Promise<LeaderboardEntry[]> {
+export type PublicBenchmarkResult = {
+  run: BenchmarkRun;
+  benchmark: { title: string; description: string };
+  suite: { slug: string; version: string } | null;
+  tasks: Array<{
+    app: string;
+    taskSlug: string;
+    status: "passed" | "failed" | "error";
+    score: number;
+    summary: string;
+  }>;
+};
+
+export async function getPublicBenchmarkResult(runId: string): Promise<PublicBenchmarkResult | null> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return null;
+  }
+
+  const { data: row, error } = await supabase
+    .from("benchmark_runs")
+    .select(benchmarkRunSelect)
+    .eq("id", runId)
+    .eq("status", "completed")
+    .eq("is_public", true)
+    .maybeSingle();
+  if (error) throw error;
+  if (!row) return null;
+
+  const run = mapRunRow(row);
+  const [{ data: benchmark, error: benchmarkError }, { data: attempt, error: attemptError }, { data: results, error: resultsError }] = await Promise.all([
+    supabase.from("benchmark_cases").select("title, description").eq("id", run.caseId).maybeSingle(),
+    supabase.from("benchmark_attempts").select("suite_slug, suite_version").eq("run_id", runId).eq("status", "completed").maybeSingle(),
+    supabase.from("hosted_web_results").select("app, task_slug, status, score, summary, created_at").eq("run_id", runId).order("created_at", { ascending: true }),
+  ]);
+  if (benchmarkError || attemptError || resultsError) {
+    throw benchmarkError ?? attemptError ?? resultsError;
+  }
+  if (!benchmark) return null;
+
+  return {
+    run,
+    benchmark,
+    suite: attempt ? { slug: attempt.suite_slug, version: attempt.suite_version } : null,
+    tasks: (results ?? []).map((result) => ({
+      app: result.app ?? "hosted-app",
+      taskSlug: result.task_slug ?? "hosted-task",
+      status: result.status,
+      score: result.score,
+      summary: result.summary,
+    })),
+  };
+}
+
+export async function listPublicLeaderboardVersions(): Promise<string[]> {
   const supabase = getSupabase();
   if (!supabase) {
     return [];
   }
 
-  const { data: runs, error } = await supabase
+  const { data: publicRuns, error: runError } = await supabase
+    .from("benchmark_runs")
+    .select("id")
+    .eq("status", "completed")
+    .eq("is_public", true)
+    .not("score", "is", null)
+    .limit(1000);
+
+  if (runError || !publicRuns) {
+    throw runError ?? new Error("Failed to load leaderboard versions");
+  }
+  if (publicRuns.length === 0) {
+    return [];
+  }
+
+  const { data: attempts, error: attemptError } = await supabase
+    .from("benchmark_attempts")
+    .select("suite_version")
+    .eq("status", "completed")
+    .in("run_id", publicRuns.map((run) => run.id))
+    .order("suite_version", { ascending: false });
+
+  if (attemptError || !attempts) {
+    throw attemptError ?? new Error("Failed to load leaderboard versions");
+  }
+
+  return [...new Set(attempts.map((attempt) => attempt.suite_version))]
+    .sort((left, right) => right.localeCompare(left, undefined, { numeric: true, sensitivity: "base" }));
+}
+
+export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): Promise<LeaderboardEntry[]> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return [];
+  }
+
+  let versionRunIds: string[] | null = null;
+  if (suiteVersion) {
+    const { data: versionAttempts, error: versionError } = await supabase
+      .from("benchmark_attempts")
+      .select("run_id")
+      .eq("status", "completed")
+      .eq("suite_version", suiteVersion)
+      .limit(1000);
+
+    if (versionError || !versionAttempts) {
+      throw versionError ?? new Error("Failed to load leaderboard version");
+    }
+    versionRunIds = [...new Set(versionAttempts.map((attempt) => attempt.run_id))];
+    if (versionRunIds.length === 0) {
+      return [];
+    }
+  }
+
+  let runsQuery = supabase
     .from("benchmark_runs")
     .select("id, case_id, score, started_at, completed_at, agent_name, agent_version, base_model, browser_environment")
     .eq("status", "completed")
     .eq("is_public", true)
     .not("score", "is", null)
     .order("score", { ascending: false })
-    .order("completed_at", { ascending: true })
-    .limit(Math.max(1, Math.min(limit, 100)));
+    .order("completed_at", { ascending: true });
+
+  if (versionRunIds) {
+    runsQuery = runsQuery.in("id", versionRunIds);
+  }
+
+  const { data: runs, error } = await runsQuery.limit(Math.max(1, Math.min(limit, 100)));
 
   if (error || !runs) {
     throw error ?? new Error("Failed to load leaderboard");

--- a/apps/web/lib/leaderboard-pagination.test.ts
+++ b/apps/web/lib/leaderboard-pagination.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { paginateLeaderboard } from "./leaderboard-pagination";
+
+test("limits leaderboard pagination to the top 20 entries", () => {
+  const result = paginateLeaderboard(Array.from({ length: 24 }, (_, index) => index + 1), 4);
+
+  assert.equal(result.entries.length, 20);
+  assert.equal(result.pageCount, 4);
+  assert.deepEqual(result.pageEntries, [16, 17, 18, 19, 20]);
+  assert.deepEqual(result.placeholderPositions, []);
+});
+
+test("fills a short leaderboard page with placeholders", () => {
+  const result = paginateLeaderboard([1, 2, 3], 1);
+
+  assert.deepEqual(result.pageEntries, [1, 2, 3]);
+  assert.deepEqual(result.placeholderPositions, [4, 5]);
+});
+
+test("fills the final partial page and clamps an invalid page", () => {
+  const result = paginateLeaderboard([1, 2, 3, 4, 5, 6, 7], 99);
+
+  assert.equal(result.page, 2);
+  assert.deepEqual(result.pageEntries, [6, 7]);
+  assert.deepEqual(result.placeholderPositions, [8, 9, 10]);
+});

--- a/apps/web/lib/leaderboard-pagination.ts
+++ b/apps/web/lib/leaderboard-pagination.ts
@@ -1,0 +1,23 @@
+export const LEADERBOARD_PAGE_SIZE = 5;
+export const LEADERBOARD_MAX_ENTRIES = 20;
+
+export function paginateLeaderboard<T>(entries: T[], requestedPage: number) {
+  const limitedEntries = entries.slice(0, LEADERBOARD_MAX_ENTRIES);
+  const pageCount = Math.max(1, Math.ceil(limitedEntries.length / LEADERBOARD_PAGE_SIZE));
+  const normalizedPage = Number.isFinite(requestedPage) ? Math.trunc(requestedPage) : 1;
+  const page = Math.min(pageCount, Math.max(1, normalizedPage));
+  const start = (page - 1) * LEADERBOARD_PAGE_SIZE;
+  const pageEntries = limitedEntries.slice(start, start + LEADERBOARD_PAGE_SIZE);
+  const placeholderPositions = Array.from(
+    { length: LEADERBOARD_PAGE_SIZE - pageEntries.length },
+    (_, index) => start + pageEntries.length + index + 1,
+  );
+
+  return {
+    entries: limitedEntries,
+    page,
+    pageCount,
+    pageEntries,
+    placeholderPositions,
+  };
+}

--- a/apps/web/lib/run-metadata.test.ts
+++ b/apps/web/lib/run-metadata.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { captureBrowserEnvironment, parseBrowserEnvironment } from "./run-metadata";
+import { buildRunMetadataUpdate, captureBrowserEnvironment, parseBrowserEnvironment } from "./run-metadata";
 
 test("captures Chromium browser metadata without exposing it to leaderboard callers", () => {
   const environment = captureBrowserEnvironment(new Headers({
@@ -36,4 +36,36 @@ test("parses a browser observed by the hosted session", () => {
 
   assert.equal(environment.browser, "Chrome");
   assert.equal(environment.platform, "macOS");
+});
+
+test("first agent registration starts and connects a waiting run", () => {
+  const patch = buildRunMetadataUpdate({
+    currentMetadata: { source: "existing" },
+    currentStatus: "waiting_for_agent",
+    startedAt: null,
+    input: { name: "Codex", version: "1.2.3", baseModel: "GPT-5", metadata: { source: "agent" } },
+    browserEnvironment: { browser: "Chrome" },
+    now: "2026-06-19T12:00:00.000Z",
+  });
+
+  assert.equal(patch.started_at, "2026-06-19T12:00:00.000Z");
+  assert.equal(patch.status, "agent_connected");
+  assert.deepEqual(patch.metadata, {
+    source: "agent",
+    identityReportedAt: "2026-06-19T12:00:00.000Z",
+  });
+});
+
+test("repeated registration preserves the original start time", () => {
+  const patch = buildRunMetadataUpdate({
+    currentMetadata: {},
+    currentStatus: "running",
+    startedAt: "2026-06-19T11:59:00.000Z",
+    input: { name: "Codex", version: "1.2.4", baseModel: "GPT-5", metadata: {} },
+    browserEnvironment: {},
+    now: "2026-06-19T12:00:00.000Z",
+  });
+
+  assert.equal(patch.started_at, "2026-06-19T11:59:00.000Z");
+  assert.equal(patch.status, "running");
 });

--- a/apps/web/lib/run-metadata.ts
+++ b/apps/web/lib/run-metadata.ts
@@ -1,4 +1,5 @@
-import type { BrowserEnvironment } from "@agentbench/protocol";
+import type { BrowserEnvironment, SubmitRunMetadataInput } from "@agentbench/protocol";
+import type { Database } from "@agentbench/shared";
 
 function browserFromUserAgent(userAgent: string) {
   const candidates = [
@@ -50,5 +51,24 @@ export function captureBrowserEnvironment(headers: Headers): BrowserEnvironment 
   return {
     ...parsed,
     userAgent,
+  };
+}
+
+export function buildRunMetadataUpdate(params: {
+  currentMetadata: Record<string, unknown>;
+  currentStatus: Database["public"]["Tables"]["benchmark_runs"]["Row"]["status"];
+  startedAt: string | null;
+  input: SubmitRunMetadataInput;
+  browserEnvironment: Record<string, unknown>;
+  now: string;
+}): Database["public"]["Tables"]["benchmark_runs"]["Update"] {
+  return {
+    agent_name: params.input.name,
+    agent_version: params.input.version,
+    base_model: params.input.baseModel,
+    browser_environment: params.browserEnvironment,
+    metadata: { ...params.currentMetadata, ...params.input.metadata, identityReportedAt: params.now },
+    started_at: params.startedAt ?? params.now,
+    status: params.currentStatus === "waiting_for_agent" ? "agent_connected" : params.currentStatus,
   };
 }


### PR DESCRIPTION
## What changed
- add version-filtered public leaderboard tabs with independent Top 20 rankings
- show five entries per page with placeholders for incomplete pages
- add compact narrow-screen ranking rows while preserving full desktop context
- add public benchmark result detail pages and capture agent/runtime metadata

## Why
Leaderboard results need to remain comparable within a benchmark version, readable on narrow screens, and inspectable beyond the summary row.

## Validation
- `pnpm --filter web test` (17/17)
- `pnpm --filter web build`
- full `pnpm verify:push`
- browser checks at 714px and 390px with no leaderboard overflow or console errors
