### PR TITLE
docs: align architecture and runtime data flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,16 @@ flowchart LR
   Edge --> Gateway["Nginx Gateway"]
   Gateway --> Sites["apps/hosted-sites replicas"]
   Gateway --> Orchestrator["orchestrator API"]
-  Sites <--> Redis[("Redis cache + command streams")]
+  Sites <--> SessionRedis[("Redis session runtime")]
   Web <--> DB[("Supabase")]
   Sites -.->|"read-only recovery"| DB
-  Sites -->|"durable commands"| Orchestrator
+  Sites -->|"authenticated commands"| Orchestrator
   Orchestrator --> Streams[("Redis Streams")]
   Streams --> Worker["orchestrator worker role"]
   Worker -->|"hosted writes"| DB
   Sites -->|"run events"| Web
-  Worker -->|"aggregate completion"| Web
+  DB -->|"callback outbox"| Worker
+  Worker -->|"completion delivery"| Web
 ```
 
 ## Repository Layout
@@ -95,6 +96,8 @@ docs/                   architecture and operational documentation
 - [Documentation Index](./docs/README.md)
 - [Getting Started](./docs/getting-started.md)
 - [Architecture](./docs/architecture.md)
+- [Data Ownership](./docs/data-ownership.md)
+- [Consistency and Failure](./docs/consistency-and-failure.md)
 - [Hosted Web Benchmarks](./docs/hosted-web-benchmark.md)
 - [Hosted Site App Authoring](./docs/hosted-site-app-authoring.md)
 - [Deployment and Scaling](./docs/deployment.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,9 @@
 
 - [Getting Started](./getting-started.md)
 - [Architecture](./architecture.md)
+- [Data Ownership](./data-ownership.md)
 - [Data Flow](./data-flow.md)
+- [Consistency and Failure](./consistency-and-failure.md)
 - [Frontend Runtime State Machine](./frontend-state-machine.md)
 - [Hosted Attempt Consistency](./attempt-consistency.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,15 +12,16 @@ flowchart LR
   Edge --> Gateway["Nginx Gateway"]
   Gateway --> Sites["apps/hosted-sites replicas"]
   Gateway --> OrchestratorAPI
-  Sites <--> Redis[("Redis cache + command streams")]
+  Sites <--> SessionRedis[("Redis session runtime")]
   Web <--> DB[("Supabase")]
   Sites -.->|"read-only recovery"| DB
-  Sites -->|"durable commands"| OrchestratorAPI
-  OrchestratorAPI --> Streams[("partitioned Redis Streams")]
+  Sites -->|"authenticated commands"| OrchestratorAPI
+  OrchestratorAPI --> Streams[("Redis command Streams")]
   Streams --> Workers["orchestrator workers"]
   Workers -->|"only hosted writers"| DB
   Sites -->|"run events"| Web
-  Workers -->|"aggregate completion"| Web
+  DB -->|"claim callback outbox"| Workers
+  Workers -->|"deliver completion"| Web
 ```
 
 ## Components
@@ -73,7 +74,9 @@ The deployment profile matters:
 
 ### Redis
 
-Redis has two isolated responsibilities. Versioned session keys provide the shared runtime cache used by hosted-sites replicas. Sixteen partitioned Streams form the orchestrator command backbone. Stable entity hashing preserves order for one attempt/session while disjoint workers process partitions concurrently. Redis leases prevent overlapping worker ownership.
+Redis has two logically separate responsibilities. Versioned session keys provide the shared runtime state used by hosted-sites replicas. Sixteen partitioned Streams form the orchestrator command transport. Stable entity hashing preserves order for one attempt/session while disjoint workers process partitions concurrently. Redis leases prevent overlapping worker ownership.
+
+The current deployment places both responsibilities in one Redis instance and separates them only by key namespace. It does not yet configure a persistent volume, AOF, independent memory policies, replication, or failover. Redis therefore provides shared runtime coordination, not a durable system of record. See [Consistency and Failure](./consistency-and-failure.md) for the exact guarantees and [Roadmap](./roadmap.md) for planned hardening.
 
 ### Supabase
 
@@ -104,7 +107,7 @@ GitHub `development` and `production` Environments hold separate variables and s
 | Attempt lifecycle and ordered progression | `apps/hosted-orchestrator` |
 | Task UI and app-state mutation | `apps/hosted-sites` |
 | Shared mutable session state | Redis |
-| Durable command ingest and worker coordination | Redis Streams |
+| Runtime command transport and worker coordination | Redis Streams |
 | Durable hosted writes | `apps/hosted-orchestrator` |
 | Durable records and audit history | Supabase |
 | Per-session evaluation functions | hosted app definitions / `packages/scoring` |
@@ -113,10 +116,10 @@ GitHub `development` and `production` Environments hold separate variables and s
 
 ## Failure Model
 
