### PR TITLE
fix(security): protect benchmark evaluator manifests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,8 @@ Redis has two isolated responsibilities. Versioned session keys provide the shar
 
 Supabase stores durable control-plane and audit data: runs, attempts, hosted sessions, events, results, aggregate scores, access logs, and artifacts. It stores app state snapshots in session metadata for recovery, but it is not the primary per-request state store.
 
+`benchmark_cases` is a private control-plane table because its metadata contains suite manifests and evaluator inputs. Anonymous and authenticated database clients can discover public cases only through `public_benchmark_cases`, which projects display-safe suite and session fields. Service-role code must not return the private manifest through a public API or read model.
+
 ### Nginx and Cloudflare
 
 Nginx is the only gateway inside the hosted Compose network. It load-balances hosted-sites replicas and routes the orchestrator prefix to the orchestrator service. Cloudflare Tunnel publishes the environment-specific hosted hostname and forwards it to the corresponding host gateway port; TLS terminates at the Cloudflare edge.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -17,6 +17,12 @@ erDiagram
 
 ## Durable Supabase Records
 
+### `benchmark_cases` and `public_benchmark_cases`
+
+`benchmark_cases` is the private control-plane definition of a benchmark case. Its `metadata` may contain suite manifests, variant pools, canonical answers, and evaluator parameters, so only service-role code can read the base table.
+
+`public_benchmark_cases` is the anonymous/authenticated discovery boundary. It contains display fields plus a sanitized metadata projection with suite identity and ordered app/task summaries. It never contains question variants, generated task configuration, canonical answers, or evaluator parameters.
+
 ### `benchmark_runs`
 
 The user-facing execution record. Important fields include owner (`user_id` or `guest_id`), `case_id`, `execution_mode`, lifecycle `status`, final `score`, timestamps, and error information.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,6 +24,7 @@ P0 is now organized as ordered, independently verifiable milestones. A milestone
 | P0.3 Atomic lifecycle transitions | Complete | Timeout, terminal completion, and active promotion share an attempt row lock and pass real-Postgres timeout-versus-completion and duplicate-completion race tests. |
 | P0.4 Durable callback recovery | Complete | Web completion callbacks use a transactional outbox, eight-attempt bounded retry, stale-claim recovery, periodic reconciliation, and an idempotent Web receiver. |
 | P0.5 Poison-command containment | Complete | Commands retry at most three times, persist diagnostic dead letters before acknowledgement, and support authenticated inspection and replay with a new command ID. |
+| P0.6 Evaluator confidentiality | In progress | Public case discovery exposes only display-safe metadata while suite manifests, generated variant pools, canonical answers, and evaluator parameters remain service-role-only. |
 
 ### P0.2 Implementation Scope
 
@@ -62,6 +63,13 @@ P0 completion criterion: after any single-process failure or command retry, the 
 - Internal authenticated APIs list dead letters and replay a selected record with a new command ID, avoiding the original result cache.
 - CI covers retry limits, DLQ persistence failure recovery, diagnostic schema, and database storage.
 
+### P0.6 Implementation Scope
+
+- Anonymous and authenticated database clients read benchmark cases through an explicit public projection rather than the base table.
+- The public projection exposes suite identity and display-safe session summaries, but never variant pools, generated task configuration, canonical answers, or evaluator parameters.
+- Server-side control-plane and hosted services retain private manifest access through service-role credentials.
+- Real-Postgres CI verifies both denied base-table access and sanitized public projection output.
+
 ## P1: Observability and Operations
 
 - Emit structured logs with request ID, command ID, run ID, attempt ID, session ID, partition, and deployment environment.
@@ -91,6 +99,8 @@ Detailed scoring and coverage rules are defined in [Benchmark Scoring And Testin
 | BQ.1 Scorer and task contract | Complete | Every information-retrieval variant has an unambiguous canonical answer, declared normalization, valid source evidence, and positive/negative tests. |
 | BQ.2 Terminal score consistency | In progress | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
 | BQ.3 Testcase expansion | In progress | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
+| BQ.4 Typed testcase catalog | Planned | Hosted task definitions and suite composition have one discriminated, validated TypeScript source used by tests, local data, and publishing. |
+| BQ.5 Immutable benchmark releases | Planned | Every attempt references an immutable case revision, and changing the current release cannot alter historical interpretation. |
 
 Complete BQ.1 and BQ.2 before expanding the hosted app catalog so new applications do not inherit ambiguous or mutable terminal scoring.
 

--- a/packages/shared/src/database.types.ts
+++ b/packages/shared/src/database.types.ts
@@ -649,7 +649,22 @@ export type Database = {
         Relationships: [];
       };
     };
