### PR TITLE
refactor(hosted): hide attempt ids from browser advance

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -213,9 +213,9 @@ Do not run the mutation steps against production unless the user explicitly requ
 3. Start one run. Record the run ID and attempt ID from the API response or connection payload before navigating away.
 4. Confirm quota decrements exactly once and the connection guide shows four ordered sessions with only session 1 active.
 5. Keep the Web preview open and open the hosted agent URL in a second tab. Do not replace the preview tab when live-view behavior is under test.
-6. Confirm the hosted attempt overview loads through the public HTTPS hostname and contains the expected session order.
+6. Confirm the active hosted session URL loads through the public HTTPS hostname. Browser-facing hosted URLs must use the opaque session token, not an attempt-scoped navigation route.
 7. Complete each hosted task using its generated task text rather than hard-coded fixture assumptions. Verify each evaluator preview or score endpoint returns `score: 1`.
-8. After each completed session, call the attempt advance endpoint and verify:
+8. After each completed session, call the session advance endpoint and verify:
    - `nextSessionId` matches the next ordered session.
    - `nextStartUrl` uses the public HTTPS hosted hostname.
    - `nextStartUrl` never exposes Docker names such as `hosted-sites`, localhost, or private ports.
@@ -239,10 +239,10 @@ Check public service health and lifecycle responses without exposing credentials
 ```bash
 curl -fsS https://hosted-test.project-echo.xyz/health
 curl -fsS 'https://hosted-test.project-echo.xyz/api/sessions/<redacted-token>/score'
-curl -fsS 'https://hosted-test.project-echo.xyz/api/attempts/<attempt-id>/advance?session=<redacted-token>'
+curl -fsS 'https://hosted-test.project-echo.xyz/api/sessions/advance?session=<redacted-token>'
 ```
 
-Verify response URLs are externally reachable. Internal service URLs may be used for server-to-server calls, but must not appear in browser-facing `startUrl`, `nextStartUrl`, viewer URLs, redirects, or connection instructions.
+Verify response URLs are externally reachable. Internal service URLs and attempt-scoped command URLs may be used for server-to-server calls, but must not appear in browser-facing `startUrl`, `nextStartUrl`, viewer URLs, redirects, or connection instructions.
 
 ### Result Reporting
 

