### PR TITLE
refactor(hosted): remove attempt overview entry

### DIFF
--- a/apps/hosted-sites/src/routes/attempts.ts
+++ b/apps/hosted-sites/src/routes/attempts.ts
@@ -1,16 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { HostedAttemptReadModel } from "@agentbench/shared";
-import { renderAttemptOverview } from "../templates.js";
 import { sendJson } from "../runtime/http.js";
-import type { HostedAttemptOverviewSession, HostedSession } from "../runtime/types.js";
+import type { HostedSession } from "../runtime/types.js";
 
 type AttemptsRouteDeps = {
-  publicBaseUrl: string;
-  defaultStartPathForApp: (app: string) => string;
   getSession: (url: URL, request: IncomingMessage) => Promise<HostedSession | null>;
-  getAttemptOverview: (
-    attemptId: string,
-  ) => Promise<HostedAttemptReadModel<HostedAttemptOverviewSession> | null>;
   resolveAdvance: (params: {
     attemptId: string;
     currentSessionId: string;
@@ -26,30 +19,6 @@ type AttemptsRouteDeps = {
 
 export function createAttemptsRoutes(deps: AttemptsRouteDeps) {
   async function handle(request: IncomingMessage, response: ServerResponse, url: URL) {
-    const attemptMatch = url.pathname.match(/^\/attempts\/([^/]+)$/);
-    if (request.method === "GET" && attemptMatch) {
-      const session = await deps.getSession(url, request);
-      if (!session) {
-        deps.badRequest(response, "Missing or invalid session");
-        return true;
-      }
-
-      const attemptId = decodeURIComponent(attemptMatch[1]);
-      if (session.attemptId !== attemptId) {
-        deps.badRequest(response, "Session does not belong to this attempt");
-        return true;
-      }
-
-      const overview = await deps.getAttemptOverview(attemptId);
-      if (!overview) {
-        sendJson(response, 502, { error: "Hosted orchestrator unavailable" });
-        return true;
-      }
-
-      renderAttemptOverview(overview, session, response, deps.publicBaseUrl, deps.defaultStartPathForApp);
-      return true;
-    }
-
     const advanceMatch = url.pathname.match(/^\/api\/attempts\/([^/]+)\/advance$/);
     if (request.method === "GET" && advanceMatch) {
       const session = await deps.getSession(url, request);

--- a/apps/hosted-sites/src/server.ts
+++ b/apps/hosted-sites/src/server.ts
@@ -105,7 +105,6 @@ const { recordEvent, forwardRunEvent, telemetryRunEventType } = telemetryRuntime
 const {
   completeSession: completeSessionViaOrchestrator,
   getSessionResult: getSessionResultViaOrchestrator,
-  getAttemptOverview: getAttemptOverviewViaOrchestrator,
   resolveAdvance: resolveAdvanceViaOrchestrator,
 } = orchestratorClient;
 
@@ -137,10 +136,7 @@ function rejectTerminalMutation(session: HostedSession, response: ServerResponse
 }
 
 const attemptsRoutes = createAttemptsRoutes({
-  publicBaseUrl,
-  defaultStartPathForApp,
   getSession,
-  getAttemptOverview: getAttemptOverviewViaOrchestrator,
   resolveAdvance: resolveAdvanceViaOrchestrator,
   badRequest,
 });

--- a/apps/hosted-sites/src/templates.ts
+++ b/apps/hosted-sites/src/templates.ts
@@ -1,7 +1,5 @@
 import type { ServerResponse } from "node:http";
-import type { HostedAttemptReadModel } from "@agentbench/shared";
-import type { HostedSession, HostedAttemptOverviewSession } from "./runtime/types.js";
-import { sendJson } from "./runtime/http.js";
+import type { HostedSession } from "./runtime/types.js";
 import { readUiTheme, readUiVariant } from "./runtime/question-config.js";
 
 export function escapeHtml(value: string) {
@@ -355,41 +353,4 @@ export function layout(params: {
     </div>
   </body>
 </html>`;
-}
-
-export function renderAttemptOverview(
-  readModel: HostedAttemptReadModel<HostedAttemptOverviewSession>,
-  currentSession: HostedSession,
-  response: ServerResponse,
-  publicBaseUrl: string,
-  defaultStartPathForApp: (app: string) => string,
-) {
-  const cards = readModel.sessions
-    .map((session, index) => {
-      const state = session.id === readModel.activeSessionId ? "active" : session.status;
-      return `<article class="card">
-        <div class="muted">Session ${index + 1}</div>
-        <h2>${escapeHtml(session.title ?? session.taskSlug)}</h2>
-        <p>${escapeHtml(session.goal)}</p>
-        <p class="muted">App: ${escapeHtml(session.app)} · State: ${escapeHtml(state)}</p>
-        <a href="${escapeHtml(`${publicBaseUrl}${session.startPath ?? defaultStartPathForApp(session.app)}?session=${encodeURIComponent(session.token)}`)}">Open session</a>
-      </article>`;
-    })
-    .join("");
-
-  sendHtml(
-    response,
-    200,
-    layout({
-      title: "Hosted Suite Overview",
-      session: currentSession,
-      body: `<section class="panel">
-        <h2>Attempt ${escapeHtml(readModel.attemptId)}</h2>
-        <p>${readModel.progress.completed} of ${readModel.progress.total} sessions have submitted results.</p>
-      </section>
-      <section class="grid" style="margin-top:16px;">${cards}</section>`,
-      publicBaseUrl,
-      defaultStartPathForApp,
-    }),
-  );
 }

--- a/apps/hosted-sites/tests/unit/routes/attempts.test.ts
+++ b/apps/hosted-sites/tests/unit/routes/attempts.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import test from "node:test";
+import { createAttemptsRoutes } from "../../../src/routes/attempts.js";
+import type { HostedSession } from "../../../src/runtime/types.js";
+
+function writeBadRequest(response: ServerResponse, message: string) {
+  response.writeHead(400, { "Content-Type": "application/json" });
+  response.end(JSON.stringify({ error: message }));
+}
+
+async function withAttemptsServer<T>(
+  handler: (baseUrl: string, calls: { getSession: number; resolveAdvance: number }) => Promise<T>,
+) {
+  const calls = { getSession: 0, resolveAdvance: 0 };
+  const session = {
+    id: "session-1",
+    token: "tok_1",
+    attemptId: "attempt-1",
+  } as HostedSession;
+  const routes = createAttemptsRoutes({
+    getSession: async () => {
+      calls.getSession += 1;
+      return session;
+    },
+    resolveAdvance: async () => {
+      calls.resolveAdvance += 1;
+      return {
+        attemptId: "attempt-1",
+        currentSessionId: "session-1",
+        complete: false,
+        nextSessionId: "session-2",
+        nextStartUrl: "http://localhost:3003/forum?session=tok_2",
+      };
+    },
+    badRequest: writeBadRequest,
+  });
+
+  const server = createServer(async (request: IncomingMessage, response: ServerResponse) => {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const handled = await routes.handle(request, response, url);
+    if (!handled) {
+      response.writeHead(404, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: "not_found" }));
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    return await handler(`http://127.0.0.1:${address.port}`, calls);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("attempt overview page is not exposed as a second suite navigation surface", async () => {
+  await withAttemptsServer(async (baseUrl, calls) => {
+    const response = await fetch(`${baseUrl}/attempts/attempt-1?session=tok_1`);
+
+    assert.equal(response.status, 404);
+    assert.equal(calls.getSession, 0);
+    assert.equal(calls.resolveAdvance, 0);
+  });
+});
+
+test("attempt advance API remains available", async () => {
+  await withAttemptsServer(async (baseUrl, calls) => {
+    const response = await fetch(`${baseUrl}/api/attempts/attempt-1/advance?session=tok_1`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.getSession, 1);
+    assert.equal(calls.resolveAdvance, 1);
+    assert.equal(body.nextSessionId, "session-2");
+  });
+});

--- a/apps/web/components/landing/ServiceUnavailableDialog.tsx
+++ b/apps/web/components/landing/ServiceUnavailableDialog.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
 type ServiceUnavailableDialogProps = {
   message: string;
   onClose: () => void;
@@ -11,9 +14,19 @@ export function ServiceUnavailableDialog({
   onClose,
   onRetry,
 }: ServiceUnavailableDialogProps) {
-  return (
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return createPortal(
     <div
-      className="fixed inset-0 z-[100] grid place-items-center bg-[#111111]/45 px-5 backdrop-blur-sm"
+      className="fixed inset-0 z-[9999] grid place-items-center bg-[#111111]/45 px-5 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-labelledby="service-unavailable-title"
@@ -41,6 +54,7 @@ export function ServiceUnavailableDialog({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/apps/web/lib/hosted-web.ts
+++ b/apps/web/lib/hosted-web.ts
@@ -110,10 +110,7 @@ function toAttemptConnection(params: {
     attemptId: params.attempt.id ?? null,
     suiteSlug: params.attempt.suiteSlug,
     suiteVersion: params.attempt.suiteVersion,
-    orchestratorUrl:
-      activeSession && params.attempt.id && activeSession.token
-        ? `${baseUrl}/attempts/${encodeURIComponent(params.attempt.id)}?session=${encodeURIComponent(activeSession.token)}`
-        : activeSession?.startUrl ?? null,
+    orchestratorUrl: activeSession?.startUrl ?? null,
     advanceUrl:
       activeSession && params.attempt.id && activeSession.token
         ? `${baseUrl}/api/attempts/${encodeURIComponent(params.attempt.id)}/advance?session=${encodeURIComponent(activeSession.token)}`


### PR DESCRIPTION
## Summary
- remove the hosted attempt overview page as a second suite navigation surface
- point Web connect payloads directly at the active hosted session URL
- keep the attempt advance API covered by unit tests

## Verification
- pnpm --filter hosted-sites test
- pnpm --filter web test