### PR TITLE
docs(agent): define test placement rules

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -179,6 +179,8 @@ For hosted-web, telemetry should be lightweight and generic:
 - design every run so it can be debugged after the fact
 - do not add hosted app-specific database tables unless there is a clear persistence requirement that cannot fit session snapshots or final result evidence
 - do not make hosted-sites responsible for attempt lifecycle; use hosted-orchestrator for attempt init/state/commands
+- keep production source directories free of test files; use workspace `tests/unit` or `tests/integration`, and root `tests/e2e` for cross-service scenarios
+- update explicit test discovery and `scripts/check-test-layout.sh` when introducing a new test category
 
 ## Documentation Policy
 


### PR DESCRIPTION
## Summary
- document the workspace test placement and explicit discovery rules omitted from PR #75 because of a local filename case mismatch

## Verification
- documentation-only follow-up to PR #75; `pnpm verify:ci` passed on the implementation commit

Related to #64