### PR TITLE
docs(roadmap): complete BQ and evaluator privacy gates

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@ P0 is now organized as ordered, independently verifiable milestones. A milestone
 | P0.3 Atomic lifecycle transitions | Complete | Timeout, terminal completion, and active promotion share an attempt row lock and pass real-Postgres timeout-versus-completion and duplicate-completion race tests. |
 | P0.4 Durable callback recovery | Complete | Web completion callbacks use a transactional outbox, eight-attempt bounded retry, stale-claim recovery, periodic reconciliation, and an idempotent Web receiver. |
 | P0.5 Poison-command containment | Complete | Commands retry at most three times, persist diagnostic dead letters before acknowledgement, and support authenticated inspection and replay with a new command ID. |
-| P0.6 Evaluator confidentiality | In progress | Public case discovery exposes only display-safe metadata while suite manifests, generated variant pools, canonical answers, and evaluator parameters remain service-role-only. |
+| P0.6 Evaluator confidentiality | Complete | Public case discovery exposes only display-safe metadata while suite manifests, generated variant pools, canonical answers, and evaluator parameters remain service-role-only. |
 
 ### P0.2 Implementation Scope
 
@@ -69,6 +69,7 @@ P0 completion criterion: after any single-process failure or command retry, the 
 - The public projection exposes suite identity and display-safe session summaries, but never variant pools, generated task configuration, canonical answers, or evaluator parameters.
 - Server-side control-plane and hosted services retain private manifest access through service-role credentials.
 - Real-Postgres CI verifies both denied base-table access and sanitized public projection output.
+- Completion evidence: `develop@4d941b1` passed [Hosted deployment run 27939566570](https://github.com/Kaiwen0418/agent-benchmark/actions/runs/27939566570), including the development migration, deployment, and four-app lifecycle smoke.
 
 ## P1: Observability and Operations
 
@@ -97,12 +98,14 @@ Detailed scoring and coverage rules are defined in [Benchmark Scoring And Testin
 | Milestone | Status | Exit criteria |
 | --- | --- | --- |
 | BQ.1 Scorer and task contract | Complete | Every information-retrieval variant has an unambiguous canonical answer, declared normalization, valid source evidence, and positive/negative tests. |
-| BQ.2 Terminal score consistency | In progress | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
-| BQ.3 Testcase expansion | In progress | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
+| BQ.2 Terminal score consistency | Complete | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
+| BQ.3 Testcase expansion | Complete | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
 | BQ.4 Typed testcase catalog | Planned | Hosted task definitions and suite composition have one discriminated, validated TypeScript source used by tests, local data, and publishing. |
 | BQ.5 Immutable benchmark releases | Planned | Every attempt references an immutable case revision, and changing the current release cannot alter historical interpretation. |
 
 Complete BQ.1 and BQ.2 before expanding the hosted app catalog so new applications do not inherit ambiguous or mutable terminal scoring.
+
+BQ.1-BQ.3 completion evidence: `develop@3ca9329` passed [Hosted deployment run 27937799988](https://github.com/Kaiwen0418/agent-benchmark/actions/runs/27937799988), including generated variant checks, first-result terminal consistency, one result per session, one aggregate score, and the four-app lifecycle smoke.
 
 ## P2: Benchmark and Product Depth
 


### PR DESCRIPTION
## Summary

- mark P0.6, BQ.2, and BQ.3 complete after development verification
- record the successful deployment, migration, and lifecycle smoke runs

## Verification

- `pnpm verify:ci`
- P0.6 development run: https://github.com/Kaiwen0418/agent-benchmark/actions/runs/27939566570
- BQ.1-BQ.3 development run: https://github.com/Kaiwen0418/agent-benchmark/actions/runs/27937799988

Documents completion of #45, #46, #47, and #53.