### PR TITLE
fix(scoring): define wiki answer contracts

### DIFF
--- a/apps/hosted-orchestrator/src/question-data.test.ts
+++ b/apps/hosted-orchestrator/src/question-data.test.ts
@@ -5,10 +5,10 @@ import test from "node:test";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const seedSql = fs.readFileSync(path.join(root, "supabase/seed.sql"), "utf8");
-const migrationSql = fs.readFileSync(
-  path.join(root, "supabase/migrations/20260611000010_add_hosted_question_variants.sql"),
-  "utf8",
-);
+const migrationSql = [
+  "20260611000010_add_hosted_question_variants.sql",
+  "20260622000018_add_wiki_answer_contracts.sql",
+].map((file) => fs.readFileSync(path.join(root, "supabase/migrations", file), "utf8")).join("\n");
 
 function readHostedSuiteSeed() {
   const jsonValues = [...seedSql.matchAll(/'(\{[\s\S]*?\})'::jsonb/g)].map((match) =>
@@ -50,5 +50,27 @@ test("production data migration contains every seeded question variant", () => {
     for (const value of metadata.questionVariants as Array<Record<string, unknown>>) {
       assert.match(migrationSql, new RegExp(`"id"\\s*:\\s*"${String(value.id)}"`));
     }
+  }
+});
+
+test("wiki question variants declare typed answer contracts", () => {
+  const suite = readHostedSuiteSeed();
+  assert.equal(suite.suiteVersion, "v2");
+  const sessions = suite.sessions as Array<Record<string, unknown>>;
+  const wiki = sessions.find((session) => session.app === "wiki-lite");
+  assert.ok(wiki);
+  assert.equal(wiki.taskVersion, "v2");
+  assert.equal(wiki.seedVersion, "wiki-lite-v2");
+  const metadata = wiki.metadata as Record<string, unknown>;
+  const variants = metadata.questionVariants as Array<Record<string, unknown>>;
+  assert.equal(variants.length, 3);
+  for (const variant of variants) {
+    const config = variant.taskConfig as Record<string, unknown>;
+    assert.equal("expectedAnswer" in config, false);
+    const contract = config.answerContract as Record<string, unknown>;
+    assert.match(String(contract.kind), /^(date|duration|currency)$/);
+    assert.equal(typeof contract.canonicalValue, "string");
+    assert.match(String(contract.normalization), /^(trim|trim-casefold|trim-casefold-punctuation)$/);
+    assert.equal(contract.sourceArticleSlug, config.targetArticleSlug);
   }
 });

--- a/apps/hosted-orchestrator/src/question-generation.test.ts
+++ b/apps/hosted-orchestrator/src/question-generation.test.ts
@@ -30,6 +30,7 @@ test("question generation persists the selected hidden task config", () => {
   assert.equal(typeof generated.goal, "string");
   assert.notEqual(generated.goal, session.goal);
   assert.equal(selection.generationSeed, "another-seed");
+  assert.equal(selection.schemaVersion, 3);
   assert.equal(typeof selection.variantId, "string");
   assert.match(String(selection.uiVariant), /^(workspace|sidebar|compact|dashboard|editorial)$/);
   assert.match(String(selection.uiTheme), /^(light|dark)$/);

--- a/apps/hosted-orchestrator/src/question-generation.ts
+++ b/apps/hosted-orchestrator/src/question-generation.ts
@@ -113,7 +113,7 @@ export function generateAttemptQuestions<TSession extends QuestionSession>(
         metadata: {
           ...sourceMetadata,
           questionGeneration: {
-            schemaVersion: 2,
+            schemaVersion: 3,
             generationSeed,
             variantId: variant.id,
             uiVariant: selectedUiVariant,

--- a/apps/hosted-sites/scripts/orchestrator-smoke.sh
+++ b/apps/hosted-sites/scripts/orchestrator-smoke.sh
@@ -258,9 +258,10 @@ async function completeRepo(session, config) {
 
 async function completeWiki(session, config) {
   const articleSlug = requireString(config.targetArticleSlug, "wiki targetArticleSlug");
+  const answerContract = requireObject(config.answerContract, "wiki answerContract");
   await checkedFetch(`${hostedBaseUrl}/wiki/article/${encodeURIComponent(articleSlug)}?session=${encodeURIComponent(session.token)}`);
   await postForm("/wiki/answer", session.token, {
-    answer: requireString(config.expectedAnswer, "wiki expectedAnswer"),
+    answer: requireString(answerContract.canonicalValue, "wiki canonicalValue"),
   });
 }
 

--- a/apps/hosted-sites/src/app-registry.test.ts
+++ b/apps/hosted-sites/src/app-registry.test.ts
@@ -20,13 +20,21 @@ const expectedApps = ["shopping-lite", "wiki-lite", "forum-lite", "repo-lite"] a
 function taskConfigForApp(app: HostedAppId) {
   const configs = {
     "shopping-lite": { targetCategory: "charger", quantity: 1, maxTotal: 30, shippingMethod: "standard", avoidRestricted: true },
-    "wiki-lite": { targetArticleSlug: "agentbench-release-history", expectedAnswer: "June 1, 2026" },
+    "wiki-lite": {
+      targetArticleSlug: "agentbench-release-history",
+      answerContract: {
+        kind: "date",
+        canonicalValue: "June 1, 2026",
+        normalization: "trim-casefold-punctuation",
+        sourceArticleSlug: "agentbench-release-history",
+      },
+    },
     "forum-lite": { targetThreadId: "thr-battery", expectedReplyValue: "https://support.example.com/recall/battery-2026", expectedLockReason: "safety escalation" },
     "repo-lite": { filePath: "README.md", expectedText: "pnpm install", forbiddenText: "npm install", expectedMrTitle: "Fix install instructions", expectedTargetBranch: "main" },
   } satisfies Record<HostedAppId, Record<string, unknown>>;
   return {
     questionGeneration: {
-      schemaVersion: 1,
+      schemaVersion: 3,
       generationSeed: "registry-test",
       variantId: `${app}-test`,
       uiVariant: "workspace",

--- a/apps/hosted-sites/src/apps/wiki-lite/answer-contract.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/answer-contract.ts
@@ -1,0 +1,88 @@
+import { configString, readQuestionSchemaVersion, readTaskConfig } from "../../runtime/question-config.js";
+import type { WikiArticle } from "./types.js";
+
+export type WikiAnswerKind = "date" | "duration" | "currency";
+export type WikiAnswerNormalization = "trim" | "trim-casefold" | "trim-casefold-punctuation";
+
+export type WikiAnswerContract = {
+  kind: WikiAnswerKind;
+  canonicalValue: string;
+  normalization: WikiAnswerNormalization;
+  sourceArticleSlug: string;
+  legacy: boolean;
+};
+
+const answerKinds = new Set<WikiAnswerKind>(["date", "duration", "currency"]);
+const normalizationPolicies = new Set<WikiAnswerNormalization>([
+  "trim",
+  "trim-casefold",
+  "trim-casefold-punctuation",
+]);
+
+function contractString(contract: Record<string, unknown>, key: string) {
+  const value = contract[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Generated wiki answerContract.${key} must be a non-empty string.`);
+  }
+  return value;
+}
+
+export function readWikiAnswerContract(metadata: Record<string, unknown>): WikiAnswerContract {
+  const schemaVersion = readQuestionSchemaVersion(metadata);
+  const taskConfig = readTaskConfig(metadata);
+  const targetArticleSlug = configString(taskConfig, "targetArticleSlug");
+  const value = taskConfig.answerContract;
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    if (schemaVersion > 2) {
+      throw new Error("Generated wiki taskConfig.answerContract is required for schema version 3 or newer.");
+    }
+    return {
+      kind: "date",
+      canonicalValue: configString(taskConfig, "expectedAnswer"),
+      normalization: "trim-casefold-punctuation",
+      sourceArticleSlug: targetArticleSlug,
+      legacy: true,
+    };
+  }
+
+  const contract = value as Record<string, unknown>;
+  const kind = contractString(contract, "kind") as WikiAnswerKind;
+  const canonicalValue = contractString(contract, "canonicalValue");
+  const normalization = contractString(contract, "normalization") as WikiAnswerNormalization;
+  const sourceArticleSlug = contractString(contract, "sourceArticleSlug");
+  if (!answerKinds.has(kind)) {
+    throw new Error(`Unsupported wiki answer kind: ${kind}.`);
+  }
+  if (!normalizationPolicies.has(normalization)) {
+    throw new Error(`Unsupported wiki answer normalization: ${normalization}.`);
+  }
+  if (sourceArticleSlug !== targetArticleSlug) {
+    throw new Error("Generated wiki answerContract.sourceArticleSlug must match targetArticleSlug.");
+  }
+  return { kind, canonicalValue, normalization, sourceArticleSlug, legacy: false };
+}
+
+export function normalizeWikiAnswer(value: string, policy: WikiAnswerNormalization) {
+  const trimmed = value.trim();
+  if (policy === "trim") {
+    return trimmed;
+  }
+  const casefolded = trimmed.toLocaleLowerCase("en-US");
+  return policy === "trim-casefold-punctuation"
+    ? casefolded.replaceAll(/[,.]/g, "")
+    : casefolded;
+}
+
+export function validateWikiAnswerSource(contract: WikiAnswerContract, articles: WikiArticle[]) {
+  const article = articles.find((candidate) => candidate.slug === contract.sourceArticleSlug);
+  if (!article) {
+    throw new Error(`Generated wiki source article does not exist: ${contract.sourceArticleSlug}.`);
+  }
+  if (!article.body.includes(contract.canonicalValue)) {
+    throw new Error(
+      `Generated wiki source article ${contract.sourceArticleSlug} does not contain canonical answer ${contract.canonicalValue}.`,
+    );
+  }
+  return article;
+}

--- a/apps/hosted-sites/src/apps/wiki-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/evaluate.ts
@@ -4,8 +4,12 @@ import {
   passedEvaluator,
   type HostedWebScoreResult,
 } from "@agentbench/scoring";
-import type { WikiAnswerSubmission } from "./types.js";
-import { configString, readTaskConfig } from "../../runtime/question-config.js";
+import type { WikiAnswerSubmission, WikiArticle } from "./types.js";
+import {
+  normalizeWikiAnswer,
+  readWikiAnswerContract,
+  validateWikiAnswerSource,
+} from "./answer-contract.js";
 
 export type WikiEvaluationSession = {
   app: "wiki-lite" | string;
@@ -13,18 +17,16 @@ export type WikiEvaluationSession = {
   metadata: Record<string, unknown>;
   events: Array<Record<string, unknown>>;
   state: {
+    wikiArticles: WikiArticle[];
     wikiAnswerSubmissions: WikiAnswerSubmission[];
   };
 };
 
-export function normalizeWikiAnswer(value: string) {
-  return value.trim().toLowerCase().replaceAll(/[,\.]/g, "");
-}
-
 export function evaluateWiki(session: WikiEvaluationSession): HostedWebScoreResult {
-  const config = readTaskConfig(session.metadata);
-  const expectedAnswer = configString(config, "expectedAnswer");
-  const targetArticleSlug = configString(config, "targetArticleSlug");
+  const answerContract = readWikiAnswerContract(session.metadata);
+  validateWikiAnswerSource(answerContract, session.state.wikiArticles);
+  const expectedAnswer = answerContract.canonicalValue;
+  const targetArticleSlug = answerContract.sourceArticleSlug;
   const latestAnswer = session.state.wikiAnswerSubmissions.at(-1);
   const viewedArticleSlugs = Array.isArray(session.metadata.viewedArticleSlugs)
     ? session.metadata.viewedArticleSlugs.filter((value): value is string => typeof value === "string")
@@ -37,20 +39,21 @@ export function evaluateWiki(session: WikiEvaluationSession): HostedWebScoreResu
         String(event.url).includes(`/wiki/article/${targetArticleSlug}`),
     ) || viewedArticleSlugs.includes(targetArticleSlug);
   const answerMatches = latestAnswer
-    ? normalizeWikiAnswer(latestAnswer.answer) === normalizeWikiAnswer(expectedAnswer)
+    ? normalizeWikiAnswer(latestAnswer.answer, answerContract.normalization) ===
+      normalizeWikiAnswer(expectedAnswer, answerContract.normalization)
     : false;
 
   const retrieveValue = answerMatches
-      ? passedEvaluator({
-          type: "retrieve_value",
-          name: "retrieved generated wiki answer",
+    ? passedEvaluator({
+        type: "retrieve_value",
+        name: "retrieved generated wiki answer",
         evidence: { answer: latestAnswer?.answer, expectedAnswer },
       })
-      : failedEvaluator({
-          type: "retrieve_value",
-          name: "retrieved generated wiki answer",
-        errorMessage: "Submitted answer does not match the expected date.",
-        evidence: { answer: latestAnswer?.answer ?? null, expectedAnswer },
+    : failedEvaluator({
+        type: "retrieve_value",
+        name: "retrieved generated wiki answer",
+        errorMessage: `Submitted answer does not match the expected ${answerContract.kind}.`,
+        evidence: { answer: latestAnswer?.answer ?? null, expectedAnswer, answerKind: answerContract.kind },
       });
   const backendState = latestAnswer
     ? passedEvaluator({

--- a/apps/hosted-sites/src/evaluation.test.ts
+++ b/apps/hosted-sites/src/evaluation.test.ts
@@ -4,16 +4,34 @@ import { evaluateForum, type ForumEvaluationSession } from "./apps/forum-lite/ev
 import { evaluateRepo, type RepoEvaluationSession } from "./apps/repo-lite/evaluate.js";
 import { evaluateShopping, type ShoppingEvaluationSession } from "./apps/shopping-lite/evaluate.js";
 import { evaluateWiki, type WikiEvaluationSession } from "./apps/wiki-lite/evaluate.js";
+import { wikiSeedArticles } from "./apps/wiki-lite/seed.js";
 
-function generatedTaskConfig(taskConfig: Record<string, unknown>) {
+function generatedTaskConfig(taskConfig: Record<string, unknown>, schemaVersion = 3) {
   return {
     questionGeneration: {
-      schemaVersion: 1,
+      schemaVersion,
       generationSeed: "test-seed",
       variantId: "test-variant",
       taskConfig,
     },
   };
+}
+
+function wikiTaskConfig(params: {
+  targetArticleSlug: string;
+  kind: "date" | "duration" | "currency";
+  canonicalValue: string;
+  normalization: "trim" | "trim-casefold" | "trim-casefold-punctuation";
+}) {
+  return generatedTaskConfig({
+    targetArticleSlug: params.targetArticleSlug,
+    answerContract: {
+      kind: params.kind,
+      canonicalValue: params.canonicalValue,
+      normalization: params.normalization,
+      sourceArticleSlug: params.targetArticleSlug,
+    },
+  });
 }
 
 const defaultTaskConfigs = {
@@ -67,6 +85,7 @@ function makeShoppingSession(
 function makeWikiSession(overrides?: {
   metadata?: Record<string, unknown>;
   events?: Array<Record<string, unknown>>;
+  wikiArticles?: WikiEvaluationSession["state"]["wikiArticles"];
   wikiAnswerSubmissions?: WikiEvaluationSession["state"]["wikiAnswerSubmissions"];
 }): WikiEvaluationSession {
   return {
@@ -74,9 +93,15 @@ function makeWikiSession(overrides?: {
     taskSlug: "wiki-release-answer",
     metadata:
       overrides?.metadata ??
-      generatedTaskConfig({ targetArticleSlug: "agentbench-release-history", expectedAnswer: "June 1, 2026" }),
+      wikiTaskConfig({
+        targetArticleSlug: "agentbench-release-history",
+        kind: "date",
+        canonicalValue: "June 1, 2026",
+        normalization: "trim-casefold-punctuation",
+      }),
     events: overrides?.events ?? [],
     state: {
+      wikiArticles: overrides?.wikiArticles ?? wikiSeedArticles,
       wikiAnswerSubmissions: overrides?.wikiAnswerSubmissions ?? [],
     },
   };
@@ -364,11 +389,125 @@ test("generated shopping config changes the accepted category and shipping metho
 
 test("generated wiki config changes both the target article and answer", () => {
   const result = evaluateWiki(makeWikiSession({
-    metadata: generatedTaskConfig({ targetArticleSlug: "shipping-policy", expectedAnswer: "two business days" }),
+    metadata: wikiTaskConfig({
+      targetArticleSlug: "shipping-policy",
+      kind: "duration",
+      canonicalValue: "two business days",
+      normalization: "trim-casefold",
+    }),
     events: [{ type: "page.load", url: "/wiki/article/shipping-policy?session=tok" }],
     wikiAnswerSubmissions: [{ answer: "two business days", submittedAt: "2026-06-01T00:00:00.000Z" }],
   }));
   assert.equal(result.status, "passed");
+});
+
+test("generated wiki contracts score every current answer kind", () => {
+  const variants = [
+    {
+      targetArticleSlug: "agentbench-release-history",
+      kind: "date" as const,
+      canonicalValue: "June 1, 2026",
+      normalization: "trim-casefold-punctuation" as const,
+      submittedAnswer: "june 1 2026",
+    },
+    {
+      targetArticleSlug: "shipping-policy",
+      kind: "duration" as const,
+      canonicalValue: "two business days",
+      normalization: "trim-casefold" as const,
+      submittedAnswer: "TWO BUSINESS DAYS",
+    },
+    {
+      targetArticleSlug: "usb-c-charger-faq",
+      kind: "currency" as const,
+      canonicalValue: "$24.99",
+      normalization: "trim" as const,
+      submittedAnswer: " $24.99 ",
+    },
+  ];
+
+  for (const variant of variants) {
+    const result = evaluateWiki(makeWikiSession({
+      metadata: wikiTaskConfig(variant),
+      events: [{ type: "page.load", url: `/wiki/article/${variant.targetArticleSlug}?session=tok` }],
+      wikiAnswerSubmissions: [{ answer: variant.submittedAnswer, submittedAt: "2026-06-01T00:00:00.000Z" }],
+    }));
+    assert.equal(result.status, "passed", variant.kind);
+  }
+});
+
+test("generated wiki duration rejects surrounding words", () => {
+  const result = evaluateWiki(makeWikiSession({
+    metadata: wikiTaskConfig({
+      targetArticleSlug: "shipping-policy",
+      kind: "duration",
+      canonicalValue: "two business days",
+      normalization: "trim-casefold",
+    }),
+    events: [{ type: "page.load", url: "/wiki/article/shipping-policy?session=tok" }],
+    wikiAnswerSubmissions: [{ answer: "within two business days", submittedAt: "2026-06-01T00:00:00.000Z" }],
+  }));
+  assert.equal(result.status, "failed");
+  assert.match(result.evaluators[0]?.errorMessage ?? "", /expected duration/);
+});
+
+test("generated wiki contract rejects empty answers", () => {
+  const result = evaluateWiki(makeWikiSession({
+    wikiAnswerSubmissions: [{ answer: "   ", submittedAt: "2026-06-01T00:00:00.000Z" }],
+  }));
+  assert.equal(result.status, "failed");
+  assert.equal(result.evaluators[0]?.status, "failed");
+});
+
+test("legacy wiki metadata remains scoreable", () => {
+  const result = evaluateWiki(makeWikiSession({
+    metadata: generatedTaskConfig(
+      { targetArticleSlug: "agentbench-release-history", expectedAnswer: "June 1, 2026" },
+      2,
+    ),
+    events: [{ type: "page.load", url: "/wiki/article/agentbench-release-history?session=tok" }],
+    wikiAnswerSubmissions: [{ answer: "june 1 2026", submittedAt: "2026-06-01T00:00:00.000Z" }],
+  }));
+  assert.equal(result.status, "passed");
+});
+
+test("generated wiki config rejects missing or inconsistent source evidence", () => {
+  assert.throws(
+    () => evaluateWiki(makeWikiSession({
+      metadata: wikiTaskConfig({
+        targetArticleSlug: "missing-article",
+        kind: "duration",
+        canonicalValue: "two business days",
+        normalization: "trim-casefold",
+      }),
+    })),
+    /source article does not exist/,
+  );
+  assert.throws(
+    () => evaluateWiki(makeWikiSession({
+      metadata: wikiTaskConfig({
+        targetArticleSlug: "shipping-policy",
+        kind: "duration",
+        canonicalValue: "three business days",
+        normalization: "trim-casefold",
+      }),
+    })),
+    /does not contain canonical answer/,
+  );
+  assert.throws(
+    () => evaluateWiki(makeWikiSession({
+      metadata: generatedTaskConfig({
+        targetArticleSlug: "shipping-policy",
+        answerContract: {
+          kind: "duration",
+          canonicalValue: "two business days",
+          normalization: "trim-casefold",
+          sourceArticleSlug: "agentbench-release-history",
+        },
+      }),
+    })),
+    /sourceArticleSlug must match targetArticleSlug/,
+  );
 });
 
 test("generated forum config changes the target thread, reply value, and lock reason", () => {

--- a/apps/hosted-sites/src/runtime/question-config.test.ts
+++ b/apps/hosted-sites/src/runtime/question-config.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { configString, readTaskConfig, readUiTheme, readUiVariant } from "./question-config.js";
+import {
+  configString,
+  readQuestionSchemaVersion,
+  readTaskConfig,
+  readUiTheme,
+  readUiVariant,
+} from "./question-config.js";
 
 test("generated question metadata is required for scoring", () => {
   assert.throws(() => readTaskConfig(undefined), /missing generated question metadata/);
@@ -13,6 +19,11 @@ test("generated question metadata is required for scoring", () => {
 
 test("generated task config fields do not accept fallback values", () => {
   assert.throws(() => configString({}, "expectedAnswer"), /expectedAnswer/);
+  assert.throws(
+    () => readQuestionSchemaVersion({ questionGeneration: { schemaVersion: 0, taskConfig: {} } }),
+    /positive integer/,
+  );
+  assert.equal(readQuestionSchemaVersion({ questionGeneration: { schemaVersion: 3, taskConfig: {} } }), 3);
 });
 
 test("UI variant remains independently readable from generated metadata", () => {

--- a/apps/hosted-sites/src/runtime/question-config.ts
+++ b/apps/hosted-sites/src/runtime/question-config.ts
@@ -1,4 +1,4 @@
-export function readTaskConfig(metadata: Record<string, unknown> | null | undefined) {
+export function readQuestionGeneration(metadata: Record<string, unknown> | null | undefined) {
   if (!metadata) {
     throw new Error("Hosted session is missing generated question metadata.");
   }
@@ -6,6 +6,20 @@ export function readTaskConfig(metadata: Record<string, unknown> | null | undefi
   if (!generation || typeof generation !== "object" || Array.isArray(generation)) {
     throw new Error("Hosted session is missing questionGeneration metadata.");
   }
+  return generation as Record<string, unknown>;
+}
+
+export function readQuestionSchemaVersion(metadata: Record<string, unknown> | null | undefined) {
+  const generation = readQuestionGeneration(metadata);
+  const value = generation.schemaVersion;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error("Hosted session questionGeneration.schemaVersion must be a positive integer.");
+  }
+  return value;
+}
+
+export function readTaskConfig(metadata: Record<string, unknown> | null | undefined) {
+  const generation = readQuestionGeneration(metadata);
   const taskConfig = (generation as Record<string, unknown>).taskConfig;
   if (!taskConfig || typeof taskConfig !== "object" || Array.isArray(taskConfig)) {
     throw new Error("Hosted session is missing a generated taskConfig.");

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -40,7 +40,7 @@ flowchart TD
 
 ## Current Hosted Testcases
 
-The production `shopping-constrained-checkout` case runs `hosted-web-suite-v1`. All four sessions are required and have weight 1.
+The production `shopping-constrained-checkout` case runs `hosted-web-suite-v1` version `v2`. All four sessions are required and have weight 1.
 
 | App | Variants |
 | --- | --- |
@@ -79,10 +79,15 @@ Question pools belong in `benchmark_cases.metadata.sessions[].metadata.questionV
     "questionVariants": [
       {
         "id": "shipping-window",
-        "goal": "Find the dispatch window and submit only the duration.",
+        "goal": "Find the dispatch window and submit only the duration without surrounding words.",
         "taskConfig": {
           "targetArticleSlug": "shipping-policy",
-          "expectedAnswer": "two business days"
+          "answerContract": {
+            "kind": "duration",
+            "canonicalValue": "two business days",
+            "normalization": "trim-casefold",
+            "sourceArticleSlug": "shipping-policy"
+          }
         }
       }
     ]
@@ -102,7 +107,12 @@ After selection, the orchestrator removes the pool and persists only the selecte
     "uiTheme": "dark",
     "taskConfig": {
       "targetArticleSlug": "shipping-policy",
-      "expectedAnswer": "two business days"
+      "answerContract": {
+        "kind": "duration",
+        "canonicalValue": "two business days",
+        "normalization": "trim-casefold",
+        "sourceArticleSlug": "shipping-policy"
+      }
     }
   }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,7 +88,7 @@ Detailed scoring and coverage rules are defined in [Benchmark Scoring And Testin
 
 | Milestone | Status | Exit criteria |
 | --- | --- | --- |
-| BQ.1 Scorer and task contract | Planned | Every information-retrieval variant has an unambiguous canonical answer, declared normalization, valid source evidence, and positive/negative tests. |
+| BQ.1 Scorer and task contract | Complete | Every information-retrieval variant has an unambiguous canonical answer, declared normalization, valid source evidence, and positive/negative tests. |
 | BQ.2 Terminal score consistency | Planned | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
 | BQ.3 Testcase expansion | Planned | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
 

--- a/supabase/migrations/20260622000018_add_wiki_answer_contracts.sql
+++ b/supabase/migrations/20260622000018_add_wiki_answer_contracts.sql
@@ -1,0 +1,63 @@
+update public.benchmark_cases
+set metadata = jsonb_set(
+  jsonb_set(metadata, '{suiteVersion}', '"v2"'::jsonb),
+  '{sessions}',
+  (
+    select jsonb_agg(
+      case
+        when session->>'app' = 'wiki-lite' then
+          session || jsonb_build_object(
+            'taskVersion', 'v2',
+            'seedVersion', 'wiki-lite-v2',
+            'metadata', coalesce(session->'metadata', '{}'::jsonb) || jsonb_build_object(
+              'questionVariants', '[
+                {
+                  "id": "release-date",
+                  "goal": "Use the hosted wiki to find when wiki-lite followed the hosted-web suite alpha, then submit only the date.",
+                  "taskConfig": {
+                    "targetArticleSlug": "agentbench-release-history",
+                    "answerContract": {
+                      "kind": "date",
+                      "canonicalValue": "June 1, 2026",
+                      "normalization": "trim-casefold-punctuation",
+                      "sourceArticleSlug": "agentbench-release-history"
+                    }
+                  }
+                },
+                {
+                  "id": "dispatch-window",
+                  "goal": "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit only the duration without surrounding words.",
+                  "taskConfig": {
+                    "targetArticleSlug": "shipping-policy",
+                    "answerContract": {
+                      "kind": "duration",
+                      "canonicalValue": "two business days",
+                      "normalization": "trim-casefold",
+                      "sourceArticleSlug": "shipping-policy"
+                    }
+                  }
+                },
+                {
+                  "id": "charger-price",
+                  "goal": "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit only the exact price.",
+                  "taskConfig": {
+                    "targetArticleSlug": "usb-c-charger-faq",
+                    "answerContract": {
+                      "kind": "currency",
+                      "canonicalValue": "$24.99",
+                      "normalization": "trim",
+                      "sourceArticleSlug": "usb-c-charger-faq"
+                    }
+                  }
+                }
+              ]'::jsonb
+            )
+          )
+        else session
+      end
+      order by (session->>'sequenceIndex')::integer
+    )
+    from jsonb_array_elements(metadata->'sessions') as session
+  )
+)
+where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -57,7 +57,7 @@ values
     'hosted-web',
     '{
       "suiteSlug": "hosted-web-suite-v1",
-      "suiteVersion": "v1",
+      "suiteVersion": "v2",
       "sessions": [
         {
           "app": "shopping-lite",
@@ -117,16 +117,16 @@ values
           "taskSlug": "wiki-release-answer",
           "title": "Wiki Release Lookup",
           "startPath": "/wiki",
-          "taskVersion": "v1",
-          "seedVersion": "wiki-lite-v1",
+          "taskVersion": "v2",
+          "seedVersion": "wiki-lite-v2",
           "sequenceIndex": 3,
           "weight": 1,
           "required": true,
           "metadata": {
             "questionVariants": [
-              {"id": "release-date", "goal": "Use the hosted wiki to find when wiki-lite followed the hosted-web suite alpha, then submit the exact date.", "taskConfig": {"targetArticleSlug": "agentbench-release-history", "expectedAnswer": "June 1, 2026"}},
-              {"id": "dispatch-window", "goal": "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit the exact duration phrase.", "taskConfig": {"targetArticleSlug": "shipping-policy", "expectedAnswer": "two business days"}},
-              {"id": "charger-price", "goal": "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit the exact price.", "taskConfig": {"targetArticleSlug": "usb-c-charger-faq", "expectedAnswer": "$24.99"}}
+              {"id": "release-date", "goal": "Use the hosted wiki to find when wiki-lite followed the hosted-web suite alpha, then submit only the date.", "taskConfig": {"targetArticleSlug": "agentbench-release-history", "answerContract": {"kind": "date", "canonicalValue": "June 1, 2026", "normalization": "trim-casefold-punctuation", "sourceArticleSlug": "agentbench-release-history"}}},
+              {"id": "dispatch-window", "goal": "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit only the duration without surrounding words.", "taskConfig": {"targetArticleSlug": "shipping-policy", "answerContract": {"kind": "duration", "canonicalValue": "two business days", "normalization": "trim-casefold", "sourceArticleSlug": "shipping-policy"}}},
+              {"id": "charger-price", "goal": "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit only the exact price.", "taskConfig": {"targetArticleSlug": "usb-c-charger-faq", "answerContract": {"kind": "currency", "canonicalValue": "$24.99", "normalization": "trim", "sourceArticleSlug": "usb-c-charger-faq"}}}
             ]
           }
         }


### PR DESCRIPTION
## Summary
- define typed, versioned canonical answer contracts for every wiki variant
- validate normalization and source evidence during scoring
- migrate the active suite to v2 while preserving legacy schema v2 scoring
- cover canonical, formatting, near-miss, empty, and wrong-source behavior

## Verification
- `pnpm verify:ci`
- `pnpm --filter hosted-sites test`
- PostgreSQL 17 migration integration: `v2:v2:3`

Closes #45