### PR TITLE
feat(benchmark): publish immutable case revisions

### DIFF
--- a/apps/hosted-orchestrator/src/attempt-handlers.ts
+++ b/apps/hosted-orchestrator/src/attempt-handlers.ts
@@ -12,23 +12,9 @@ type AttemptHandlersDeps<TReadModel extends HostedAttemptReadModel> = {
   initializeAttempt: (params: {
     runId: string | null;
     caseId: string | null;
+    caseRevisionId: string | null;
     callbackSecret: string | null;
-    suiteSlug: string;
-    suiteVersion: string;
     generationSeed?: string;
-    sessions: Array<{
-      app: string;
-      taskSlug: string;
-      taskVersion: string;
-      sequenceIndex: number;
-      weight: number;
-      required: boolean;
-      title: string | null;
-      goal: string | null;
-      startPath: string | null;
-      seedVersion: string | null;
-      metadata: Record<string, unknown>;
-    }>;
   }) => Promise<{
     attemptId: string;
     suiteSlug: string;
@@ -149,22 +135,9 @@ export function createAttemptHandlers<TReadModel extends HostedAttemptReadModel>
   async function handleInitializeAttempt(params: {
     runId: string | null;
     caseId: string | null;
+    caseRevisionId: string | null;
     callbackSecret: string | null;
-    suiteSlug: string;
-    suiteVersion: string;
-    sessions: Array<{
-      app: string;
-      taskSlug: string;
-      taskVersion: string;
-      sequenceIndex: number;
-      weight: number;
-      required: boolean;
-      title: string | null;
-      goal: string | null;
-      startPath: string | null;
-      seedVersion: string | null;
-      metadata: Record<string, unknown>;
-    }>;
+    generationSeed?: string;
   }): Promise<InitializeAttemptHandlerResponse> {
     return {
       statusCode: 201,

--- a/apps/hosted-orchestrator/src/case-revisions.test.ts
+++ b/apps/hosted-orchestrator/src/case-revisions.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hostedWebSuiteMetadata } from "@agentbench/test-cases";
+import { resolveBenchmarkCaseRevision } from "./case-revisions.js";
+
+const row = {
+  id: "revision-1",
+  case_id: "case-1",
+  revision: "hosted-web-suite-v2",
+  content_hash: "a".repeat(64),
+  manifest: hostedWebSuiteMetadata,
+};
+
+test("revision loader validates and returns a typed private manifest", async () => {
+  const revision = await resolveBenchmarkCaseRevision({
+    caseId: "case-1",
+    caseRevisionId: "revision-1",
+    loadRevision: async () => row,
+  });
+  assert.equal(revision.sessions.length, 4);
+  assert.equal(revision.contentHash, "a".repeat(64));
+});
+
+test("revision loader rejects missing, unavailable, cross-case, and invalid revisions", async () => {
+  await assert.rejects(() => resolveBenchmarkCaseRevision({ caseId: "case-1", caseRevisionId: null, loadRevision: async () => row }));
+  await assert.rejects(() => resolveBenchmarkCaseRevision({ caseId: "case-1", caseRevisionId: "missing", loadRevision: async () => null }));
+  await assert.rejects(() => resolveBenchmarkCaseRevision({ caseId: "case-2", caseRevisionId: "revision-1", loadRevision: async () => row }));
+  await assert.rejects(() => resolveBenchmarkCaseRevision({
+    caseId: "case-1",
+    caseRevisionId: "revision-1",
+    loadRevision: async () => ({ ...row, manifest: { suiteSlug: "invalid" } }),
+  }));
+});

--- a/apps/hosted-orchestrator/src/case-revisions.ts
+++ b/apps/hosted-orchestrator/src/case-revisions.ts
@@ -1,0 +1,33 @@
+import { hostedSuiteMetadataSchema } from "@agentbench/test-cases";
+
+export type BenchmarkCaseRevisionRow = {
+  id: string;
+  case_id: string;
+  revision: string;
+  content_hash: string;
+  manifest: unknown;
+};
+
+export async function resolveBenchmarkCaseRevision(params: {
+  caseId: string;
+  caseRevisionId: string | null;
+  loadRevision: (revisionId: string) => Promise<BenchmarkCaseRevisionRow | null>;
+}) {
+  if (!params.caseRevisionId) {
+    throw new Error("Hosted attempt initialization requires a published case revision.");
+  }
+  const row = await params.loadRevision(params.caseRevisionId);
+  if (!row || row.case_id !== params.caseId) {
+    throw new Error("Benchmark case revision is unavailable for this case.");
+  }
+  const parsed = hostedSuiteMetadataSchema.safeParse(row.manifest);
+  if (!parsed.success) {
+    throw new Error(`Benchmark case revision manifest is invalid: ${parsed.error.message}`);
+  }
+  return {
+    ...parsed.data,
+    id: row.id,
+    revision: row.revision,
+    contentHash: row.content_hash,
+  };
+}

--- a/apps/hosted-orchestrator/src/question-generation.ts
+++ b/apps/hosted-orchestrator/src/question-generation.ts
@@ -16,7 +16,7 @@ type QuestionSession = {
   taskSlug: string;
   sequenceIndex: number;
   title: string | null;
-  goal: string | null;
+  goal?: string | null;
   seedVersion: string | null;
   metadata: Record<string, unknown>;
 };

--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -27,6 +27,7 @@ import { generateAttemptQuestions } from "./question-generation.js";
 import { createIdempotentInitializer } from "./idempotent-initializer.js";
 import { createSingleFlight } from "./single-flight.js";
 import { createCallbackOutboxProcessor } from "./callback-outbox.js";
+import { resolveBenchmarkCaseRevision } from "./case-revisions.js";
 
 const port = Number(process.env.HOSTED_ORCHESTRATOR_PORT ?? 3004);
 const publicBaseUrl = process.env.HOSTED_ORCHESTRATOR_PUBLIC_URL ?? `http://localhost:${port}`;
@@ -563,7 +564,7 @@ async function findExistingInitializedAttempt(
   }
   const { data, error } = await supabase
     .from("benchmark_attempts")
-    .select("id")
+    .select("id, case_revision_id")
     .eq("run_id", params.runId)
     .eq("case_id", params.caseId)
     .eq("provider", "hosted-web")
@@ -574,10 +575,14 @@ async function findExistingInitializedAttempt(
     throw error;
   }
   if (data) {
+    if (data.case_revision_id !== params.caseRevisionId) {
+      throw new Error("Existing hosted attempt is bound to a different benchmark revision.");
+    }
+    const revision = await loadBenchmarkCaseRevision(params.caseId, params.caseRevisionId);
     return recoverInitializedAttempt({
       runId: params.runId,
       caseId: params.caseId,
-      expectedSessionCount: params.sessions.length,
+      expectedSessionCount: revision.sessions.length,
     });
   }
   return null;
@@ -607,38 +612,50 @@ async function acquireInitializationLease(key: string) {
   };
 }
 
-async function initializeAttempt(params: {
+type InitializeAttemptParams = {
   runId: string | null;
   caseId: string | null;
+  caseRevisionId: string | null;
   callbackSecret: string | null;
-  suiteSlug: string;
-  suiteVersion: string;
   generationSeed?: string;
-  sessions: Array<{
-    app: string;
-    taskSlug: string;
-    taskVersion: string;
-    sequenceIndex: number;
-    weight: number;
-    required: boolean;
-    title: string | null;
-    goal: string | null;
-    startPath: string | null;
-    seedVersion: string | null;
-    metadata: Record<string, unknown>;
-  }>;
-}) {
+};
+
+async function loadBenchmarkCaseRevision(caseId: string, caseRevisionId: string | null) {
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    throw new Error("Hosted attempt initialization requires a database connection.");
+  }
+  return resolveBenchmarkCaseRevision({
+    caseId,
+    caseRevisionId,
+    loadRevision: async (revisionId) => {
+      const { data, error } = await supabase
+        .from("benchmark_case_revisions")
+        .select("id, case_id, revision, content_hash, manifest")
+        .eq("id", revisionId)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+async function initializeAttempt(params: InitializeAttemptParams) {
   const supabase = getSupabaseAdmin();
   if (!supabase || !params.runId || !params.caseId) {
     throw new Error("Hosted attempt initialization requires database-backed run and case ids.");
   }
   const runId = params.runId;
   const caseId = params.caseId;
-  const generated = generateAttemptQuestions(params.sessions, params.generationSeed);
+  const revision = await loadBenchmarkCaseRevision(caseId, params.caseRevisionId);
+  const generated = generateAttemptQuestions(revision.sessions, params.generationSeed);
   const generatedSessions = generated.sessions;
 
   const metadata = {
     generationSeed: generated.generationSeed,
+    caseRevisionId: revision.id,
+    caseRevision: revision.revision,
+    caseRevisionContentHash: revision.contentHash,
     sessions: generatedSessions.map((session) => ({
       app: session.app,
       taskSlug: session.taskSlug,
@@ -661,9 +678,10 @@ async function initializeAttempt(params: {
     .insert({
       run_id: runId,
       case_id: caseId,
+      case_revision_id: revision.id,
       provider: "hosted-web",
-      suite_slug: params.suiteSlug,
-      suite_version: params.suiteVersion,
+      suite_slug: revision.suiteSlug,
+      suite_version: revision.suiteVersion,
       status: "running",
       metadata,
       started_at: now(),
@@ -692,8 +710,11 @@ async function initializeAttempt(params: {
     const sessionMetadata = {
       ...session.metadata,
       schemaVersion: 1,
-      suiteSlug: params.suiteSlug,
-      suiteVersion: params.suiteVersion,
+      suiteSlug: revision.suiteSlug,
+      suiteVersion: revision.suiteVersion,
+      caseRevisionId: revision.id,
+      caseRevision: revision.revision,
+      caseRevisionContentHash: revision.contentHash,
       title: session.title,
       goal: session.goal,
       startPath,
@@ -785,7 +806,7 @@ async function initializeAttempt(params: {
           attemptId: attemptRow.id,
           app: session.app,
           taskSlug: session.taskSlug,
-          suiteSlug: params.suiteSlug,
+          suiteSlug: revision.suiteSlug,
           sequenceIndex: session.sequenceIndex,
           weight: session.weight,
           status: session.status === "scoring" ? "active" : session.status,
@@ -974,16 +995,16 @@ const attemptLifecycle = createAttemptLifecycle({
 });
 
 const initializeAttemptIdempotently = createIdempotentInitializer({
-  key: (params: Parameters<typeof initializeAttempt>[0]) => `${params.runId}:${params.caseId}`,
+  key: (params: Parameters<typeof initializeAttempt>[0]) => `${params.runId}:${params.caseId}:${params.caseRevisionId}`,
   findExisting: findExistingInitializedAttempt,
-  waitForExisting: (params) => {
+  waitForExisting: async (params) => {
     if (!params.runId || !params.caseId) {
       throw new Error("Hosted attempt recovery requires run and case ids.");
     }
     return recoverInitializedAttempt({
       runId: params.runId,
       caseId: params.caseId,
-      expectedSessionCount: params.sessions.length,
+      expectedSessionCount: (await loadBenchmarkCaseRevision(params.caseId, params.caseRevisionId)).sessions.length,
     });
   },
   acquireLock: acquireInitializationLease,
@@ -991,7 +1012,7 @@ const initializeAttemptIdempotently = createIdempotentInitializer({
 });
 
 const initializeAttemptSingleFlight = createSingleFlight({
-  key: (params: Parameters<typeof initializeAttempt>[0]) => `${params.runId}:${params.caseId}`,
+  key: (params: Parameters<typeof initializeAttempt>[0]) => `${params.runId}:${params.caseId}:${params.caseRevisionId}`,
   run: initializeAttemptIdempotently,
 });
 
@@ -1357,33 +1378,9 @@ const server = createServer(async (request, response) => {
       const initialized = await commandBackbone.execute("attempt.init", {
         runId: typeof input.runId === "string" ? input.runId : null,
         caseId: typeof input.caseId === "string" ? input.caseId : null,
+        caseRevisionId: typeof input.caseRevisionId === "string" ? input.caseRevisionId : null,
         callbackSecret: typeof input.callbackSecret === "string" ? input.callbackSecret : null,
-        suiteSlug: typeof input.suiteSlug === "string" ? input.suiteSlug : "hosted-web-suite",
-        suiteVersion: typeof input.suiteVersion === "string" ? input.suiteVersion : "v1",
         generationSeed: typeof input.generationSeed === "string" ? input.generationSeed : undefined,
-        sessions: Array.isArray(input.sessions)
-          ? input.sessions
-              .filter((session): session is Record<string, unknown> => Boolean(session && typeof session === "object"))
-              .map((session, index) => ({
-                app: typeof session.app === "string" ? session.app : "shopping-lite",
-                taskSlug: typeof session.taskSlug === "string" ? session.taskSlug : `hosted-task-${index + 1}`,
-                taskVersion: typeof session.taskVersion === "string" ? session.taskVersion : "v1",
-                sequenceIndex:
-                  typeof session.sequenceIndex === "number" && Number.isFinite(session.sequenceIndex)
-                    ? session.sequenceIndex
-                    : index,
-                weight: typeof session.weight === "number" ? session.weight : 1,
-                required: typeof session.required === "boolean" ? session.required : true,
-                title: typeof session.title === "string" ? session.title : null,
-                goal: typeof session.goal === "string" ? session.goal : null,
-                startPath: typeof session.startPath === "string" ? session.startPath : null,
-                seedVersion: typeof session.seedVersion === "string" ? session.seedVersion : null,
-                metadata:
-                  session.metadata && typeof session.metadata === "object" && !Array.isArray(session.metadata)
-                    ? (session.metadata as Record<string, unknown>)
-                    : {},
-              }))
-          : [],
       }, typeof input.runId === "string" ? input.runId : typeof input.caseId === "string" ? input.caseId : "attempt.init", commandIdFromRequest(request));
       sendJson(response, initialized.statusCode, initialized.body);
       return;

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -18,7 +18,7 @@ import { completableRunStatuses, terminalRunStatuses } from "./run-lifecycle";
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
 const DEVELOPMENT_GUEST_RUN_LIMIT = 10;
 const DEFAULT_USER_DAILY_RUN_LIMIT = 3;
-const benchmarkCaseSelect = "id, slug, title, description, category, difficulty, provider, metadata, is_public, created_at";
+const benchmarkCaseSelect = "id, slug, title, description, category, difficulty, provider, current_revision_id, metadata, is_public, created_at";
 const benchmarkRunSelect = "id, user_id, guest_id, case_id, runner_id, execution_mode, status, score, live_view_url, error_message, started_at, completed_at, created_at, metadata, agent_name, agent_version, base_model, browser_environment, is_public";
 
 function getSupabase() {
@@ -120,6 +120,7 @@ export async function listBenchmarkCases(): Promise<BenchmarkCase[]> {
     category: item.category,
     difficulty: item.difficulty,
     provider: item.provider ?? "native",
+    currentRevisionId: item.current_revision_id,
     metadata: item.metadata ?? {},
     isPublic: item.is_public,
     createdAt: item.created_at,
@@ -147,6 +148,7 @@ export async function getBenchmarkCase(caseId: string): Promise<BenchmarkCase | 
       category: byId.data.category,
       difficulty: byId.data.difficulty,
       provider: byId.data.provider ?? "native",
+      currentRevisionId: byId.data.current_revision_id,
       metadata: byId.data.metadata ?? {},
       isPublic: byId.data.is_public,
       createdAt: byId.data.created_at,
@@ -171,6 +173,7 @@ export async function getBenchmarkCase(caseId: string): Promise<BenchmarkCase | 
     category: bySlug.data.category,
     difficulty: bySlug.data.difficulty,
     provider: bySlug.data.provider ?? "native",
+    currentRevisionId: bySlug.data.current_revision_id,
     metadata: bySlug.data.metadata ?? {},
     isPublic: bySlug.data.is_public,
     createdAt: bySlug.data.created_at,

--- a/apps/web/lib/hosted-web-revision.test.ts
+++ b/apps/web/lib/hosted-web-revision.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildHostedAttemptInitPayload } from "./hosted-web";
+
+test("hosted attempt initialization sends a revision reference without a private manifest", () => {
+  const payload = buildHostedAttemptInitPayload({
+    runId: "run-1",
+    caseId: "case-1",
+    caseRevisionId: "revision-1",
+    callbackSecret: "secret",
+  });
+
+  assert.deepEqual(payload, {
+    runId: "run-1",
+    caseId: "case-1",
+    caseRevisionId: "revision-1",
+    callbackSecret: "secret",
+  });
+  assert.equal("sessions" in payload, false);
+  assert.equal("suiteSlug" in payload, false);
+});

--- a/apps/web/lib/hosted-web.ts
+++ b/apps/web/lib/hosted-web.ts
@@ -53,6 +53,7 @@ export type HostedWebAttemptConnection = {
 
 type HostedWebAttempt = {
   id: string | null;
+  caseRevisionId: string | null;
   suiteSlug: string;
   suiteVersion: string;
   sessionDefinitions: HostedWebSuiteSession[];
@@ -271,7 +272,7 @@ async function findExistingHostedWebAttempt(params: {
 
   const { data, error } = await supabase
     .from("benchmark_attempts")
-    .select("id, suite_slug, suite_version, metadata")
+    .select("id, case_revision_id, suite_slug, suite_version, metadata")
     .eq("run_id", params.run.id)
     .eq("case_id", params.benchmarkCase.id)
     .eq("provider", "hosted-web")
@@ -283,9 +284,25 @@ async function findExistingHostedWebAttempt(params: {
     return null;
   }
 
-  const normalized = normalizeSessionDefinitions(params.benchmarkCase);
+  let normalized = normalizeSessionDefinitions(params.benchmarkCase);
+  if (data.case_revision_id) {
+    const { data: revision, error: revisionError } = await supabase
+      .from("benchmark_case_revisions")
+      .select("manifest")
+      .eq("id", data.case_revision_id)
+      .eq("case_id", params.benchmarkCase.id)
+      .maybeSingle();
+    if (revisionError || !revision) {
+      throw revisionError ?? new Error("Hosted attempt references an unavailable benchmark revision.");
+    }
+    normalized = normalizeSessionDefinitions({
+      ...params.benchmarkCase,
+      metadata: revision.manifest as Record<string, unknown>,
+    });
+  }
   return {
     id: data.id,
+    caseRevisionId: data.case_revision_id,
     suiteSlug: data.suite_slug,
     suiteVersion: data.suite_version,
     sessionDefinitions: normalized.sessionDefinitions,
@@ -504,6 +521,7 @@ async function getOrCreateHostedWebAttempt(params: {
   const { suiteSlug, suiteVersion, sessionDefinitions } = normalizeSessionDefinitions(params.benchmarkCase);
   const localAttempt: HostedWebAttempt = {
     id: supabase ? null : `${params.run.id}:local-hosted-suite`,
+    caseRevisionId: params.benchmarkCase.currentRevisionId,
     suiteSlug,
     suiteVersion,
     sessionDefinitions,
@@ -581,6 +599,20 @@ type HostedAttemptInitResponse = {
   sessions: HostedWebSessionConnection[];
 };
 
+export function buildHostedAttemptInitPayload(params: {
+  runId: string;
+  caseId: string;
+  caseRevisionId: string | null;
+  callbackSecret: string;
+}) {
+  return {
+    runId: params.runId,
+    caseId: params.caseId,
+    caseRevisionId: params.caseRevisionId,
+    callbackSecret: params.callbackSecret,
+  };
+}
+
 async function initializeHostedWebAttempt(params: {
   run: BenchmarkRun;
   benchmarkCase: BenchmarkCase;
@@ -598,26 +630,12 @@ async function initializeHostedWebAttempt(params: {
         "Content-Type": "application/json",
         "x-runner-secret": runnerSecret,
       },
-      body: JSON.stringify({
+      body: JSON.stringify(buildHostedAttemptInitPayload({
         runId: params.run.id,
         caseId: params.benchmarkCase.id,
+        caseRevisionId: params.attempt.caseRevisionId,
         callbackSecret: runnerSecret,
-        suiteSlug: params.attempt.suiteSlug,
-        suiteVersion: params.attempt.suiteVersion,
-        sessions: params.attempt.sessionDefinitions.map((session) => ({
-          app: session.app,
-          taskSlug: session.taskSlug,
-          taskVersion: session.taskVersion,
-          sequenceIndex: session.sequenceIndex,
-          weight: session.weight,
-          required: session.required,
-          title: session.title ?? null,
-          goal: session.goal ?? null,
-          startPath: session.startPath ?? null,
-          seedVersion: session.seedVersion ?? null,
-          metadata: session.metadata ?? {},
-        })),
-      }),
+      })),
       cache: "no-store",
     });
   } catch (error) {
@@ -719,6 +737,14 @@ export async function getOrCreateHostedWebAttemptConnection(params: {
   }
 
   if (!attempt.id && createSupabaseAdminClient()) {
+    if (!attempt.caseRevisionId) {
+      throw new HostedWebSessionError({
+        message: "Hosted benchmark case has no published revision.",
+        hostedSitesUrl: getHostedOrchestratorBaseUrl(),
+        retryable: false,
+        status: 409,
+      });
+    }
     const initialized = await initializeHostedWebAttempt({
       ...params,
       attempt,

--- a/apps/web/lib/mock-store.ts
+++ b/apps/web/lib/mock-store.ts
@@ -13,6 +13,7 @@ const now = () => new Date().toISOString();
 
 const seedCases: BenchmarkCase[] = [...nativeBenchmarkCases, hostedWebSuiteCase].map((item) => ({
   ...item,
+  currentRevisionId: null,
   createdAt: now(),
 }));
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -136,20 +136,13 @@ Write endpoints append a command to Redis Streams and wait for the worker result
 {
   "runId": "uuid",
   "caseId": "uuid",
+  "caseRevisionId": "uuid",
   "callbackSecret": "optional",
-  "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v1",
-  "sessions": [
-    {
-      "app": "shopping-lite",
-      "taskSlug": "shopping-constrained-checkout",
-      "sequenceIndex": 0,
-      "weight": 1,
-      "required": true
-    }
-  ]
+  "generationSeed": "optional deterministic seed"
 }
 ```
+
+The orchestrator loads the service-role-only manifest identified by `caseRevisionId`, verifies that it belongs to `caseId`, validates the typed suite schema, and rejects missing or invalid revisions before creating sessions. Clients cannot supply or override suite sessions.
 
 ### Complete Session Command
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,6 +81,8 @@ Supabase stores durable control-plane and audit data: runs, attempts, hosted ses
 
 `benchmark_cases` is a private control-plane table because its metadata contains suite manifests and evaluator inputs. Anonymous and authenticated database clients can discover public cases only through `public_benchmark_cases`, which projects display-safe suite and session fields. Service-role code must not return the private manifest through a public API or read model.
 
+Typed catalog releases are stored in immutable `benchmark_case_revisions`. A case points to the release selected for new attempts, while every attempt retains its own revision foreign key and generated question snapshot. The orchestrator, not Web input, is authoritative for loading and validating the private manifest during initialization.
+
 ### Nginx and Cloudflare
 
 Nginx is the only gateway inside the hosted Compose network. It load-balances hosted-sites replicas and routes the orchestrator prefix to the orchestrator service. Cloudflare Tunnel publishes the environment-specific hosted hostname and forwards it to the corresponding host gateway port; TLS terminates at the Cloudflare edge.

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -55,9 +55,16 @@ CI must fail when a declared variant lacks both positive and negative scorer cov
 
 Tests and local Web data import the catalog directly. `supabase/seed.sql` is generated from it with `pnpm catalog:generate`; CI runs `pnpm catalog:check` and rejects manual or stale SQL. Production schema migrations remain immutable historical records and are not parsed as testcase source code.
 
+## Immutable Releases
+
+Publishing converts the validated catalog into an immutable `benchmark_case_revisions` row identified by a revision name and SHA-256 content hash. `pnpm catalog:publish` uses the service-role-only publication RPC; repeating the same revision or content is idempotent, while reusing an identity with different content is rejected.
+
+`benchmark_cases.current_revision_id` selects the release for new runs. The Web sends only this revision ID during attempt initialization. The orchestrator loads the private manifest directly, validates it again, generates the seeded question snapshot, and writes `benchmark_attempts.case_revision_id`. Updating the current release therefore does not change the manifest associated with an earlier attempt.
+
 ## Commands And Scheduled Coverage
 
-- `pnpm --filter hosted-sites test` reads the canonical suite from `supabase/seed.sql`, executes positive and negative scoring for all 12 current variants, and repeats each passing state across all five layouts and both themes.
+- `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for all 12 current variants, and repeats each passing state across all five layouts and both themes.
+- `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
 - `Hosted Variant Sweep` runs four deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, and `full-pool-4` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires four unique `hosted_web_results` rows plus one `benchmark_attempt_scores` row.

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -12,14 +12,15 @@ sequenceDiagram
   U->>W: POST /api/runs
   W->>D: insert benchmark_run
   U->>W: GET /api/runs/:id/connect
-  W->>O: POST /api/attempts/init
+  W->>O: POST /api/attempts/init with caseRevisionId
+  O->>D: load and validate immutable revision
   O->>D: insert benchmark_attempt
   O->>D: insert ordered hosted_web_sessions
   O-->>W: attempt and session URLs
   W-->>U: connection payload
 ```
 
-The first session is `active`; later sessions are `created`. Raw session tokens are returned to the client but only token hashes are stored durably.
+The Web never sends the private suite manifest. The orchestrator loads the selected revision with service-role access, validates it against the typed catalog schema, generates the seeded question snapshot, and binds the attempt to that revision before creating sessions. The first session is `active`; later sessions are `created`. Raw session tokens are returned to the client but only token hashes are stored durably.
 
 ## 2. Task Request Across Replicas
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -5,6 +5,8 @@
 ```mermaid
 erDiagram
   BENCHMARK_CASES ||--o{ BENCHMARK_RUNS : selects
+  BENCHMARK_CASES ||--o{ BENCHMARK_CASE_REVISIONS : publishes
+  BENCHMARK_CASE_REVISIONS ||--o{ BENCHMARK_ATTEMPTS : defines
   BENCHMARK_RUNS ||--o{ BENCHMARK_ATTEMPTS : contains
   BENCHMARK_ATTEMPTS ||--o{ HOSTED_WEB_SESSIONS : orders
   HOSTED_WEB_SESSIONS ||--o{ HOSTED_WEB_EVENTS : emits
@@ -23,6 +25,12 @@ erDiagram
 
 `public_benchmark_cases` is the anonymous/authenticated discovery boundary. It contains display fields plus a sanitized metadata projection with suite identity and ordered app/task summaries. It never contains question variants, generated task configuration, canonical answers, or evaluator parameters.
 
+`benchmark_cases.current_revision_id` points to the release used for new attempts. `metadata` remains a service-role compatibility copy of that current manifest and is not the historical source of truth.
+
+### `benchmark_case_revisions`
+
+An immutable, service-role-only release record containing `revision`, SHA-256 `content_hash`, and the complete validated private `manifest`. Publication is atomic and idempotent through `publish_benchmark_case_revision`; normal updates and deletes are rejected. Historical attempts keep their revision foreign key when the case's current revision changes.
+
 ### `benchmark_runs`
 
 The user-facing execution record. Important fields include owner (`user_id` or `guest_id`), `case_id`, `execution_mode`, lifecycle `status`, final `score`, timestamps, and error information.
@@ -35,6 +43,7 @@ One execution of a hosted suite under a run.
 
 - status: `created | running | scoring | completed | failed | cancelled | timeout`
 - suite identity: `suite_slug`, `suite_version`
+- immutable definition: `case_revision_id`
 - `aggregate_score` and `scoring_summary`
 - metadata control fields: `activeSessionId`, `activeSequenceIndex`, `completedSessionIds`
 
@@ -164,6 +173,7 @@ stateDiagram-v2
 
 - Redis is authoritative for mutable task state during an active session.
 - Supabase is authoritative for durable lifecycle, audit, and scoring records.
+- `benchmark_case_revisions` is authoritative for the suite manifest used by an attempt; its generated question snapshot remains in attempt/session metadata.
 - The orchestrator is the only application writer for attempts, hosted sessions, and hosted results; hosted-sites may read session rows only for cache recovery.
 - The process-local Map is not authoritative and may be lost at any time.
 - `metadata.appState` is a recovery snapshot, not a separately writable domain model.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,12 +100,14 @@ Detailed scoring and coverage rules are defined in [Benchmark Scoring And Testin
 | BQ.1 Scorer and task contract | Complete | Every information-retrieval variant has an unambiguous canonical answer, declared normalization, valid source evidence, and positive/negative tests. |
 | BQ.2 Terminal score consistency | Complete | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
 | BQ.3 Testcase expansion | Complete | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
-| BQ.4 Typed testcase catalog | In progress | Hosted task definitions and suite composition have one discriminated, validated TypeScript source used by tests, local data, and publishing. |
-| BQ.5 Immutable benchmark releases | Planned | Every attempt references an immutable case revision, and changing the current release cannot alter historical interpretation. |
+| BQ.4 Typed testcase catalog | Complete | Hosted task definitions and suite composition have one discriminated, validated TypeScript source used by tests, local data, and publishing. |
+| BQ.5 Immutable benchmark releases | In progress | Every attempt references an immutable case revision, and changing the current release cannot alter historical interpretation. |
 
 Complete BQ.1 and BQ.2 before expanding the hosted app catalog so new applications do not inherit ambiguous or mutable terminal scoring.
 
 BQ.1-BQ.3 completion evidence: `develop@3ca9329` passed [Hosted deployment run 27937799988](https://github.com/Kaiwen0418/agent-benchmark/actions/runs/27937799988), including generated variant checks, first-result terminal consistency, one result per session, one aggregate score, and the four-app lifecycle smoke.
+
+BQ.4 completion evidence: `develop@8e24b02` passed [Hosted deployment run 27941406084](https://github.com/Kaiwen0418/agent-benchmark/actions/runs/27941406084), including catalog validation, generated-seed drift checks, both hosted image builds, development deployment, and the four-app lifecycle smoke.
 
 ## P2: Benchmark and Product Depth
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "bash scripts/test-coverage.sh",
     "catalog:generate": "pnpm --filter @agentbench/test-cases generate-seed",
     "catalog:check": "pnpm --filter @agentbench/test-cases check-seed",
+    "catalog:publish": "pnpm --filter @agentbench/test-cases publish",
     "smoke:local": "bash scripts/smoke-local.sh",
     "smoke:lifecycle": "bash apps/hosted-sites/scripts/orchestrator-smoke-full-pass.sh",
     "db:migrate:test": "bash scripts/db-migrate.sh test",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -48,6 +48,7 @@ export const benchmarkCaseSchema = z.object({
   category: z.string(),
   difficulty: z.string(),
   provider: z.enum(["native", "hosted-web", "webarena"]).default("native"),
+  currentRevisionId: z.string().uuid().nullable().default(null),
   metadata: z.record(z.any()).default({}),
   isPublic: z.boolean(),
   createdAt: z.string(),

--- a/packages/shared/src/database.types.ts
+++ b/packages/shared/src/database.types.ts
@@ -7,6 +7,7 @@ export type Database = {
         Row: {
           category: string;
           created_at: string;
+          current_revision_id: string | null;
           description: string;
           difficulty: string;
           id: string;
@@ -19,6 +20,7 @@ export type Database = {
         Insert: {
           category: string;
           created_at?: string;
+          current_revision_id?: string | null;
           description: string;
           difficulty: string;
           id?: string;
@@ -31,6 +33,7 @@ export type Database = {
         Update: {
           category?: string;
           created_at?: string;
+          current_revision_id?: string | null;
           description?: string;
           difficulty?: string;
           id?: string;
@@ -40,6 +43,26 @@ export type Database = {
           slug?: string;
           title?: string;
         };
+        Relationships: [];
+      };
+      benchmark_case_revisions: {
+        Row: {
+          case_id: string;
+          content_hash: string;
+          created_at: string;
+          id: string;
+          manifest: Json;
+          revision: string;
+        };
+        Insert: {
+          case_id: string;
+          content_hash: string;
+          created_at?: string;
+          id?: string;
+          manifest: Json;
+          revision: string;
+        };
+        Update: never;
         Relationships: [];
       };
       benchmark_attempt_scores: {
@@ -78,6 +101,7 @@ export type Database = {
       benchmark_attempts: {
         Row: {
           aggregate_score: number | null;
+          case_revision_id: string | null;
           case_id: string;
           completed_at: string | null;
           created_at: string;
@@ -93,6 +117,7 @@ export type Database = {
         };
         Insert: {
           aggregate_score?: number | null;
+          case_revision_id?: string | null;
           case_id: string;
           completed_at?: string | null;
           created_at?: string;
@@ -108,6 +133,7 @@ export type Database = {
         };
         Update: {
           aggregate_score?: number | null;
+          case_revision_id?: string | null;
           case_id?: string;
           completed_at?: string | null;
           created_at?: string;

--- a/packages/test-cases/package.json
+++ b/packages/test-cases/package.json
@@ -15,7 +15,8 @@
     "build": "tsc -p tsconfig.json",
     "test": "pnpm run build && node --import tsx --test src/*.test.ts",
     "generate-seed": "tsx scripts/generate-seed.ts",
-    "check-seed": "tsx scripts/generate-seed.ts --check"
+    "check-seed": "tsx scripts/generate-seed.ts --check",
+    "publish": "tsx scripts/publish.ts"
   },
   "dependencies": {
     "zod": "^3.24.1"

--- a/packages/test-cases/scripts/publish.ts
+++ b/packages/test-cases/scripts/publish.ts
@@ -1,0 +1,33 @@
+import { hostedSuiteMetadataSchema } from "../src/schemas.js";
+import { createHostedWebCatalogRelease } from "../src/release.js";
+
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) and SUPABASE_SERVICE_ROLE_KEY are required.");
+}
+
+const release = createHostedWebCatalogRelease();
+hostedSuiteMetadataSchema.parse(release.manifest);
+
+const response = await fetch(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/rpc/publish_benchmark_case_revision`, {
+  method: "POST",
+  headers: {
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    target_case_id: release.caseId,
+    target_revision: release.revision,
+    target_manifest: release.manifest,
+    target_content_hash: release.contentHash,
+  }),
+});
+
+if (!response.ok) {
+  throw new Error(`Catalog publication failed (${response.status}): ${await response.text()}`);
+}
+
+console.log(`published ${release.revision} as ${await response.text()}`);

--- a/packages/test-cases/src/catalog.test.ts
+++ b/packages/test-cases/src/catalog.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { hostedSuiteMetadataSchema, hostedWebSuiteMetadata } from "./index.js";
+import { createHostedWebCatalogRelease } from "./release.js";
 
 test("hosted catalog is valid and has unique app/task definitions", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebSuiteMetadata);
@@ -21,4 +22,13 @@ test("hosted catalog rejects cross-app task config", () => {
     expectedLockReason: "wrong app",
   } as never;
   assert.throws(() => hostedSuiteMetadataSchema.parse(invalid));
+});
+
+test("hosted catalog release has a stable revision identity and content hash", () => {
+  const first = createHostedWebCatalogRelease();
+  const second = createHostedWebCatalogRelease();
+
+  assert.equal(first.revision, "hosted-web-suite-v2");
+  assert.match(first.contentHash, /^[0-9a-f]{64}$/);
+  assert.deepEqual(second, first);
 });

--- a/packages/test-cases/src/release.ts
+++ b/packages/test-cases/src/release.ts
@@ -1,0 +1,12 @@
+import { createHash } from "node:crypto";
+import { hostedWebSuiteCase, hostedWebSuiteRevision } from "./index.js";
+
+export function createHostedWebCatalogRelease() {
+  const manifest = hostedWebSuiteCase.metadata;
+  return {
+    caseId: hostedWebSuiteCase.id,
+    revision: hostedWebSuiteRevision,
+    manifest,
+    contentHash: createHash("sha256").update(JSON.stringify(manifest)).digest("hex"),
+  };
+}

--- a/packages/test-cases/src/seed-sql.ts
+++ b/packages/test-cases/src/seed-sql.ts
@@ -1,4 +1,5 @@
 import { hostedWebSuiteCase, nativeBenchmarkCases } from "./index.js";
+import { createHostedWebCatalogRelease } from "./release.js";
 
 function sqlString(value: string) {
   return `'${value.replaceAll("'", "''")}'`;
@@ -15,6 +16,7 @@ export function generateSupabaseSeedSql() {
     true
   )`).join(",\n");
   const metadata = JSON.stringify(hostedWebSuiteCase.metadata, null, 2);
+  const release = createHostedWebCatalogRelease();
 
   return `-- Generated from packages/test-cases. Run \`pnpm catalog:generate\`; do not edit by hand.
 insert into public.benchmark_cases (id, slug, title, description, category, difficulty, is_public)
@@ -49,8 +51,14 @@ set
   category = excluded.category,
   difficulty = excluded.difficulty,
   provider = excluded.provider,
-  metadata = excluded.metadata,
   is_public = excluded.is_public;
+
+select public.publish_benchmark_case_revision(
+  '${hostedWebSuiteCase.id}',
+  '${release.revision}',
+  $catalog$${metadata}$catalog$::jsonb,
+  '${release.contentHash}'
+);
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)
 values (

--- a/packages/test-cases/src/suites/hosted-web-v2.ts
+++ b/packages/test-cases/src/suites/hosted-web-v2.ts
@@ -15,6 +15,8 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
+export const hostedWebSuiteRevision = "hosted-web-suite-v2";
+
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",
   slug: "shopping-constrained-checkout",

--- a/scripts/test-case-revisions-postgres.sh
+++ b/scripts/test-case-revisions-postgres.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER="agentbench-case-revisions-postgres-$RANDOM"
+PSQL=(docker exec -i "${CONTAINER}" psql -h 127.0.0.1 -U postgres -d postgres)
+
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run -d --rm --name "${CONTAINER}" -e POSTGRES_PASSWORD=postgres postgres:17-alpine >/dev/null
+for _ in $(seq 1 30); do
+  docker exec "${CONTAINER}" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break
+  sleep 1
+done
+
+"${PSQL[@]}" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+create extension if not exists pgcrypto;
+create role anon;
+create role authenticated;
+create role service_role bypassrls;
+
+create table public.benchmark_cases (
+  id uuid primary key,
+  provider text,
+  metadata jsonb not null default '{}'::jsonb
+);
+create table public.benchmark_runs (id uuid primary key);
+create table public.benchmark_attempts (
+  id uuid primary key,
+  run_id uuid not null references public.benchmark_runs(id),
+  case_id uuid not null references public.benchmark_cases(id),
+  provider text not null
+);
+
+insert into public.benchmark_cases values (
+  '70000000-0000-0000-0000-000000000001',
+  'hosted-web',
+  '{"suiteSlug":"hosted-suite","suiteVersion":"v1","sessions":[]}'::jsonb
+);
+insert into public.benchmark_runs values ('71000000-0000-0000-0000-000000000001');
+insert into public.benchmark_attempts values (
+  '72000000-0000-0000-0000-000000000001',
+  '71000000-0000-0000-0000-000000000001',
+  '70000000-0000-0000-0000-000000000001',
+  'hosted-web'
+);
+SQL
+
+"${PSQL[@]}" -v ON_ERROR_STOP=1 \
+  < "${ROOT_DIR}/supabase/migrations/20260622000020_immutable_benchmark_case_revisions.sql" >/dev/null
+
+initial_revision="$(${PSQL[@]} -Atqc "select current_revision_id from public.benchmark_cases")"
+attempt_revision="$(${PSQL[@]} -Atqc "select case_revision_id from public.benchmark_attempts")"
+[[ -n "${initial_revision}" && "${initial_revision}" == "${attempt_revision}" ]]
+
+published_revision="$(${PSQL[@]} -Atqc "
+  set role service_role;
+  select public.publish_benchmark_case_revision(
+    '70000000-0000-0000-0000-000000000001',
+    'v2',
+    '{\"suiteSlug\":\"hosted-suite\",\"suiteVersion\":\"v2\",\"sessions\":[]}'::jsonb,
+    repeat('b', 64)
+  );
+")"
+duplicate_revision="$(${PSQL[@]} -Atqc "
+  set role service_role;
+  select public.publish_benchmark_case_revision(
+    '70000000-0000-0000-0000-000000000001',
+    'v2',
+    '{\"suiteSlug\":\"hosted-suite\",\"suiteVersion\":\"v2\",\"sessions\":[]}'::jsonb,
+    repeat('b', 64)
+  );
+")"
+[[ "${published_revision}" == "${duplicate_revision}" && "${published_revision}" != "${initial_revision}" ]]
+
+content_duplicate_revision="$(${PSQL[@]} -Atqc "
+  set role service_role;
+  select public.publish_benchmark_case_revision(
+    '70000000-0000-0000-0000-000000000001',
+    'v2-alias',
+    '{\"suiteSlug\":\"hosted-suite\",\"suiteVersion\":\"v2\",\"sessions\":[]}'::jsonb,
+    repeat('b', 64)
+  );
+")"
+[[ "${content_duplicate_revision}" == "${published_revision}" ]]
+
+if "${PSQL[@]}" -v ON_ERROR_STOP=1 -c "
+  set role service_role;
+  select public.publish_benchmark_case_revision(
+    '70000000-0000-0000-0000-000000000001',
+    'v2',
+    '{\"suiteSlug\":\"hosted-suite\",\"suiteVersion\":\"changed\",\"sessions\":[]}'::jsonb,
+    repeat('c', 64)
+  );
+" >/dev/null 2>&1; then
+  echo "revision identity accepted different content" >&2
+  exit 1
+fi
+
+historical_revision="$(${PSQL[@]} -Atqc "select case_revision_id from public.benchmark_attempts where id = '72000000-0000-0000-0000-000000000001'")"
+current_revision="$(${PSQL[@]} -Atqc "select current_revision_id from public.benchmark_cases")"
+[[ "${historical_revision}" == "${initial_revision}" && "${current_revision}" == "${published_revision}" ]]
+
+if "${PSQL[@]}" -v ON_ERROR_STOP=1 -c "update public.benchmark_case_revisions set revision = 'mutated' where id = '${initial_revision}'" >/dev/null 2>&1; then
+  echo "immutable revision accepted an update" >&2
+  exit 1
+fi
+if "${PSQL[@]}" -v ON_ERROR_STOP=1 -c "delete from public.benchmark_case_revisions where id = '${initial_revision}'" >/dev/null 2>&1; then
+  echo "immutable revision accepted a delete" >&2
+  exit 1
+fi
+if "${PSQL[@]}" -v ON_ERROR_STOP=1 -c "insert into public.benchmark_attempts(id, run_id, case_id, provider) values ('72000000-0000-0000-0000-000000000002', '71000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000001', 'hosted-web')" >/dev/null 2>&1; then
+  echo "hosted attempt without a revision passed validation" >&2
+  exit 1
+fi
+if "${PSQL[@]}" -v ON_ERROR_STOP=1 -c "set role anon; select * from public.benchmark_case_revisions" >/dev/null 2>&1; then
+  echo "anonymous role can read private revisions" >&2
+  exit 1
+fi
+
+echo "benchmark case revision Postgres tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -16,6 +16,9 @@ bash scripts/test-lifecycle-postgres.sh
 echo "== Benchmark case privacy =="
 bash scripts/test-benchmark-case-privacy.sh
 
+echo "== Benchmark case revisions =="
+bash scripts/test-case-revisions-postgres.sh
+
 echo "== Benchmark catalog =="
 pnpm --filter @agentbench/test-cases test
 pnpm catalog:check

--- a/supabase/migrations/20260622000020_immutable_benchmark_case_revisions.sql
+++ b/supabase/migrations/20260622000020_immutable_benchmark_case_revisions.sql
@@ -1,0 +1,136 @@
+create table public.benchmark_case_revisions (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.benchmark_cases(id) on delete restrict,
+  revision text not null,
+  content_hash text not null check (content_hash ~ '^[0-9a-f]{64}$'),
+  manifest jsonb not null,
+  created_at timestamptz not null default now(),
+  unique (case_id, id),
+  unique (case_id, revision),
+  unique (case_id, content_hash)
+);
+
+alter table public.benchmark_cases
+  add column current_revision_id uuid;
+
+alter table public.benchmark_cases
+  add constraint benchmark_cases_current_revision_id_fkey
+  foreign key (id, current_revision_id) references public.benchmark_case_revisions(case_id, id) on delete restrict;
+
+alter table public.benchmark_attempts
+  add column case_revision_id uuid;
+
+alter table public.benchmark_attempts
+  add constraint benchmark_attempts_case_revision_id_fkey
+  foreign key (case_id, case_revision_id) references public.benchmark_case_revisions(case_id, id) on delete restrict;
+
+create index idx_benchmark_attempts_case_revision_id
+  on public.benchmark_attempts(case_revision_id);
+
+create or replace function public.reject_benchmark_case_revision_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  raise exception 'benchmark case revisions are immutable' using errcode = '55000';
+end;
+$$;
+
+create trigger benchmark_case_revisions_immutable
+before update or delete on public.benchmark_case_revisions
+for each row execute function public.reject_benchmark_case_revision_mutation();
+
+create or replace function public.publish_benchmark_case_revision(
+  target_case_id uuid,
+  target_revision text,
+  target_manifest jsonb,
+  target_content_hash text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  revision_row public.benchmark_case_revisions%rowtype;
+begin
+  if target_revision is null or btrim(target_revision) = '' then
+    raise exception 'revision is required' using errcode = '22023';
+  end if;
+  if target_manifest is null or jsonb_typeof(target_manifest) <> 'object' then
+    raise exception 'manifest must be a JSON object' using errcode = '22023';
+  end if;
+  if target_content_hash is null or target_content_hash !~ '^[0-9a-f]{64}$' then
+    raise exception 'content hash must be lowercase SHA-256' using errcode = '22023';
+  end if;
+
+  select * into revision_row
+  from public.benchmark_case_revisions
+  where case_id = target_case_id
+    and (revision = target_revision or content_hash = target_content_hash)
+  order by (revision = target_revision) desc
+  limit 1;
+
+  if revision_row.id is null then
+    insert into public.benchmark_case_revisions(case_id, revision, content_hash, manifest)
+    values (target_case_id, target_revision, target_content_hash, target_manifest)
+    returning * into revision_row;
+  end if;
+
+  if revision_row.content_hash <> target_content_hash or revision_row.manifest <> target_manifest then
+    raise exception 'revision identity already exists with different content' using errcode = '23505';
+  end if;
+
+  update public.benchmark_cases
+  set current_revision_id = revision_row.id,
+      metadata = revision_row.manifest
+  where id = target_case_id;
+
+  if not found then
+    raise exception 'benchmark case does not exist' using errcode = '23503';
+  end if;
+
+  return revision_row.id;
+end;
+$$;
+
+revoke all on function public.publish_benchmark_case_revision(uuid, text, jsonb, text) from public, anon, authenticated;
+grant execute on function public.publish_benchmark_case_revision(uuid, text, jsonb, text) to service_role;
+
+alter table public.benchmark_case_revisions enable row level security;
+revoke all on table public.benchmark_case_revisions from public, anon, authenticated;
+grant select, insert on table public.benchmark_case_revisions to service_role;
+
+do $$
+declare
+  case_row record;
+  revision_id uuid;
+begin
+  for case_row in
+    select id, metadata, coalesce(metadata ->> 'suiteVersion', 'legacy') as revision
+    from public.benchmark_cases
+    where provider = 'hosted-web' and current_revision_id is null
+  loop
+    revision_id := public.publish_benchmark_case_revision(
+      case_row.id,
+      case_row.revision,
+      case_row.metadata,
+      encode(digest(convert_to(case_row.metadata::text, 'UTF8'), 'sha256'), 'hex')
+    );
+
+    update public.benchmark_attempts
+    set case_revision_id = revision_id
+    where case_id = case_row.id and case_revision_id is null;
+  end loop;
+end;
+$$;
+
+alter table public.benchmark_attempts
+  add constraint benchmark_attempts_hosted_revision_required
+  check (provider <> 'hosted-web' or case_revision_id is not null) not valid;
+
+alter table public.benchmark_attempts
+  validate constraint benchmark_attempts_hosted_revision_required;
+
+comment on table public.benchmark_case_revisions is
+  'Immutable, service-role-only benchmark manifests. Attempts retain the exact revision used for generation and scoring.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -262,8 +262,210 @@ set
   category = excluded.category,
   difficulty = excluded.difficulty,
   provider = excluded.provider,
-  metadata = excluded.metadata,
   is_public = excluded.is_public;
+
+select public.publish_benchmark_case_revision(
+  '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005',
+  'hosted-web-suite-v2',
+  $catalog${
+  "suiteSlug": "hosted-web-suite-v1",
+  "suiteVersion": "v2",
+  "sessions": [
+    {
+      "app": "shopping-lite",
+      "taskSlug": "shopping-constrained-checkout",
+      "title": "Shopping Checkout",
+      "taskVersion": "v1",
+      "seedVersion": "shopping-lite-v1",
+      "sequenceIndex": 0,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "budget-charger-standard",
+            "goal": "Buy exactly one charger with a total price at or below $30, use standard shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 1,
+              "maxTotal": 30,
+              "shippingMethod": "standard",
+              "avoidRestricted": true
+            }
+          },
+          {
+            "id": "cable-express",
+            "goal": "Buy exactly one USB-C cable with a total price at or below $10, use express shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "cable",
+              "quantity": 1,
+              "maxTotal": 10,
+              "shippingMethod": "express",
+              "avoidRestricted": true
+            }
+          },
+          {
+            "id": "travel-case-standard",
+            "goal": "Buy exactly one travel case with a total price at or below $15, use standard shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "case",
+              "quantity": 1,
+              "maxTotal": 15,
+              "shippingMethod": "standard",
+              "avoidRestricted": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "forum-lite",
+      "taskSlug": "forum-battery-moderation",
+      "title": "Forum Moderation",
+      "startPath": "/forum",
+      "taskVersion": "v1",
+      "seedVersion": "forum-lite-v1",
+      "sequenceIndex": 1,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "battery-recall",
+            "goal": "Find the battery swelling thread, reply with the official recall link from the support post, then lock it with reason 'safety escalation'.",
+            "taskConfig": {
+              "targetThreadId": "thr-battery",
+              "expectedReplyValue": "https://support.example.com/recall/battery-2026",
+              "expectedLockReason": "safety escalation"
+            }
+          },
+          {
+            "id": "wifi-reset",
+            "goal": "Find the 5GHz connectivity thread, reply with the official reset-guide link from support, then lock it with reason 'resolved with guide'.",
+            "taskConfig": {
+              "targetThreadId": "thr-wifi",
+              "expectedReplyValue": "https://support.example.com/network/5ghz-reset",
+              "expectedLockReason": "resolved with guide"
+            }
+          },
+          {
+            "id": "screen-advisory",
+            "goal": "Find the low-brightness flickering thread, reply with the display calibration advisory link, then lock it with reason 'known display issue'.",
+            "taskConfig": {
+              "targetThreadId": "thr-screen",
+              "expectedReplyValue": "https://support.example.com/display/flicker-calibration",
+              "expectedLockReason": "known display issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "repo-lite",
+      "taskSlug": "repo-readme-fix",
+      "title": "Repository README Fix",
+      "startPath": "/repo",
+      "taskVersion": "v1",
+      "seedVersion": "repo-lite-v1",
+      "sequenceIndex": 2,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "pnpm-install",
+            "goal": "Replace the README install command with `pnpm install`, remove `npm install`, then open a merge request titled `Fix install instructions` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "pnpm install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Fix install instructions",
+              "expectedTargetBranch": "main"
+            }
+          },
+          {
+            "id": "yarn-install",
+            "goal": "Replace the README install command with `yarn install`, remove `npm install`, then open a merge request titled `Document Yarn setup` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "yarn install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Document Yarn setup",
+              "expectedTargetBranch": "main"
+            }
+          },
+          {
+            "id": "bun-install",
+            "goal": "Replace the README install command with `bun install`, remove `npm install`, then open a merge request titled `Add Bun setup` targeting `develop`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "bun install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Add Bun setup",
+              "expectedTargetBranch": "develop"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "wiki-lite",
+      "taskSlug": "wiki-release-answer",
+      "title": "Wiki Release Lookup",
+      "startPath": "/wiki",
+      "taskVersion": "v2",
+      "seedVersion": "wiki-lite-v2",
+      "sequenceIndex": 3,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "release-date",
+            "goal": "Use the hosted wiki to find when wiki-lite followed the hosted-web suite alpha, then submit only the date.",
+            "taskConfig": {
+              "targetArticleSlug": "agentbench-release-history",
+              "answerContract": {
+                "kind": "date",
+                "canonicalValue": "June 1, 2026",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "agentbench-release-history"
+              }
+            }
+          },
+          {
+            "id": "dispatch-window",
+            "goal": "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit only the duration without surrounding words.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "duration",
+                "canonicalValue": "two business days",
+                "normalization": "trim-casefold",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          },
+          {
+            "id": "charger-price",
+            "goal": "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit only the exact price.",
+            "taskConfig": {
+              "targetArticleSlug": "usb-c-charger-faq",
+              "answerContract": {
+                "kind": "currency",
+                "canonicalValue": "$24.99",
+                "normalization": "trim",
+                "sourceArticleSlug": "usb-c-charger-faq"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}$catalog$::jsonb,
+  '2ca49e204251e7d55ceead92ab6ffa98ff854d38fbb1e9dc448eeaf66245f406'
+);
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)
 values (


### PR DESCRIPTION
## Summary
- add immutable benchmark case revisions, current-release pointers, historical attempt binding, and a service-role publication RPC
- make Web initialize attempts by revision ID while orchestrator loads and validates the private manifest
- add typed catalog publication, generated seed support, real Postgres invariants, and synchronized architecture/testing docs

## Verification
- pnpm verify:ci
- bash scripts/test-case-revisions-postgres.sh
- docker build -f infra/docker/hosted-orchestrator.Dockerfile -t agentbench-hosted-orchestrator:bq5 .

Advances #55