### PR TITLE
fix(smoke): initialize attempts by case revision

### DIFF
--- a/apps/hosted-sites/scripts/orchestrator-smoke.sh
+++ b/apps/hosted-sites/scripts/orchestrator-smoke.sh
@@ -305,7 +305,7 @@ async function loadAttemptState(attemptId) {
 
 async function main() {
   const benchmarkCases = await selectRows("benchmark_cases", {
-    select: "id,slug,title,description,metadata",
+    select: "id,slug,title,description,current_revision_id",
     slug: "eq.shopping-constrained-checkout",
     limit: "1",
   });
@@ -313,7 +313,19 @@ async function main() {
     throw new Error("benchmark case not found");
   }
   const benchmarkCase = benchmarkCases[0];
-  const suite = normalizedSessions(benchmarkCase);
+  const caseRevisionId = requireString(benchmarkCase.current_revision_id, "current benchmark revision");
+  const revisions = await selectRows("benchmark_case_revisions", {
+    select: "id,case_id,manifest",
+    id: `eq.${caseRevisionId}`,
+    case_id: `eq.${benchmarkCase.id}`,
+    limit: "1",
+  });
+  if (!Array.isArray(revisions) || revisions.length !== 1) {
+    throw new Error("current benchmark revision not found");
+  }
+  const revision = revisions[0];
+  const revisionManifest = requireObject(revision.manifest, "benchmark revision manifest");
+  const suite = normalizedSessions({ ...benchmarkCase, metadata: revisionManifest });
 
   const run = await insertRow("benchmark_runs", {
       case_id: benchmarkCase.id,
@@ -328,17 +340,23 @@ async function main() {
       body: JSON.stringify({
         runId: run.id,
         caseId: benchmarkCase.id,
+        caseRevisionId,
         callbackSecret: runnerSecret,
-        suiteSlug: suite.suiteSlug,
-        suiteVersion: suite.suiteVersion,
         generationSeed,
-        sessions: suite.sessions,
       }),
     })
   ).json();
 
   if (initialized.sessions.length !== suite.sessions.length) {
     throw new Error(`Expected ${suite.sessions.length} initialized sessions, got ${initialized.sessions.length}.`);
+  }
+  const attempts = await selectRows("benchmark_attempts", {
+    select: "id,case_revision_id",
+    id: `eq.${initialized.attemptId}`,
+    limit: "1",
+  });
+  if (!Array.isArray(attempts) || attempts.length !== 1 || attempts[0].case_revision_id !== caseRevisionId) {
+    throw new Error("Initialized attempt did not retain the selected benchmark revision.");
   }
   const sessions = [...initialized.sessions].sort(
     (left, right) => left.sequenceIndex - right.sequenceIndex,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,7 @@ Detailed scoring and coverage rules are defined in [Benchmark Scoring And Testin
 | BQ.2 Terminal score consistency | Complete | Terminal sessions reject mutation and every API, UI projection, and database row returns the first persisted result. |
 | BQ.3 Testcase expansion | Complete | CI enumerates every app variant across positive/negative paths and development E2E proves one consistent aggregate. |
 | BQ.4 Typed testcase catalog | Complete | Hosted task definitions and suite composition have one discriminated, validated TypeScript source used by tests, local data, and publishing. |
-| BQ.5 Immutable benchmark releases | In progress | Every attempt references an immutable case revision, and changing the current release cannot alter historical interpretation. |
+| BQ.5 Immutable benchmark releases | Complete | Every attempt references an immutable case revision, and changing the current release cannot alter historical interpretation. |
 
 Complete BQ.1 and BQ.2 before expanding the hosted app catalog so new applications do not inherit ambiguous or mutable terminal scoring.
 


### PR DESCRIPTION
## Summary
- update lifecycle smoke to load the selected immutable revision manifest
- initialize attempts with `caseRevisionId` instead of the removed client-supplied suite payload
- assert the persisted attempt retains the selected revision
- mark BQ.5 complete in the roadmap

## Verification
- pnpm verify:ci
- development full-pass smoke: run `fe815151-246d-4fa5-bc50-db9b8f32f373`, attempt `c4c9434a-afd2-4625-bf56-98415448c64c`

Completes #55