-    Views: Record<string, never>;
+    Views: {
+      public_benchmark_cases: {
+        Row: {
+          category: string | null;
+          created_at: string | null;
+          description: string | null;
+          difficulty: string | null;
+          id: string | null;
+          metadata: Json | null;
+          provider: "native" | "hosted-web" | "webarena" | null;
+          slug: string | null;
+          title: string | null;
+        };
+        Relationships: [];
+      };
+    };
     Functions: {
       complete_hosted_attempt_session: {
         Args: {

--- a/scripts/test-benchmark-case-privacy.sh
+++ b/scripts/test-benchmark-case-privacy.sh
@@ -81,16 +81,31 @@ for role in anon authenticated; do
     exit 1
   fi
 
-  public_case="$("${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "set role ${role}; select row_to_json(cases) from public.public_benchmark_cases cases;")"
-  [[ "${public_case}" == *'"suiteVersion":"v2"'* ]]
-  [[ "${public_case}" == *'"app":"wiki-lite"'* ]]
-  [[ "${public_case}" != *'taskConfig'* ]]
-  [[ "${public_case}" != *'canonicalValue'* ]]
-  [[ "${public_case}" != *'June 1, 2026'* ]]
+  public_projection_valid="$("${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "
+    set role ${role};
+    select count(*) = 1
+      and bool_and(metadata ->> 'suiteVersion' = 'v2')
+      and bool_and(metadata -> 'sessions' -> 0 ->> 'app' = 'wiki-lite')
+      and bool_and(metadata::text not like '%taskConfig%')
+      and bool_and(metadata::text not like '%canonicalValue%')
+      and bool_and(metadata::text not like '%June 1, 2026%')
+    from public.public_benchmark_cases;
+  ")"
+  if [[ "${public_projection_valid}" != "t" ]]; then
+    echo "${role} received an invalid public benchmark case projection: ${public_projection_valid}" >&2
+    exit 1
+  fi
 done
 
-private_metadata="$("${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "set role service_role; select metadata from public.benchmark_cases;")"
-[[ "${private_metadata}" == *'taskConfig'* ]]
-[[ "${private_metadata}" == *'June 1, 2026'* ]]
+private_manifest_valid="$("${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "
+  set role service_role;
+  select bool_and(metadata::text like '%taskConfig%')
+    and bool_and(metadata::text like '%June 1, 2026%')
+  from public.benchmark_cases;
+")"
+if [[ "${private_manifest_valid}" != "t" ]]; then
+  echo "service_role could not read the private benchmark case manifest: ${private_manifest_valid}" >&2
+  exit 1
+fi
 
 echo "benchmark case privacy tests passed"

--- a/scripts/test-benchmark-case-privacy.sh
+++ b/scripts/test-benchmark-case-privacy.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER="agentbench-case-privacy-postgres-$RANDOM"
+PSQL=(docker exec -i "${CONTAINER}" psql -h 127.0.0.1 -U postgres -d postgres)
+
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run -d --rm --name "${CONTAINER}" \
+  -e POSTGRES_PASSWORD=postgres \
+  postgres:17-alpine >/dev/null
+
+for _ in $(seq 1 30); do
+  if docker exec "${CONTAINER}" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+"${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc 'select 1' >/dev/null
+
+"${PSQL[@]}" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+create role anon;
+create role authenticated;
+create role service_role bypassrls;
+
+create table public.benchmark_cases (
+  id uuid primary key,
+  slug text not null,
+  title text not null,
+  description text not null,
+  category text not null,
+  difficulty text not null,
+  provider text,
+  metadata jsonb not null default '{}'::jsonb,
+  is_public boolean not null default false,
+  created_at timestamptz not null default now()
+);
+alter table public.benchmark_cases enable row level security;
+create policy "benchmark_cases_public_read"
+  on public.benchmark_cases for select to anon, authenticated using (is_public = true);
+grant select on public.benchmark_cases to anon, authenticated, service_role;
+
+insert into public.benchmark_cases (
+  id, slug, title, description, category, difficulty, provider, metadata, is_public
+) values (
+  '70000000-0000-0000-0000-000000000001',
+  'hosted-web-suite',
+  'Hosted Web Suite',
+  'Public description',
+  'browser',
+  'easy',
+  'hosted-web',
+  '{
+    "suiteSlug":"hosted-web-suite-v1",
+    "suiteVersion":"v2",
+    "sessions":[{
+      "app":"wiki-lite",
+      "taskSlug":"wiki-release-answer",
+      "title":"Wiki Release Lookup",
+      "taskVersion":"v2",
+      "sequenceIndex":0,
+      "weight":1,
+      "required":true,
+      "metadata":{"questionVariants":[{"goal":"Find the date","taskConfig":{"canonicalValue":"June 1, 2026"}}]}
+    }]
+  }'::jsonb,
+  true
+);
+SQL
+
+"${PSQL[@]}" -v ON_ERROR_STOP=1 \
+  < "${ROOT_DIR}/supabase/migrations/20260622000019_protect_benchmark_case_manifests.sql" >/dev/null
+
+for role in anon authenticated; do
+  if "${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "set role ${role}; select metadata from public.benchmark_cases;" >/dev/null 2>&1; then
+    echo "${role} can still read private benchmark case metadata" >&2
+    exit 1
+  fi
+
+  public_case="$("${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "set role ${role}; select row_to_json(cases) from public.public_benchmark_cases cases;")"
+  [[ "${public_case}" == *'"suiteVersion":"v2"'* ]]
+  [[ "${public_case}" == *'"app":"wiki-lite"'* ]]
+  [[ "${public_case}" != *'taskConfig'* ]]
+  [[ "${public_case}" != *'canonicalValue'* ]]
+  [[ "${public_case}" != *'June 1, 2026'* ]]
+done
+
+private_metadata="$("${PSQL[@]}" -v ON_ERROR_STOP=1 -Atqc "set role service_role; select metadata from public.benchmark_cases;")"
+[[ "${private_metadata}" == *'taskConfig'* ]]
+[[ "${private_metadata}" == *'June 1, 2026'* ]]
+
+echo "benchmark case privacy tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -13,6 +13,9 @@ bash scripts/test-orchestrator-topology.sh
 echo "== Lifecycle Postgres integration =="
 bash scripts/test-lifecycle-postgres.sh
 
+echo "== Benchmark case privacy =="
+bash scripts/test-benchmark-case-privacy.sh
+
 echo "== Web library tests =="
 pnpm --filter web test
 

--- a/supabase/migrations/20260622000019_protect_benchmark_case_manifests.sql
+++ b/supabase/migrations/20260622000019_protect_benchmark_case_manifests.sql
@@ -1,0 +1,59 @@
+drop policy if exists "benchmark_cases_public_read" on public.benchmark_cases;
+
+revoke select on table public.benchmark_cases from anon, authenticated;
+
+create or replace view public.public_benchmark_cases
+with (security_barrier = true)
+as
+select
+  cases.id,
+  cases.slug,
+  cases.title,
+  cases.description,
+  cases.category,
+  cases.difficulty,
+  cases.provider,
+  jsonb_strip_nulls(
+    jsonb_build_object(
+      'suiteSlug', cases.metadata -> 'suiteSlug',
+      'suiteVersion', cases.metadata -> 'suiteVersion',
+      'sessionCount', case
+        when jsonb_typeof(cases.metadata -> 'sessions') = 'array'
+          then jsonb_array_length(cases.metadata -> 'sessions')
+        else null
+      end,
+      'sessions', case
+        when jsonb_typeof(cases.metadata -> 'sessions') = 'array' then (
+          select coalesce(
+            jsonb_agg(
+              jsonb_strip_nulls(
+                jsonb_build_object(
+                  'app', session.value -> 'app',
+                  'taskSlug', session.value -> 'taskSlug',
+                  'title', session.value -> 'title',
+                  'taskVersion', session.value -> 'taskVersion',
+                  'sequenceIndex', session.value -> 'sequenceIndex',
+                  'weight', session.value -> 'weight',
+                  'required', session.value -> 'required'
+                )
+              )
+              order by session.ordinality
+            ),
+            '[]'::jsonb
+          )
+          from jsonb_array_elements(cases.metadata -> 'sessions')
+            with ordinality as session(value, ordinality)
+        )
+        else '[]'::jsonb
+      end
+    )
+  ) as metadata,
+  cases.created_at
+from public.benchmark_cases as cases
+where cases.is_public = true;
+
+comment on view public.public_benchmark_cases is
+  'Display-safe benchmark case projection. Private suite manifests and evaluator taskConfig remain service-role-only.';
+
+revoke all on table public.public_benchmark_cases from public;
+grant select on table public.public_benchmark_cases to anon, authenticated;


### PR DESCRIPTION
## Summary

- revoke anonymous and authenticated reads from the private `benchmark_cases` base table
- expose display-safe case discovery through `public_benchmark_cases`
- add real-Postgres privacy regression coverage to repository CI
- document P0.6 and the public/private benchmark metadata boundary

## Verification

- `pnpm verify:ci`
- pre-push verification
- anonymous/authenticated base-table denial
- sanitized projection and service-role access checks

## Deployment

The migration must pass in development and the hosted lifecycle smoke must remain green before P0.6 is marked complete.

Advances #53