### PR TITLE
test(hosted-web): cover the full variant matrix

### DIFF
--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -1,0 +1,49 @@
+name: Hosted Variant Sweep
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-variant-sweep-development
+  cancel-in-progress: false
+
+jobs:
+  sweep-development:
+    runs-on:
+      - self-hosted
+      - linux
+      - agentbench-dev
+    environment: development
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        generation_seed:
+          - full-pool-0
+          - full-pool-1
+          - full-pool-2
+          - full-pool-4
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Run deterministic full-pool lifecycle smoke
+        env:
+          START_LOCAL_SERVICES: "false"
+          SMOKE_MODE: full-pass
+          GENERATION_SEED: ${{ matrix.generation_seed }}
+          HOSTED_SITES_PUBLIC_URL: ${{ vars.HOSTED_SITES_PUBLIC_URL }}
+          HOSTED_ORCHESTRATOR_PUBLIC_URL: ${{ vars.HOSTED_ORCHESTRATOR_PUBLIC_URL }}
+          AGENTBENCH_WEB_URL: ${{ vars.AGENTBENCH_WEB_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          RUNNER_SHARED_SECRET: ${{ secrets.RUNNER_SHARED_SECRET }}
+        run: bash apps/hosted-sites/scripts/orchestrator-smoke.sh

--- a/apps/hosted-orchestrator/src/attempt-handlers.ts
+++ b/apps/hosted-orchestrator/src/attempt-handlers.ts
@@ -15,6 +15,7 @@ type AttemptHandlersDeps<TReadModel extends HostedAttemptReadModel> = {
     callbackSecret: string | null;
     suiteSlug: string;
     suiteVersion: string;
+    generationSeed?: string;
     sessions: Array<{
       app: string;
       taskSlug: string;
@@ -32,6 +33,7 @@ type AttemptHandlersDeps<TReadModel extends HostedAttemptReadModel> = {
     attemptId: string;
     suiteSlug: string;
     suiteVersion: string;
+    generationSeed?: string;
     metadata: Record<string, unknown>;
     sessions: Array<{
       sessionId: string;

--- a/apps/hosted-orchestrator/src/question-data.test.ts
+++ b/apps/hosted-orchestrator/src/question-data.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import { generateAttemptQuestions } from "./question-generation.js";
 
 const root = path.resolve(import.meta.dirname, "../../..");
 const seedSql = fs.readFileSync(path.join(root, "supabase/seed.sql"), "utf8");
@@ -72,5 +73,32 @@ test("wiki question variants declare typed answer contracts", () => {
     assert.equal(typeof contract.canonicalValue, "string");
     assert.match(String(contract.normalization), /^(trim|trim-casefold|trim-casefold-punctuation)$/);
     assert.equal(contract.sourceArticleSlug, config.targetArticleSlug);
+  }
+});
+
+test("scheduled development seeds cover every declared variant", () => {
+  const suite = readHostedSuiteSeed();
+  const sessions = suite.sessions as Array<Record<string, unknown>>;
+  const selectedByApp = new Map<string, Set<string>>();
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4"]) {
+    const generated = generateAttemptQuestions(
+      sessions as Parameters<typeof generateAttemptQuestions>[0],
+      seed,
+    );
+    for (const session of generated.sessions) {
+      const generation = session.metadata.questionGeneration as Record<string, unknown>;
+      const selected = selectedByApp.get(session.app) ?? new Set<string>();
+      selected.add(String(generation.variantId));
+      selectedByApp.set(session.app, selected);
+    }
+  }
+
+  for (const session of sessions) {
+    const variants = (session.metadata as Record<string, unknown>).questionVariants as Array<Record<string, unknown>>;
+    assert.deepEqual(
+      selectedByApp.get(String(session.app)),
+      new Set(variants.map((variant) => String(variant.id))),
+      String(session.app),
+    );
   }
 });

--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -613,6 +613,7 @@ async function initializeAttempt(params: {
   callbackSecret: string | null;
   suiteSlug: string;
   suiteVersion: string;
+  generationSeed?: string;
   sessions: Array<{
     app: string;
     taskSlug: string;
@@ -633,7 +634,7 @@ async function initializeAttempt(params: {
   }
   const runId = params.runId;
   const caseId = params.caseId;
-  const generated = generateAttemptQuestions(params.sessions);
+  const generated = generateAttemptQuestions(params.sessions, params.generationSeed);
   const generatedSessions = generated.sessions;
 
   const metadata = {
@@ -1359,6 +1360,7 @@ const server = createServer(async (request, response) => {
         callbackSecret: typeof input.callbackSecret === "string" ? input.callbackSecret : null,
         suiteSlug: typeof input.suiteSlug === "string" ? input.suiteSlug : "hosted-web-suite",
         suiteVersion: typeof input.suiteVersion === "string" ? input.suiteVersion : "v1",
+        generationSeed: typeof input.generationSeed === "string" ? input.generationSeed : undefined,
         sessions: Array.isArray(input.sessions)
           ? input.sessions
               .filter((session): session is Record<string, unknown> => Boolean(session && typeof session === "object"))

--- a/apps/hosted-sites/scripts/orchestrator-smoke.sh
+++ b/apps/hosted-sites/scripts/orchestrator-smoke.sh
@@ -10,6 +10,7 @@ ORCHESTRATOR_BASE_URL="${HOSTED_ORCHESTRATOR_PUBLIC_URL:-http://127.0.0.1:${ORCH
 WEB_URL="${AGENTBENCH_WEB_URL:-http://127.0.0.1:3999}"
 SMOKE_MODE="${SMOKE_MODE:-timeout}"
 START_LOCAL_SERVICES="${START_LOCAL_SERVICES:-true}"
+GENERATION_SEED="${GENERATION_SEED:-}"
 
 if [[ -f "${ENV_FILE}" && -z "${NEXT_PUBLIC_SUPABASE_URL:-}" && -z "${SUPABASE_SERVICE_ROLE_KEY:-}" && -z "${RUNNER_SHARED_SECRET:-}" ]]; then
   set -a
@@ -74,10 +75,12 @@ curl -fsS "${HOSTED_BASE_URL}/health" >/dev/null
 curl -fsS "${ORCHESTRATOR_BASE_URL}/health" >/dev/null
 
 SMOKE_MODE="${SMOKE_MODE}" \
+GENERATION_SEED="${GENERATION_SEED}" \
 HOSTED_BASE_URL="${HOSTED_BASE_URL}" \
 ORCHESTRATOR_BASE_URL="${ORCHESTRATOR_BASE_URL}" \
 node <<'NODE'
 const smokeMode = process.env.SMOKE_MODE;
+const generationSeed = process.env.GENERATION_SEED || undefined;
 const hostedBaseUrl = process.env.HOSTED_BASE_URL;
 const orchestratorBaseUrl = process.env.ORCHESTRATOR_BASE_URL;
 const runnerSecret = process.env.RUNNER_SHARED_SECRET;
@@ -328,6 +331,7 @@ async function main() {
         callbackSecret: runnerSecret,
         suiteSlug: suite.suiteSlug,
         suiteVersion: suite.suiteVersion,
+        generationSeed,
         sessions: suite.sessions,
       }),
     })
@@ -434,8 +438,11 @@ async function main() {
     throw new Error(`Expected one aggregate attempt score, got ${scoreRows.length}.`);
   }
 
+  const selectedVariants = initialized.metadata.sessions
+    .map((session) => `${session.app}:${session.metadata.questionGeneration.variantId}`)
+    .join(",");
   console.log(
-    `orchestrator smoke (${smokeMode}) passed: run=${run.id} attempt=${initialized.attemptId} sessions=${sessions.length}`,
+    `orchestrator smoke (${smokeMode}) passed: run=${run.id} attempt=${initialized.attemptId} sessions=${sessions.length} variants=${selectedVariants}`,
   );
 }
 

--- a/apps/hosted-sites/src/variant-matrix.test.ts
+++ b/apps/hosted-sites/src/variant-matrix.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { buildInitialSessionState, evaluateSession } from "./runtime/app-registry.js";
+import type { HostedAppId, HostedSession } from "./runtime/types.js";
+
+type DeclaredVariant = {
+  id: string;
+  goal: string;
+  taskConfig: Record<string, unknown>;
+};
+
+type DeclaredSession = {
+  app: HostedAppId;
+  taskSlug: string;
+  sequenceIndex: number;
+  metadata: { questionVariants: DeclaredVariant[] };
+};
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const seedSql = fs.readFileSync(path.join(root, "supabase/seed.sql"), "utf8");
+const uiVariants = ["workspace", "sidebar", "compact", "dashboard", "editorial"] as const;
+const uiThemes = ["light", "dark"] as const;
+
+function readDeclaredSessions() {
+  const values = [...seedSql.matchAll(/'(\{[\s\S]*?\})'::jsonb/g)].map((match) =>
+    JSON.parse(match[1].replaceAll("''", "'")) as Record<string, unknown>,
+  );
+  const suite = values.find((value) => value.suiteSlug === "hosted-web-suite-v1");
+  assert.ok(suite && Array.isArray(suite.sessions));
+  return suite.sessions as DeclaredSession[];
+}
+
+function configString(config: Record<string, unknown>, key: string) {
+  const value = config[key];
+  assert.equal(typeof value, "string", key);
+  return value as string;
+}
+
+function makeSession(definition: DeclaredSession, variant: DeclaredVariant): HostedSession {
+  const state = buildInitialSessionState(definition.app);
+  return {
+    id: `session-${definition.app}-${variant.id}`,
+    token: "matrix-token",
+    accessMode: "write",
+    runId: "matrix-run",
+    caseId: "matrix-case",
+    attemptId: "matrix-attempt",
+    callbackSecret: null,
+    app: definition.app,
+    suiteSlug: "hosted-web-suite-v1",
+    suiteVersion: "v2",
+    taskSlug: definition.taskSlug,
+    taskVersion: "matrix",
+    sequenceIndex: definition.sequenceIndex,
+    weight: 1,
+    required: true,
+    title: null,
+    goal: variant.goal,
+    startPath: null,
+    seedVersion: `${definition.app}:${variant.id}`,
+    metadata: {
+      questionGeneration: {
+        schemaVersion: 3,
+        generationSeed: "matrix",
+        variantId: variant.id,
+        uiVariant: "workspace",
+        uiTheme: "light",
+        taskConfig: variant.taskConfig,
+      },
+    },
+    status: "active",
+    expiresAt: null,
+    accessCount: 0,
+    lastAccessedAt: null,
+    firstSeenIp: null,
+    lastSeenIp: null,
+    firstSeenUserAgent: null,
+    lastSeenUserAgent: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    events: [],
+    state,
+    persisted: true,
+  } as HostedSession;
+}
+
+function applyPassingState(session: HostedSession, config: Record<string, unknown>) {
+  if (session.app === "shopping-lite") {
+    const category = configString(config, "targetCategory");
+    const maxTotal = Number(config.maxTotal);
+    const product = session.state.products.find(
+      (candidate) => candidate.category === category && !candidate.restricted && candidate.price <= maxTotal,
+    );
+    assert.ok(product, `missing valid ${category} fixture`);
+    const quantity = Number(config.quantity);
+    session.state.orders.push({
+      id: "order-matrix",
+      items: [{ productId: product.id, quantity }],
+      total: product.price * quantity,
+      shippingMethod: configString(config, "shippingMethod") as "standard" | "express",
+      submittedAt: "2026-06-01T00:00:00.000Z",
+    });
+    return;
+  }
+  if (session.app === "forum-lite") {
+    const threadId = configString(config, "targetThreadId");
+    const thread = session.state.threads.find((candidate) => candidate.id === threadId);
+    assert.ok(thread, `missing thread ${threadId}`);
+    thread.posts.push({ id: "post-matrix", author: "agent", body: configString(config, "expectedReplyValue") });
+    thread.locked = true;
+    session.state.moderationActions.push({
+      id: "moderation-matrix",
+      threadId,
+      action: "lock",
+      reason: configString(config, "expectedLockReason"),
+    });
+    return;
+  }
+  if (session.app === "repo-lite") {
+    const filePath = configString(config, "filePath");
+    const file = session.state.files.find((candidate) => candidate.path === filePath);
+    assert.ok(file, `missing file ${filePath}`);
+    file.content = file.content.replaceAll(configString(config, "forbiddenText"), configString(config, "expectedText"));
+    session.state.mergeRequests.push({
+      id: "mr-matrix",
+      title: configString(config, "expectedMrTitle"),
+      targetBranch: configString(config, "expectedTargetBranch"),
+      changedFiles: [{ path: file.path, content: file.content }],
+    });
+    return;
+  }
+
+  const contract = config.answerContract as Record<string, unknown>;
+  const slug = configString(config, "targetArticleSlug");
+  session.events.push({ type: "page.load", url: `/wiki/article/${slug}` });
+  session.state.wikiAnswerSubmissions.push({
+    answer: configString(contract, "canonicalValue"),
+    submittedAt: "2026-06-01T00:00:00.000Z",
+  });
+}
+
+function breakPassingState(session: HostedSession) {
+  if (session.app === "shopping-lite") {
+    session.state.orders[0]!.shippingMethod = session.state.orders[0]!.shippingMethod === "standard" ? "express" : "standard";
+  } else if (session.app === "forum-lite") {
+    session.state.moderationActions[0]!.reason = "wrong reason";
+  } else if (session.app === "repo-lite") {
+    session.state.mergeRequests[0]!.title = "Wrong title";
+  } else {
+    session.state.wikiAnswerSubmissions[0]!.answer = "wrong answer";
+  }
+}
+
+for (const definition of readDeclaredSessions()) {
+  for (const variant of definition.metadata.questionVariants) {
+    test(`${definition.app}/${variant.id} has positive, negative, and presentation-invariant scoring`, () => {
+      const passing = makeSession(definition, variant);
+      applyPassingState(passing, variant.taskConfig);
+      assert.equal(evaluateSession(passing).status, "passed");
+
+      for (const uiVariant of uiVariants) {
+        for (const uiTheme of uiThemes) {
+          const generation = passing.metadata.questionGeneration as Record<string, unknown>;
+          generation.uiVariant = uiVariant;
+          generation.uiTheme = uiTheme;
+          assert.equal(evaluateSession(passing).status, "passed", `${uiVariant}/${uiTheme}`);
+        }
+      }
+
+      const failing = structuredClone(passing);
+      breakPassingState(failing);
+      assert.equal(evaluateSession(failing).status, "failed");
+    });
+  }
+}

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -48,3 +48,12 @@ CI should enumerate declared variants directly instead of relying on a few rando
 - A development-only scheduled sweep covers the complete pool without consuming production guest quota.
 
 CI must fail when a declared variant lacks both positive and negative scorer coverage. Development E2E must show that Web, hosted-sites, orchestrator, Redis, and Supabase converge on one terminal score.
+
+## Commands And Scheduled Coverage
+
+- `pnpm --filter hosted-sites test` reads the canonical suite from `supabase/seed.sql`, executes positive and negative scoring for all 12 current variants, and repeats each passing state across all five layouts and both themes.
+- `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
+- `Hosted Variant Sweep` runs four deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, and `full-pool-4` cover every current variant without using Web guest quota.
+- Each lifecycle smoke logs selected variant IDs and requires four unique `hosted_web_results` rows plus one `benchmark_attempt_scores` row.
+
+The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,7 +90,7 @@ Detailed scoring and coverage rules are defined in [Benchmark Scoring And Testin
 | --- | --- | --- |
 | BQ.1 Scorer and task contract | Complete | Every information-retrieval variant has an unambiguous canonical answer, declared normalization, valid source evidence, and positive/negative tests. |
 | BQ.2 Terminal score consistency | In progress | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
-| BQ.3 Testcase expansion | Planned | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
+| BQ.3 Testcase expansion | In progress | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
 
 Complete BQ.1 and BQ.2 before expanding the hosted app catalog so new applications do not inherit ambiguous or mutable terminal scoring.
 


### PR DESCRIPTION
## Summary
- enumerate all 12 declared variants directly from `supabase/seed.sql`
- require a positive and negative scorer path for every variant
- verify every passing semantic state across five layouts and light/dark themes
- add deterministic internal generation seeds and a development-only weekly full-pool sweep
- log selected variants and retain the four-results/one-aggregate smoke invariant

## Verification
- `pnpm verify:ci`
- hosted-sites: 80 tests
- hosted-orchestrator: 46 tests with Redis enabled by the CI gate
- scheduled seed coverage contract covers every declared variant

## Remaining gate
- first development full-pool sweep after the stacked changes deploy

Depends on #49. Advances #47.