--- a/apps/hosted-sites/src/routes/attempts.ts
+++ b/apps/hosted-sites/src/routes/attempts.ts
@@ -19,15 +19,19 @@ type AttemptsRouteDeps = {
 
 export function createAttemptsRoutes(deps: AttemptsRouteDeps) {
   async function handle(request: IncomingMessage, response: ServerResponse, url: URL) {
-    const advanceMatch = url.pathname.match(/^\/api\/attempts\/([^/]+)\/advance$/);
-    if (request.method === "GET" && advanceMatch) {
+    if (request.method === "GET" && url.pathname === "/api/sessions/advance") {
       const session = await deps.getSession(url, request);
       if (!session) {
         deps.badRequest(response, "Missing or invalid session");
         return true;
       }
 
-      const attemptId = decodeURIComponent(advanceMatch[1]);
+      const attemptId = session.attemptId;
+      if (!attemptId) {
+        deps.badRequest(response, "Session is not attached to an attempt");
+        return true;
+      }
+
       const advance = await deps.resolveAdvance({
         attemptId,
         currentSessionId: session.id,

--- a/apps/hosted-sites/src/runtime/orchestrator-client.ts
+++ b/apps/hosted-sites/src/runtime/orchestrator-client.ts
@@ -1,7 +1,6 @@
-import type { HostedAttemptReadModel } from "@agentbench/shared";
 import type { HostedWebScoreResult } from "@agentbench/scoring";
 import type { IncomingMessage } from "node:http";
-import type { HostedAttemptOverviewSession, HostedSession } from "./types.js";
+import type { HostedSession } from "./types.js";
 import type { PersistedHostedSession } from "./session-store.js";
 
 function resolveHostedUrl(baseUrl: string, path: string) {
@@ -162,12 +161,6 @@ export function createOrchestratorClient(deps: OrchestratorClientDeps) {
     }>(`/api/attempts/${encodeURIComponent(params.attemptId)}/commands/timeout`, params);
   }
 
-  async function getAttemptOverview(attemptId: string) {
-    return getOrchestratorState<HostedAttemptReadModel<HostedAttemptOverviewSession>>(
-      `/api/attempts/${encodeURIComponent(attemptId)}/state`,
-    );
-  }
-
   async function resolveAdvance(params: {
     attemptId: string;
     currentSessionId: string;
@@ -191,7 +184,6 @@ export function createOrchestratorClient(deps: OrchestratorClientDeps) {
     recordSessionAccess,
     recordHostedEvent,
     timeoutAttempt,
-    getAttemptOverview,
     resolveAdvance,
   };
 }

--- a/apps/hosted-sites/tests/unit/routes/attempts.test.ts
+++ b/apps/hosted-sites/tests/unit/routes/attempts.test.ts
@@ -68,14 +68,24 @@ test("attempt overview page is not exposed as a second suite navigation surface"
   });
 });
 
-test("attempt advance API remains available", async () => {
+test("session advance API derives the attempt from the tokenized session", async () => {
   await withAttemptsServer(async (baseUrl, calls) => {
-    const response = await fetch(`${baseUrl}/api/attempts/attempt-1/advance?session=tok_1`);
+    const response = await fetch(`${baseUrl}/api/sessions/advance?session=tok_1`);
     const body = await response.json();
 
     assert.equal(response.status, 200);
     assert.equal(calls.getSession, 1);
     assert.equal(calls.resolveAdvance, 1);
     assert.equal(body.nextSessionId, "session-2");
+  });
+});
+
+test("old attempt-scoped browser advance route is not exposed", async () => {
+  await withAttemptsServer(async (baseUrl, calls) => {
+    const response = await fetch(`${baseUrl}/api/attempts/attempt-1/advance?session=tok_1`);
+
+    assert.equal(response.status, 404);
+    assert.equal(calls.getSession, 0);
+    assert.equal(calls.resolveAdvance, 0);
   });
 });

--- a/apps/web/lib/hosted-web.ts
+++ b/apps/web/lib/hosted-web.ts
@@ -112,8 +112,8 @@ function toAttemptConnection(params: {
     suiteVersion: params.attempt.suiteVersion,
     orchestratorUrl: activeSession?.startUrl ?? null,
     advanceUrl:
-      activeSession && params.attempt.id && activeSession.token
-        ? `${baseUrl}/api/attempts/${encodeURIComponent(params.attempt.id)}/advance?session=${encodeURIComponent(activeSession.token)}`
+      activeSession?.token
+        ? `${baseUrl}/api/sessions/advance?session=${encodeURIComponent(activeSession.token)}`
         : null,
     activeSessionId: activeSession?.sessionId ?? null,
     progress: {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,8 +68,7 @@ The connection lasts at most 25 seconds and clients reconnect using `retry: 2000
 | `POST` | `/api/telemetry` | Persist and forward a hosted event |
 | `GET` | `/api/sessions/:token/score` | Evaluate current session state |
 | `POST` | `/api/sessions/:token/complete` | Evaluate and submit session completion |
-| `GET` | `/attempts/:attemptId?session=...` | Render attempt overview |
-| `GET` | `/api/attempts/:attemptId/advance?session=...` | Resolve next task URL |
+| `GET` | `/api/sessions/advance?session=...` | Resolve the next task URL from the opaque session token |
 
 ### Create Session
 

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -12,7 +12,7 @@ After a session becomes `completed` or `failed`:
 - active forms become read-only result views;
 - score APIs return the persisted hosted result rather than recalculating mutable state;
 - duplicate completion returns the first persisted result;
-- viewer, attempt overview, public result, and database rows report the same terminal score.
+- viewer, run connection payload, public result, and database rows report the same terminal score.
 
 A retryable task requires an explicit draft/finalize protocol and a new task or suite version.
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -145,12 +145,12 @@ Web completion is not part of the terminal transaction. The database trigger cre
 
 ## 6. Advance Resolution
 
-`GET /api/attempts/:id/advance?session=...` reaches hosted-sites through the default Nginx route. Hosted-sites sends an authenticated `resolve-advance` request to the orchestrator. This read handler verifies the current session against durable attempt state and returns either:
+`GET /api/sessions/advance?session=...` reaches hosted-sites through the default Nginx route. Hosted-sites resolves the opaque session token, derives the durable attempt ID from the recovered session, and sends an authenticated `resolve-advance` request to the orchestrator. This read handler verifies the current session against durable attempt state and returns either:
 
 - `complete: true` with no next URL, or
 - the next session ID and tokenized start URL.
 
-The client does not calculate suite ordering from URLs, Redis state, or its local history.
+The browser-facing URL never needs an attempt ID. The client does not calculate suite ordering from URLs, Redis state, or its local history; retry and current-attempt selection remain orchestrator-owned.
 
 ## 7. Expiry, Cleanup, and Recovery
 


### PR DESCRIPTION
## Summary
- change browser-facing hosted advance routing to `/api/sessions/advance?session=...`
- derive the attempt ID from the recovered session before calling orchestrator commands
- remove unused hosted-sites attempt overview client code
- update hosted API, data-flow, testing, and agent guidance docs

## Verification
- pnpm --filter hosted-sites test
- pnpm --filter web test
- pnpm verify:ci