### PR TITLE
[codex] simplify agent connection flow

### DIFF
--- a/apps/web/app/runs/[runId]/connect/page.tsx
+++ b/apps/web/app/runs/[runId]/connect/page.tsx
@@ -1,5 +1,6 @@
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { RunMetadataForm } from "@/components/run/RunMetadataForm";
 import { getBenchmarkCase, getBenchmarkRun } from "@/lib/db";
 import { buildRunConnectPayload } from "@/lib/run-connect";
 
@@ -31,6 +32,9 @@ export default async function RunConnectPage({
     benchmarkCase,
     origin,
   });
+  const metadata = { ...run.metadata };
+  delete metadata.identityReportedAt;
+  const metadataLocked = ["completed", "failed", "cancelled", "timeout"].includes(run.status);
 
   return (
     <main className="min-h-screen bg-[#f5f0e6] px-6 py-10 text-[#111111] md:px-10">
@@ -52,6 +56,13 @@ export default async function RunConnectPage({
             </div>
           ) : null}
 
+          <RunMetadataForm
+            runId={run.id}
+            initialAgent={run.agent}
+            initialMetadata={metadata}
+            locked={metadataLocked}
+          />
+
           <div className="mt-8 grid gap-5 md:grid-cols-[1.1fr_0.9fr]">
             <section className="rounded-[1.4rem] border border-[#ddd6ca] bg-white p-5">
               <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Instructions For Agents</div>
@@ -72,8 +83,6 @@ export default async function RunConnectPage({
                   <>
                     Suite: <span className="font-medium">{payload.hostedWeb.suiteSlug ?? "hosted-web"}</span>
                     <br />
-                    URL: <span className="font-medium">{payload.hostedWeb.orchestratorUrl ?? "not allocated"}</span>
-                    <br />
                     Attempt: <span className="font-medium">{payload.hostedWeb.attemptId ?? "not allocated"}</span>
                     <br />
                     Active Session: <span className="font-medium">{payload.hostedWeb.activeSessionId ?? "not allocated"}</span>
@@ -86,12 +95,20 @@ export default async function RunConnectPage({
                   </>
                 ) : (
                   <>
-                    Hosted URL: <span className="font-medium">{payload.connectUrl}</span>
-                    <br />
                     Status: <span className="font-medium">{payload.status}</span>
                   </>
                 )}
               </div>
+              {payload.hostedWeb.orchestratorUrl ? (
+                <a
+                  href={payload.hostedWeb.orchestratorUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-4 inline-flex rounded-full bg-[#111111] px-5 py-2.5 text-sm font-medium text-white"
+                >
+                  Open Active Benchmark
+                </a>
+              ) : null}
             </section>
           </div>
 

--- a/apps/web/components/landing/LiveMacContainer.tsx
+++ b/apps/web/components/landing/LiveMacContainer.tsx
@@ -86,7 +86,7 @@ export function LiveMacScreenContent() {
           <iframe
             src={embeddedLiveViewUrl}
             title="Embedded live run viewer"
-            className="absolute left-0 top-0 h-[220%] w-[220%] origin-top-left scale-[0.455] border-0 bg-[#111111]"
+            className="absolute left-0 top-0 h-[300%] w-[300%] origin-top-left scale-[0.334] border-0 bg-[#111111]"
           />
         </div>
       ) : liveFrameUrl ? (

--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { selectVisibleHostedSessions } from "@/lib/hosted-progress";
 import { usePlaygroundStore } from "@/lib/playground-store";
 import { RunDetailTabs } from "./RunDetailTabs";
-
-type ConnectMethod = "link" | "browser" | "advanced";
 
 type RunConnectPayload = {
   runId: string;
@@ -92,7 +90,6 @@ export function RunConnectionCard() {
         (entry) => entry.label === "hosted.page.load" || entry.label === "hosted.score",
       ).length,
   );
-  const [method, setMethod] = useState<ConnectMethod>("link");
   const [payload, setPayload] = useState<RunConnectPayload | null>(null);
   const [connectError, setConnectError] = useState<RunConnectError | null>(null);
   const [copyState, setCopyState] = useState<string | null>(null);
@@ -153,24 +150,6 @@ export function RunConnectionCard() {
       cancelled = true;
     };
   }, [connectionRefreshKey, runId, retryNonce]);
-
-  const browserPrompt = useMemo(() => {
-    if (!payload) {
-      return "";
-    }
-
-    if (payload.hostedWeb.available && payload.hostedWeb.orchestratorUrl) {
-      return [
-        "Open the hosted AgentBench benchmark suite and complete the current objective.",
-        payload.hostedWeb.orchestratorUrl,
-      ].join("\n");
-    }
-
-    return [
-      "Open the current AgentBench connection page and follow the instructions on it.",
-      payload.connectUrl,
-    ].join("\n");
-  }, [payload]);
 
   if (!runId || executionMode !== "external-agent") {
     return null;
@@ -275,156 +254,28 @@ export function RunConnectionCard() {
             </div>
           ) : null}
 
-          <div className="mt-5 grid gap-2 sm:grid-cols-3">
-            <button
-              type="button"
-              onClick={() => setMethod("link")}
-              className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
-                method === "link"
-                  ? "border-[#111111] bg-[#111111] text-white"
-                  : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
-              }`}
-            >
-              <div className="font-medium">Agent Link</div>
-              <div className={`mt-1 text-xs ${method === "link" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-                Recommended
-              </div>
-            </button>
-            <button
-              type="button"
-              onClick={() => setMethod("browser")}
-              className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
-                method === "browser"
-                  ? "border-[#111111] bg-[#111111] text-white"
-                  : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
-              }`}
-            >
-              <div className="font-medium">This Browser</div>
-              <div className={`mt-1 text-xs ${method === "browser" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-                Agent controls page
-              </div>
-            </button>
-            <button
-              type="button"
-              onClick={() => setMethod("advanced")}
-              className={`rounded-[1rem] border px-4 py-3 text-left text-sm transition ${
-                method === "advanced"
-                  ? "border-[#111111] bg-[#111111] text-white"
-                  : "border-[#d8d1c4] bg-[#faf7f1] text-[#111111]"
-              }`}
-            >
-              <div className="font-medium">Advanced</div>
-              <div className={`mt-1 text-xs ${method === "advanced" ? "text-[#d9d9d9]" : "text-[#6a655c]"}`}>
-                Raw hosted config
-              </div>
-            </button>
-          </div>
-
           <div className="mt-5 rounded-[1.2rem] bg-[#f6f3ed] p-4">
-            {method === "link" ? (
-              <>
-                <div className="text-sm font-medium text-[#111111]">Send to your agent</div>
-                <p className="mt-2 text-sm leading-7 text-[#585248]">
-                  One prompt, one URL. The agent opens the page and reads the embedded run context.
-                </p>
-                <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
-                  {payload.prompt}
-                </pre>
-                <div className="mt-4 flex flex-wrap gap-3">
-                  <button
-                    type="button"
-                    onClick={() => void copyText(payload.prompt).then(() => setCopyState("Prompt copied"))}
-                    className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
-                  >
-                    Copy Prompt
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void copyText(payload.connectUrl).then(() => setCopyState("Link copied"))}
-                    className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
-                  >
-                    Copy Agent Link
-                  </button>
-                </div>
-                {!payload.hostedWeb.orchestratorUrl && payload.hostedWeb.available ? (
-                  <p className="mt-3 text-xs leading-6 text-[#80534b]">
-                    This hosted suite no longer has an active session URL. Review the run status and summary above.
-                  </p>
-                ) : null}
-              </>
-            ) : null}
-
-            {method === "browser" ? (
-              <>
-                <div className="text-sm font-medium text-[#111111]">Browser agent</div>
-                <p className="mt-2 text-sm leading-7 text-[#585248]">
-                  Tell the agent controlling this browser to open the active hosted session for this suite.
-                </p>
-                <pre className="mt-4 whitespace-pre-wrap rounded-[1rem] bg-white p-4 text-sm leading-7 text-[#25221d]">
-                  {browserPrompt}
-                </pre>
-                <div className="mt-4 flex flex-wrap gap-3">
-                  <a
-                    href={payload.hostedWeb.orchestratorUrl ?? payload.connectUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
-                  >
-                    Open Connection Page
-                  </a>
-                  <button
-                    type="button"
-                    onClick={() => void copyText(browserPrompt).then(() => setCopyState("Browser prompt copied"))}
-                    className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
-                  >
-                    Copy Browser Prompt
-                  </button>
-                </div>
-                {!payload.hostedWeb.orchestratorUrl && payload.hostedWeb.available ? (
-                  <p className="mt-3 text-xs leading-6 text-[#80534b]">
-                    There is no active hosted session to open for this run.
-                  </p>
-                ) : null}
-              </>
-            ) : null}
-
-            {method === "advanced" ? (
-              <>
-                <div className="text-sm font-medium text-[#111111]">Raw config</div>
-                <p className="mt-2 text-sm leading-7 text-[#585248]">
-                  Full JSON payload for the run context. Hosted-web runs use the hosted URL as the primary agent target.
-                  Full JSON payload for the run context. Hosted-web runs use the hosted URL as the primary agent target.
-                </p>
-                <pre className="mt-4 overflow-x-auto rounded-[1rem] bg-[#111111] p-4 text-xs leading-6 text-[#d7ff00]">
-                  {JSON.stringify(payload, null, 2)}
-                </pre>
-                <div className="mt-4 rounded-[1rem] bg-white px-4 py-3 text-sm leading-7 text-[#3f3b34]">
-                  Suite: <span className="font-medium">{payload.hostedWeb.suiteSlug ?? "not available"}</span>
-                  <br />
-                  Attempt id: <span className="font-medium">{payload.hostedWeb.attemptId ?? "not allocated"}</span>
-                  <br />
-                  Active session: <span className="font-medium">{payload.hostedWeb.activeSessionId ?? "not allocated"}</span>
-                  <br />
-                  Hosted-web URL: <span className="font-medium">{payload.hostedWeb.orchestratorUrl ?? "not available"}</span>
-                </div>
-                <div className="mt-4 flex flex-wrap gap-3">
-                  <button
-                    type="button"
-                    onClick={() => void copyText(JSON.stringify(payload, null, 2)).then(() => setCopyState("Config copied"))}
-                    className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
-                  >
-                    Copy JSON
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void copyText(payload.configUrl).then(() => setCopyState("Config URL copied"))}
-                    className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
-                  >
-                    Copy Config URL
-                  </button>
-                </div>
-              </>
-            ) : null}
+            <div className="text-sm font-medium text-[#111111]">Browser agent</div>
+            <p className="mt-2 text-sm leading-7 text-[#585248]">
+              Open the connection page to register the agent and continue into the benchmark, or copy a short prompt for the agent controlling this browser.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <a
+                href={payload.connectUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-full bg-[#111111] px-4 py-2.5 text-sm font-medium text-white"
+              >
+                Open Connection Page
+              </a>
+              <button
+                type="button"
+                onClick={() => void copyText(payload.prompt).then(() => setCopyState("Browser prompt copied"))}
+                className="rounded-full border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111]"
+              >
+                Copy Browser Prompt
+              </button>
+            </div>
           </div>
 
           {copyState ? <div className="mt-3 text-xs uppercase tracking-[0.18em] text-[#6f695f]">{copyState}</div> : null}

--- a/apps/web/components/run/RunMetadataForm.tsx
+++ b/apps/web/components/run/RunMetadataForm.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type AgentIdentity = {
+  name: string;
+  version: string;
+  baseModel: string;
+};
+
+export function RunMetadataForm({
+  runId,
+  initialAgent,
+  initialMetadata,
+  locked,
+}: {
+  runId: string;
+  initialAgent: AgentIdentity | null;
+  initialMetadata: Record<string, unknown>;
+  locked: boolean;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState(initialAgent?.name ?? "");
+  const [version, setVersion] = useState(initialAgent?.version ?? "");
+  const [baseModel, setBaseModel] = useState(initialAgent?.baseModel ?? "");
+  const [metadata, setMetadata] = useState(() => JSON.stringify(initialMetadata, null, 2));
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<{ tone: "success" | "error"; text: string } | null>(null);
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setMessage(null);
+
+    let parsedMetadata: unknown;
+    try {
+      parsedMetadata = metadata.trim() ? JSON.parse(metadata) : {};
+    } catch {
+      setMessage({ tone: "error", text: "Metadata must be valid JSON." });
+      return;
+    }
+
+    if (!parsedMetadata || typeof parsedMetadata !== "object" || Array.isArray(parsedMetadata)) {
+      setMessage({ tone: "error", text: "Metadata must be a JSON object." });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch(`/api/runs/${runId}/metadata`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, version, baseModel, metadata: parsedMetadata }),
+      });
+      const result = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        throw new Error(result?.message ?? result?.error ?? "Unable to save agent metadata.");
+      }
+
+      setMessage({ tone: "success", text: "Agent metadata saved. You can start the benchmark." });
+      router.refresh();
+    } catch (error) {
+      setMessage({ tone: "error", text: error instanceof Error ? error.message : "Unable to save agent metadata." });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const inputClass =
+    "mt-2 w-full rounded-[0.9rem] border border-[#d8d1c4] bg-white px-3.5 py-3 text-sm text-[#111111] outline-none transition focus:border-[#111111] disabled:cursor-not-allowed disabled:bg-[#eeeae2] disabled:text-[#777168]";
+
+  return (
+    <section className="mt-8 rounded-[1.4rem] border border-[#ddd6ca] bg-[#f1eee7] p-5">
+      <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Agent Metadata</div>
+      <p className="mt-2 text-sm leading-7 text-[#585248]">
+        Register the agent identity before opening the active benchmark.
+      </p>
+      <form onSubmit={submit} className="mt-5">
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="text-xs font-medium text-[#4f4a43]">
+            Agent name
+            <input required maxLength={120} value={name} onChange={(event) => setName(event.target.value)} disabled={locked} className={inputClass} />
+          </label>
+          <label className="text-xs font-medium text-[#4f4a43]">
+            Agent version
+            <input required maxLength={120} value={version} onChange={(event) => setVersion(event.target.value)} disabled={locked} className={inputClass} />
+          </label>
+          <label className="text-xs font-medium text-[#4f4a43]">
+            Base model
+            <input required maxLength={160} value={baseModel} onChange={(event) => setBaseModel(event.target.value)} disabled={locked} className={inputClass} />
+          </label>
+        </div>
+        <label className="mt-4 block text-xs font-medium text-[#4f4a43]">
+          Additional metadata (JSON)
+          <textarea
+            rows={5}
+            value={metadata}
+            onChange={(event) => setMetadata(event.target.value)}
+            disabled={locked}
+            spellCheck={false}
+            className={`${inputClass} resize-y font-mono leading-6`}
+          />
+        </label>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={locked || submitting}
+            className="rounded-full bg-[#111111] px-5 py-2.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#8d887f]"
+          >
+            {submitting ? "Saving..." : initialAgent ? "Update Metadata" : "Register Agent"}
+          </button>
+          {locked ? <span className="text-xs text-[#756e62]">Metadata is locked because this run has ended.</span> : null}
+          {message ? (
+            <span className={`text-xs ${message.tone === "success" ? "text-[#1f6b35]" : "text-[#8a2d1f]"}`}>
+              {message.text}
+            </span>
+          ) : null}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/lib/run-connect.ts
+++ b/apps/web/lib/run-connect.ts
@@ -34,12 +34,11 @@ export async function buildRunConnectPayload(params: {
   const goal = getGoal(benchmarkCase);
   const title = benchmarkCase?.title ?? "AgentBench Run";
   const prompt = [
-    "Open the hosted AgentBench benchmark site below and complete the task.",
-    "The site is session-scoped, may contain multiple ordered tasks, and reports telemetry back to AgentBench.",
-    `Before starting, PATCH ${metadataUrl} with JSON fields name, version, and baseModel describing your agent runtime.`,
-    "Stop when the active task is completed or clearly blocked.",
+    "Open the AgentBench connection page below.",
+    "Register the agent identity in the form, then open the active hosted benchmark and complete the current objective.",
+    "Follow the ordered suite instructions and stop when the active task is completed or clearly blocked.",
     "",
-    hostedWeb?.orchestratorUrl ?? connectUrl,
+    connectUrl,
   ].join("\n");
 
   return {
@@ -57,17 +56,17 @@ export async function buildRunConnectPayload(params: {
       ? [
           `Open the hosted benchmark site for run ${run.id}.`,
           `This suite contains ${hostedWeb.sessions.length} hosted session${hostedWeb.sessions.length === 1 ? "" : "s"}.`,
+          "Register the agent name, version, base model, and optional metadata in the form on this page.",
           "Start from the active hosted URL and progress through the ordered suite.",
           "Use only the session URLs allocated for this run.",
-          `Before starting, PATCH ${metadataUrl} with your agent name, agent version, and base model.`,
           "Stop after the active objective is completed or clearly blocked.",
         ]
       : [
           `Open the connection page for run ${run.id}.`,
+          "Register the agent name, version, base model, and optional metadata in the form on this page.",
           "Read the benchmark objective and hosted suite details.",
           "Open the allocated hosted session URL for this run.",
           "Use only the tools and sites exposed for this run.",
-          `Before starting, PATCH ${metadataUrl} with your agent name, agent version, and base model.`,
           "Stop after the objective is completed or clearly blocked by policy.",
         ],
     prompt,


### PR DESCRIPTION
## Summary

- simplify the landing connection card to one browser-agent flow
- move agent identity and metadata JSON submission into the connection page form
- zoom out the embedded live viewer to show more page structure

## Impact

Users no longer choose between overlapping connection methods or see raw connection URLs in the landing card. Agent registration is handled by a validated form before entering the hosted benchmark.

## Validation

- full pre-push repository verification
- web tests: 20 passed
- production builds passed