-- A hosted-sites replica may disappear between requests; Redis allows another replica to continue.
-- Redis failure degrades session availability; hosted-sites can recover persisted app state through read-only Supabase access.
+- A hosted-sites replica may disappear between requests; another replica can continue from Redis when no concurrent session write was lost.
+- Redis failure degrades session availability. Hosted-sites can recover the latest successfully persisted app-state snapshot through read-only Supabase access; commands or snapshots that had not reached Supabase are outside that recovery point.
 - Orchestrator failure prevents attempt progression and aggregate completion, but hosted task pages can still render from Redis.
 - Web callback failure delays live observability or final run completion; persisted hosted results remain available for reconciliation.
 - Cloudflare Tunnel or Nginx failure makes hosted URLs unavailable without changing durable run state.
 
-Detailed contracts are documented in [API Reference](./api-reference.md), [Data Model](./data-model.md), and [Data Flow](./data-flow.md).
+Detailed contracts are documented in [API Reference](./api-reference.md), [Data Model](./data-model.md), [Data Ownership](./data-ownership.md), [Data Flow](./data-flow.md), and [Consistency and Failure](./consistency-and-failure.md).

--- a/docs/consistency-and-failure.md
+++ b/docs/consistency-and-failure.md
@@ -1,0 +1,89 @@
+# Consistency and Failure
+
+This document separates implemented guarantees from target architecture. It should be read before interpreting Redis as a durable queue or assuming that multiple hosted-sites replicas make concurrent session mutation safe.
+
+## Implemented Guarantees
+
+### Attempt initialization
+
+- PostgreSQL permits at most one hosted attempt for `(run_id, case_id, provider)`.
+- A short Redis lease reduces duplicate initialization work.
+- A lease contender or uniqueness loser reloads the canonical database attempt.
+- Every database-backed hosted attempt references an immutable case revision.
+
+### Terminal lifecycle
+
+- Session completion and attempt timeout use transactional PostgreSQL functions.
+- The functions lock the attempt before changing session state, aggregate state, and active-session metadata.
+- `hosted_web_results.session_id` and `benchmark_attempt_scores.attempt_id` are unique.
+- Duplicate terminal commands return or recover the persisted winner.
+- Redis partition ordering reduces contention but is not required for terminal correctness.
+
+### Callback delivery
+
+- A terminal attempt transition inserts one `hosted_callback_outbox` row in the database transaction.
+- Delivery is claim-based and retryable; stale claims can be reclaimed.
+- Reconciliation recreates a missing outbox row for a terminal attempt.
+- Web completion is idempotent and does not determine whether the hosted transaction committed.
+
+### Worker ownership and command retry
+
+- Stable hashing sends one partition key to one Stream partition.
+- A worker must hold the short lease for every assigned partition.
+- Duplicate worker ownership is rejected and missing leases fail readiness.
+- Handler failures retain retry state in Redis and stop after three attempts.
+- A command is acknowledged after success or after its final failure is persisted to the database DLQ.
+
+## Current Non-Guarantees
+
+### Concurrent task mutation
+
+The Redis session envelope has no revision or fencing field. Hosted-sites performs whole-value reads and writes, so two replicas can overwrite each other. Sticky sessions are not required for ordinary sequential requests, but the current implementation does not guarantee lossless concurrent mutation.
+
+### Redis durability and availability
+
+Production Compose currently runs one Redis container without a named data volume, explicit AOF configuration, replication, or automated failover. Redis Streams and active sessions may be lost when that container is replaced. Application Stream partitions scale workers, not the Redis server.
+
+### Snapshot recovery point
+
+Hosted-sites writes Redis first and sends snapshot/event/access commands afterward. A Redis write can succeed before the database command, and command failures are not part of one distributed transaction. Supabase recovery therefore returns the latest successful snapshot, not necessarily the last state observed by an agent.
+
+### Process-local fallback freshness
+
+After a Redis miss or error, hosted-sites checks its process-local Map before the database. With Redis configured, that local object is not refreshed against durable control state. It can therefore be older than another replica or a terminal database transition.
+
+### Exactly-once telemetry
+
+Hosted events, Web run events, snapshots, and access records travel through separate operations. Retries and partial failures can produce missing or duplicate observability records. Terminal scoring correctness must not depend on telemetry exactly-once behavior.
+
+## Failure Matrix
+
+| Failure | Current behavior | Data at risk | Recovery/operator action |
+| --- | --- | --- | --- |
+| hosted-sites process exits | another replica reads Redis | only process-local hot copy | no action when Redis state is current |
+| one orchestrator API exits | gateway/API retry can use another replica when deployed | in-flight HTTP response | retry with stable `x-command-id` where supported |
+| one worker exits | pending entries remain in the consumer group | command latency | restart worker; stale entries are reclaimed |
+| partition lease disappears | readiness reports missing partition; worker exits after lost renewal | command availability for that partition | restore one owner for the partition |
+| Redis connection interruption | session requests may use local/DB fallback; command API can fail or time out | latest runtime state and unpersisted commands | restore Redis, then reconcile against PostgreSQL |
+| Redis container replacement | no configured persistent-volume guarantee | active sessions, Streams, replies, retry state | recover persisted snapshots; manually assess missing commands |
+| snapshot command fails | Redis request may still complete | newest app-state recovery point | retry/reconcile; do not claim zero-RPO recovery |
+| terminal command repeats | PostgreSQL transaction/unique constraints return the winner | none after first commit | safe retry |
+| Web completion callback fails | outbox remains pending/dead after retries | Web status freshness | maintenance retry, inspect dead outbox row |
+| Supabase unavailable | durable workers fail and commands retry/DLQ; Redis task pages may remain available | durable progress until recovery | restore DB before accepting durable guarantees |
+
+## Consistency Priorities
+
+1. PostgreSQL terminal invariants take precedence over Redis and local state.
+2. Redis active state takes precedence over a process-local Map when present.
+3. A database app-state snapshot is a recovery checkpoint, not a live-session replica.
+4. Callback and telemetry freshness must never be interpreted as terminal commit status.
+5. Redis transport success does not imply that a durable database side effect occurred; the worker response does.
+
+## Planned Hardening
+
+- [Issue #60](https://github.com/Kaiwen0418/agent-benchmark/issues/60): persistence, capacity policy, workload separation, observability, and HA.
+- [Issue #61](https://github.com/Kaiwen0418/agent-benchmark/issues/61): revisioned atomic session mutation and stale-snapshot rejection.
+- [Issue #62](https://github.com/Kaiwen0418/agent-benchmark/issues/62): ACLs, token hashing, credential minimization, and network isolation.
+- [Issue #59](https://github.com/Kaiwen0418/agent-benchmark/issues/59): final service/database ownership boundaries.
+
+Until these issues are complete, documentation must describe Redis as shared runtime state and command transport, not as a zero-loss durable backbone.

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,110 +1,168 @@
 # Data Flow
 
+This document describes the current runtime path. It does not treat planned Redis durability or session-concurrency work as an implemented guarantee. Static component ownership is in [Architecture](./architecture.md); authority and failure boundaries are in [Data Ownership](./data-ownership.md) and [Consistency and Failure](./consistency-and-failure.md).
+
 ## 1. Run Creation and Attempt Allocation
 
 ```mermaid
 sequenceDiagram
   participant U as User Browser
   participant W as apps/web
-  participant O as hosted-orchestrator
   participant D as Supabase
+  participant A as orchestrator API
+  participant R as Redis Streams
+  participant K as partition worker
 
   U->>W: POST /api/runs
   W->>D: insert benchmark_run
   U->>W: GET /api/runs/:id/connect
-  W->>O: POST /api/attempts/init with caseRevisionId
-  O->>D: load and validate immutable revision
-  O->>D: insert benchmark_attempt
-  O->>D: insert ordered hosted_web_sessions
-  O-->>W: attempt and session URLs
+  W->>D: load case and current revision ID
+  W->>A: POST /api/attempts/init
+  A->>R: XADD attempt.init
+  K->>R: XREADGROUP assigned partition
+  K->>D: load private immutable revision
+  K->>K: validate manifest and generate questions
+  K->>D: create/recover canonical attempt and sessions
+  K-->>A: result through Redis response key
+  A-->>W: attempt and session URLs
   W-->>U: connection payload
 ```
 
-The Web never sends the private suite manifest. The orchestrator loads the selected revision with service-role access, validates it against the typed catalog schema, generates the seeded question snapshot, and binds the attempt to that revision before creating sessions. The first session is `active`; later sessions are `created`. Raw session tokens are returned to the client but only token hashes are stored durably.
+Web sends `runId`, `caseId`, and `caseRevisionId`, but never sends the private suite manifest. The worker loads the selected service-role-only revision, validates it, generates a deterministic question snapshot, and binds the attempt to that revision. The first session is `active`; later sessions are `created`.
 
-## 2. Task Request Across Replicas
+Attempt initialization also uses a short Redis lease to reduce duplicate work. PostgreSQL uniqueness on `(run_id, case_id, provider)` remains the correctness boundary when Redis is unavailable or two requests race. See [Hosted Attempt Consistency](./attempt-consistency.md).
+
+## 2. Hosted Request and Session Lookup
+
+Write-session and viewer tokens follow different paths.
+
+```mermaid
+flowchart TD
+  Request["Hosted request"] --> Token{"Viewer token?"}
+  Token -->|"yes"| ViewerDB["Load session by viewer session ID from Supabase"]
+  ViewerDB --> Viewer["Render read-only viewer state"]
+  Token -->|"no"| Redis["Read hosted-sites:session:&lt;token&gt;"]
+  Redis -->|"hit"| Handle["Validate app, expiry, and handle route"]
+  Redis -->|"miss/error"| Local{"Process-local Map hit?"}
+  Local -->|"yes"| Handle
+  Local -->|"no"| Recovery["Load by token hash from Supabase"]
+  Recovery --> Rehydrate["Hydrate persisted appState snapshot"]
+  Rehydrate --> Cache["Write Redis and local Map"]
+  Cache --> Handle
+```
+
+Nginx may send each request to any hosted-sites replica. Redis is the first shared lookup for write-session tokens; the local Map is a non-authoritative hot copy. A database recovery returns only the latest successfully persisted `metadata.appState` snapshot, not necessarily the latest state that had existed in Redis.
+
+The current local-Map fallback can serve stale state after a Redis miss, and Redis session writes are not revision-checked. These are known horizontal-scaling gaps, not guarantees supplied by the diagram.
+
+## 3. Task Mutation, Telemetry, and Snapshot Persistence
+
+```mermaid
+sequenceDiagram
+  participant A as Agent Browser
+  participant H as hosted-sites
+  participant C as Redis Session Runtime
+  participant O as orchestrator API
+  participant S as Redis Stream
+  participant K as partition worker
+  participant D as Supabase
+  participant W as apps/web
+
+  A->>H: task action with session token
+  H->>H: validate route and mutate app state
+  H->>C: SET complete V2 session envelope
+  H->>O: session.snapshot command
+  O->>S: XADD partitioned command
+  K->>D: update hosted_web_sessions.metadata
+  H->>H: append runtime event
+  H->>C: SET envelope including event
+  H->>O: session.snapshot and session.event commands
+  K->>D: update snapshot and insert hosted_web_event
+  H-->>W: best-effort normalized run event
+  H-->>A: response or redirect
+```
+
+The current implementation persists a snapshot before many app events, then `recordEvent` persists the updated envelope and another snapshot before sending the event command. This is real write amplification, not an intentional exactly-once transaction. Commands are authenticated HTTP calls to the orchestrator API; hosted-sites does not write hosted lifecycle tables directly.
+
+Access handling follows the same transport: hosted-sites updates counters in the runtime envelope and sends a `session.access` command. The worker updates the durable session access fields and appends a `hosted_web_access_logs` row.
+
+The direct hosted-sites-to-Web event is best effort and feeds live run observability. Durable hosted telemetry is written separately by the orchestrator worker. There is no transaction joining those two paths.
+
+## 4. Orchestrator Command Processing
 
 ```mermaid
 flowchart LR
-  Request["Agent request with session token"] --> Nginx
-  Nginx --> Replica["Any hosted-sites replica"]
-  Replica --> Redis{"Redis hit?"}
-  Redis -->|"yes"| Handle["Validate app and handle route"]
-  Redis -->|"no/error"| Local{"Local Map hit?"}
-  Local -->|"yes"| Handle
-  Local -->|"no"| Supabase["Load durable session + appState snapshot"]
-  Supabase --> Handle
-  Handle --> Save["Write Redis runtime cache"]
-  Save --> Command["Send snapshot/access/event command"]
-  Command --> API["orchestrator API"]
-  API -->|"hash attempt/session key"| Stream[("Redis stream partition")]
-  Stream --> Worker["partition owner worker"]
-  Worker --> SupabaseWrite["Persist durable hosted records"]
+  Caller["Web or hosted-sites"] -->|"authenticated HTTP"| API["orchestrator API"]
+  API -->|"stable entity hash"| Stream["commands:p&lt;N&gt;"]
+  Stream --> Group["hosted-orchestrator consumer group"]
+  Group --> Worker["partition owner"]
+  Worker --> Handler["typed command handler"]
+  Handler --> DB[("Supabase")]
+  Handler --> Result["24h command result key"]
+  Result --> Reply["short-lived response list"]
+  Reply --> API
 ```
 
-The shared Redis lookup is what makes horizontal scaling safe. A load balancer does not require sticky sessions.
+The API process publishes and waits for a response. Two worker services currently own disjoint ranges `0-7` and `8-15`. Worker leases reject overlapping ownership, and readiness requires a lease for every partition. A failed handler is retried up to three times; terminal failures are persisted to `orchestrator_command_dead_letters` before the Stream entry is acknowledged.
 
-`API` and `Worker` in these diagrams are logical roles. Local Compose runs them as separate services; the current server Compose colocates them in one `ORCHESTRATOR_MODE=all` process.
+Redis Streams currently survive process restart while the same Redis container data remains available, but production Compose does not yet provide a persistent Redis volume or HA. They are runtime transport, not the durable lifecycle source of truth.
 
-## 3. Task Mutation and Telemetry
-
-1. The route validates that the token's `session.app` matches the app route.
-2. An app action mutates only `session.state` for that app.
-3. hosted-sites writes the updated V2 envelope to Redis.
-4. If the session is persisted, hosted-sites sends snapshot, access, and event commands to the orchestrator.
-5. The orchestrator writes `hosted_web_sessions`, hosted events/access logs, and result state; hosted-sites does not write these tables directly.
-6. hosted-sites forwards a normalized run event to `apps/web`.
-7. The Web live page receives the next SSE snapshot containing run, events, and artifacts.
-
-## 4. Session Completion and Suite Progression
+## 5. Session Completion and Callback Outbox
 
 ```mermaid
 sequenceDiagram
   participant A as Agent
   participant H as hosted-sites
-  participant O as hosted-orchestrator
+  participant O as orchestrator API
+  participant R as Redis Stream
+  participant K as partition worker
   participant D as Supabase
   participant W as apps/web
 
-  A->>H: submit terminal task action
+  A->>H: terminal task action
   H->>H: evaluate current app state
   H->>O: complete-session command
-  O->>D: insert hosted_web_result
-  O->>D: update session status
+  O->>R: XADD attempt.complete-session
+  K->>D: transactional completion RPC
+  Note over K,D: result, session, next session, aggregate, attempt
   alt sessions remain
-    O->>D: update activeSessionId and promote next session
-    O-->>H: per-session result
-    H-->>A: redirect/advance URL
-  else suite complete
-    O->>D: insert benchmark_attempt_score
-    O->>D: mark attempt completed/failed
-    O->>W: POST run completion
-    O-->>H: aggregate terminal result
+    D-->>K: per-session result and next session
+    K-->>H: command response
+    H-->>A: result or advance URL
+  else attempt terminal
+    D->>D: trigger inserts hosted_callback_outbox
+    D-->>K: terminal aggregate result
+    K-->>H: command response
+    K->>D: claim outbox row
+    K->>W: POST run completion
+    K->>D: mark delivered or schedule retry
   end
 ```
 
-Required-session failure forces the aggregate suite result to fail. Optional evaluators or sessions can contribute evidence without blocking a pass, according to scoring configuration.
+`complete_hosted_attempt_session` locks the attempt and applies the terminal transition atomically inside PostgreSQL. Unique session-result and attempt-score constraints make retries first-writer-wins. Redis partition ordering reduces conflicts but is not the terminal lifecycle correctness boundary.
 
-## 5. Advance Resolution
+Web completion is not part of the terminal transaction. The database trigger creates one outbox row per attempt; workers attempt immediate delivery, while maintenance reconciles and retries pending rows. A failed Web callback therefore delays the Web read model without rolling back the hosted result.
 
-`GET /api/attempts/:id/advance?session=...` reaches hosted-sites, which calls the orchestrator `resolve-advance` command. The orchestrator verifies that the current session belongs to the attempt and returns either:
+## 6. Advance Resolution
+
+`GET /api/attempts/:id/advance?session=...` reaches hosted-sites through the default Nginx route. Hosted-sites sends an authenticated `resolve-advance` request to the orchestrator. This read handler verifies the current session against durable attempt state and returns either:
 
 - `complete: true` with no next URL, or
 - the next session ID and tokenized start URL.
 
-The client does not calculate ordering from URLs or local state.
+The client does not calculate suite ordering from URLs, Redis state, or its local history.
 
-## 6. Expiry and Timeout
+## 7. Expiry, Cleanup, and Recovery
 
-When hosted-sites observes an expired session, it marks the session expired, evicts cache state, and sends a timeout command. The orchestrator marks the attempt `timeout`, invalidates remaining active/created sessions, and forwards terminal completion to the Web API.
+When hosted-sites observes an expired write session, it evicts its runtime cache entry and sends an `attempt.timeout` command. A periodic orchestrator maintenance command also discovers expired durable sessions, atomically times out attempts, prunes old access logs, reconciles callback outbox rows, and retries delivery.
 
-A periodic orchestrator sweep also finds expired sessions and prunes access logs beyond the configured retention period.
+Recovery boundaries:
 
-## 7. Recovery and Consistency
+- process-local Map loss is expected and recoverable from Redis
+- Redis session loss falls back to the latest successful Supabase app-state snapshot
+- Redis Stream loss can discard commands that had not produced durable database effects
+- duplicate terminal commands recover from PostgreSQL constraints and transactional functions
+- Web callback loss recovers through `hosted_callback_outbox`
+- there is no distributed transaction spanning Redis, Supabase, hosted-sites, and Web
 
-- Redis write failures are logged; the in-process object may continue serving the current request but cross-replica continuity is at risk.
-- Orchestrator command failures do not immediately break active Redis-backed sessions, but reduce recovery durability and audit completeness.
-- Completion is designed to be idempotent: duplicate terminal commands return the latest result.
-- There is no distributed transaction spanning Redis, Supabase, orchestrator, and Web callbacks. Reconciliation and idempotency are therefore required for stronger reliability.
-
-Redis now serves both as the hosted session cache and, through separate keys, as the orchestrator ingest channel. Commands use `agentbench:orchestrator:commands:p<N>`; per-command results, replies, and partition leases use separate keys. Cache envelopes are never consumed as queue messages.
+The exact current RPO, concurrency gaps, and degraded behavior are documented in [Consistency and Failure](./consistency-and-failure.md).

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -10,11 +10,16 @@ erDiagram
   BENCHMARK_RUNS ||--o{ BENCHMARK_ATTEMPTS : contains
   BENCHMARK_ATTEMPTS ||--o{ HOSTED_WEB_SESSIONS : orders
   HOSTED_WEB_SESSIONS ||--o{ HOSTED_WEB_EVENTS : emits
-  HOSTED_WEB_SESSIONS ||--o{ HOSTED_WEB_RESULTS : produces
-  BENCHMARK_ATTEMPTS ||--o{ BENCHMARK_ATTEMPT_SCORES : aggregates
+  HOSTED_WEB_SESSIONS ||--o| HOSTED_WEB_RESULTS : produces
+  BENCHMARK_ATTEMPTS ||--o| BENCHMARK_ATTEMPT_SCORES : aggregates
   HOSTED_WEB_SESSIONS ||--o{ HOSTED_WEB_ACCESS_LOGS : records
+  BENCHMARK_ATTEMPTS ||--o| HOSTED_CALLBACK_OUTBOX : enqueues
   BENCHMARK_RUNS ||--o{ RUN_EVENTS : streams
   BENCHMARK_RUNS ||--o{ ARTIFACTS : owns
+  ORCHESTRATOR_COMMAND_DEAD_LETTERS {
+    uuid id PK
+    text command_id UK
+  }
 ```
 
 ## Durable Supabase Records
@@ -83,6 +88,14 @@ Each attempt has at most one aggregate score. A concurrent writer recovers and u
 
 Operational audit records for session access and expiry. These records have a retention sweep and should not be treated as permanent benchmark evidence.
 
+### `hosted_callback_outbox`
+
+One durable Web-completion handoff per terminal attempt. The database transition creates the row; orchestrator workers claim, deliver, retry, and eventually mark it `delivered` or `dead`. Callback failure does not roll back the hosted terminal result.
+
+### `orchestrator_command_dead_letters`
+
+Durable diagnostics for Redis commands that exhausted handler retries. It records the original command identity, Stream/message location, partition, payload type and payload, final error, attempt count, and replay state. It has no foreign key to a single domain entity because commands can be partitioned by attempt, session, or maintenance key.
+
 ## Redis Runtime Schema
 
 Key:
@@ -100,7 +113,7 @@ type RedisHostedSessionEnvelopeV2 = {
 };
 ```
 
-TTL is the smaller practical boundary derived from `session.expiresAt` or `HOSTED_SESSION_REDIS_TTL_MS`, rounded up to seconds.
+If `session.expiresAt` is present, TTL is its remaining lifetime rounded up to seconds. Otherwise the cache uses `HOSTED_SESSION_REDIS_TTL_MS`. The current implementation does not take the minimum of both values.
 
 The decoder accepts V2, V1 envelopes, and legacy raw JSON. Legacy flat app fields are migrated into `session.state` during read.
 
@@ -112,9 +125,11 @@ Shared fields:
 type HostedSessionBase = {
   id: string;
   token: string;
+  accessMode?: "write" | "viewer";
   runId: string | null;
   caseId: string | null;
   attemptId: string | null;
+  callbackSecret: string | null;
   app: HostedAppId;
   suiteSlug: string;
   suiteVersion: string;
@@ -129,7 +144,16 @@ type HostedSessionBase = {
   seedVersion: string;
   metadata: Record<string, unknown>;
   status: "created" | "active" | "completed" | "failed" | "expired";
+  expiresAt: string | null;
+  accessCount: number;
+  lastAccessedAt: string | null;
+  firstSeenIp: string | null;
+  lastSeenIp: string | null;
+  firstSeenUserAgent: string | null;
+  lastSeenUserAgent: string | null;
+  createdAt: string;
   events: Array<Record<string, unknown>>;
+  persisted: boolean;
   state: AppSpecificState;
 };
 ```
@@ -144,6 +168,8 @@ App-specific state is a discriminated union:
 | `repo-lite` | `files`, `issues`, `mergeRequests` |
 
 A session never carries another app's state fields. Redis validation rejects mismatched app/state payloads.
+
+The Redis envelope currently contains the raw write token, generated private task configuration inside `metadata`, and may contain a callback secret. Redis must therefore remain private. Token hashing, credential minimization, and ACL separation are tracked in [Issue #62](https://github.com/Kaiwen0418/agent-benchmark/issues/62).
 
 ## State Machines
 
@@ -171,7 +197,7 @@ stateDiagram-v2
 
 ## Source-of-Truth Rules
 
-- Redis is authoritative for mutable task state during an active session.
+- Redis is authoritative for the latest available mutable task state during an active session, but current whole-envelope writes are not concurrency-safe.
 - Supabase is authoritative for durable lifecycle, audit, and scoring records.
 - `benchmark_case_revisions` is authoritative for the suite manifest used by an attempt; its generated question snapshot remains in attempt/session metadata.
 - The orchestrator is the only application writer for attempts, hosted sessions, and hosted results; hosted-sites may read session rows only for cache recovery.
@@ -179,3 +205,5 @@ stateDiagram-v2
 - `metadata.appState` is a recovery snapshot, not a separately writable domain model.
 - Attempt progression is determined by orchestrator metadata plus persisted session/result rows.
 - Session cache keys and ingest records are separate. Durable commands use partitioned `agentbench:orchestrator:commands:p<N>` Streams, consumer group `hosted-orchestrator`, 24-hour command result keys, short-lived response lists, and partition lease keys.
+
+See [Data Ownership](./data-ownership.md) for the complete reader/writer matrix and [Consistency and Failure](./consistency-and-failure.md) for implemented guarantees.

--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -1,0 +1,62 @@
+# Data Ownership
+
+This document defines who may read, mutate, and recover each state family. Ownership means the component that enforces domain invariants; it does not imply that no other component has a read path.
+
+## Durable Data
+
+| Data | Domain owner | Writers | Readers | Authority and notes |
+| --- | --- | --- | --- | --- |
+| `profiles`, Supabase Auth identity | Web control plane | Supabase Auth / Web | Web | User identity and plan data |
+| `benchmark_cases` | Web control plane | release/admin workflow | Web, orchestrator service-role code | Private current-case compatibility record |
+| `public_benchmark_cases` | Web control plane | database projection | anonymous/authenticated clients, Web | Display-safe discovery only |
+| `benchmark_case_revisions` | benchmark release workflow | `publish_benchmark_case_revision` | orchestrator, Web service-role recovery | Immutable private manifest for historical interpretation |
+| `benchmark_runs` | Web control plane | Web | Web, public read models | User-facing run lifecycle |
+| `run_events`, `artifacts` | Web control plane | Web internal APIs | Web UI and public read models | Live observability and output artifacts |
+| `benchmark_attempts` | hosted orchestrator | orchestrator workers and transactional RPCs | orchestrator, Web read/recovery paths | Canonical hosted attempt lifecycle and active-session pointer |
+| `hosted_web_sessions` | hosted orchestrator | orchestrator workers and transactional RPCs | orchestrator, hosted-sites recovery, Web read fallback | Durable lifecycle plus latest successful app-state snapshot |
+| `hosted_web_events` | hosted orchestrator | orchestrator workers | orchestrator and result/read-model code | Durable hosted telemetry |
+| `hosted_web_access_logs` | hosted orchestrator | orchestrator workers | maintenance and operations | Retained operational audit, not permanent evidence |
+| `hosted_web_results` | hosted orchestrator | transactional completion RPC | orchestrator and result/read-model code | One terminal result per session |
+| `benchmark_attempt_scores` | hosted orchestrator | transactional completion RPC | Web leaderboard/result reads | One aggregate score per attempt |
+| `hosted_callback_outbox` | hosted orchestrator | database trigger and orchestrator processor | orchestrator workers/maintenance | Durable handoff from hosted terminal state to Web |
+| `orchestrator_command_dead_letters` | hosted orchestrator | orchestrator workers | authenticated operator APIs | Durable diagnostics after command retry exhaustion |
+
+`apps/hosted-sites` has service-role access only for read-only session recovery. It must not write hosted lifecycle tables. Removing this direct database credential is tracked separately; until then, database grants and code review enforce the writer boundary.
+
+## Redis and Process State
+
+| Namespace/state | Writer | Reader | Current authority | Retention |
+| --- | --- | --- | --- | --- |
+| `hosted-sites:session:<opaque-token>` | hosted-sites | hosted-sites replicas | Mutable active task state | Session expiry or configured TTL |
+| `agentbench:orchestrator:commands:p<N>` | orchestrator API | assigned orchestrator worker | Runtime command transport | Approximate max length |
+| orchestrator response lists | workers | API waiter | Synchronous command response only | Short TTL |
+| orchestrator result keys | workers | workers/API retry path | Command idempotency result cache | 24 hours |
+| retry/failure keys | workers | workers | Retry diagnostics before DB DLQ | 24 hours |
+| partition lease keys | workers | workers/API readiness | Current partition ownership | 10 seconds, renewed every 3 seconds |
+| attempt initialization lease | orchestrator worker | orchestrator workers | Duplicate-work reduction only | 30 seconds |
+| hosted-sites process Map | one hosted-sites process | same process | Non-authoritative hot copy | Process lifetime |
+
+Session keys and command keys currently share one Redis instance but are separate namespaces. They do not yet have independent persistence, memory, ACL, or failover policy.
+
+## Source-of-Truth Matrix
+
+| Question | Source of truth |
+| --- | --- |
+| Which benchmark definition did this attempt use? | `benchmark_attempts.case_revision_id` -> immutable revision |
+| Which session is active? | Durable attempt/session rows and transactional lifecycle functions |
+| What is the current in-progress app state? | Redis session envelope, subject to current concurrency limitations |
+| What app state can survive Redis loss? | Latest successfully persisted `hosted_web_sessions.metadata.appState` snapshot |
+| Did a session or attempt finish? | PostgreSQL terminal rows and unique constraints |
+| Has Web observed terminal completion? | `hosted_callback_outbox.status` plus Web run state |
+| Did a Redis command finish recently? | Redis result key; durable side effects remain authoritative in PostgreSQL |
+| Why was a command abandoned? | `orchestrator_command_dead_letters` |
+
+## Boundary Rules
+
+- Browser clients never receive Supabase service-role or Redis credentials.
+- Web does not submit private suite manifests to orchestrator; it submits a revision ID.
+- Hosted-sites owns task actions and evaluation, but not durable attempt progression.
+- Orchestrator workers are the only application writers for hosted lifecycle and scoring tables.
+- Redis cannot override a terminal PostgreSQL transition.
+- Web callbacks cannot roll back a completed hosted transaction.
+- Public case discovery never exposes private manifest, variant pool, canonical answer, or evaluator configuration.

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,10 +7,18 @@ The external agent and its browser are untrusted. AgentBench exposes only benchm
 ```mermaid
 flowchart LR
   Untrusted["External agent/browser"] -->|"opaque session token"| Gateway["Nginx"]
+  User["User browser"] --> Web["apps/web"]
   Gateway --> Sites["hosted-sites"]
-  Sites --> Redis[("Redis")]
-  Sites --> DB[("Supabase service role")]
-  Sites -->|"shared-secret callback"| Web["apps/web"]
+  Web -->|"shared-secret init"| Gateway
+  Gateway --> OrchestratorAPI["orchestrator API"]
+  Sites --> SessionRedis[("Redis session runtime")]
+  Sites -.->|"service-role read recovery"| DB[("Supabase")]
+  Sites -->|"shared-secret commands"| OrchestratorAPI
+  OrchestratorAPI --> CommandRedis[("Redis command Streams")]
+  CommandRedis --> Workers["orchestrator workers"]
+  Workers -->|"service-role hosted writes"| DB
+  Sites -->|"shared-secret run events"| Web
+  Workers -->|"shared-secret outbox delivery"| Web
 ```
 
 ## Controls
@@ -38,6 +46,8 @@ flowchart LR
 - Session tokens in URLs may appear in browser history, proxy logs, and referrers.
 - Internal auth uses a single shared secret and a legacy header name.
 - Redis and Supabase updates are not one distributed transaction.
+- Session Redis currently stores raw bearer tokens, private task configuration, and callback material.
+- Redis currently has no per-service ACL boundary; all hosted services share the private Compose network.
 - Dead callback rows require operational alerting and manual inspection.
 - Rate limiting is not yet documented as a gateway-enforced control.
 
@@ -50,3 +60,5 @@ flowchart LR
 - use command idempotency keys
 - audit RLS and service-role usage before public launch
 - define incident response for leaked session tokens
+- hash Redis session-token key suffixes and remove reusable callback credentials from session envelopes
+- introduce per-service Redis ACL identities and command/key restrictions


### PR DESCRIPTION
## Summary
- align architecture diagrams with the API, worker, Redis, and outbox topology
- document actual allocation, mutation, completion, and recovery paths
- add data ownership and consistency/failure boundaries
- correct ER cardinalities, Redis TTL/envelope, and security trust boundaries

## Why
Existing docs mixed target guarantees with current behavior and contained stale server topology and callback flow.

## Validation
- pre-push `pnpm verify:push`
- relative Markdown link check
- `git diff --check`