### PR TITLE
fix(infra): harden hosted deploy and isolate Redis

### DIFF
--- a/.github/workflows/deploy-hosted-sites.yml
+++ b/.github/workflows/deploy-hosted-sites.yml
@@ -19,6 +19,7 @@ on:
       - 'infra/nginx/**'
       - 'infra/scripts/classify-hosted-deploy-changes.sh'
       - 'infra/scripts/deploy-hosted-stack.sh'
+      - 'infra/scripts/registry-retry.sh'
       - 'infra/scripts/verify-orchestrator-worker-recovery.sh'
       - 'infra/scripts/validate-orchestrator-partitions.sh'
       - 'package.json'

--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -37,7 +37,7 @@ const runnerSharedSecret = process.env.RUNNER_SHARED_SECRET;
 const viewerTokenSecret = process.env.HOSTED_VIEWER_SECRET ?? runnerSharedSecret;
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const orchestratorRedisUrl = process.env.ORCHESTRATOR_REDIS_URL ?? process.env.REDIS_URL;
+const orchestratorRedisUrl = process.env.ORCHESTRATOR_REDIS_URL;
 const orchestratorMode = (process.env.ORCHESTRATOR_MODE ?? "all") as CommandBackboneRole;
 const orchestratorPartitionCount = Math.trunc(envNumber("ORCHESTRATOR_PARTITION_COUNT", 16));
 
@@ -1198,7 +1198,7 @@ async function persistCommandDeadLetter(deadLetter: CommandDeadLetter) {
 }
 
 if (!orchestratorRedisUrl) {
-  throw new Error("ORCHESTRATOR_REDIS_URL or REDIS_URL is required for the orchestrator command backbone.");
+  throw new Error("ORCHESTRATOR_REDIS_URL is required for the orchestrator command backbone.");
 }
 
 const commandBackbone = createCommandBackbone({

--- a/apps/hosted-sites/src/server.ts
+++ b/apps/hosted-sites/src/server.ts
@@ -34,7 +34,7 @@ const agentbenchWebUrl = process.env.AGENTBENCH_WEB_URL ?? "http://localhost:300
 const runnerSharedSecret = process.env.RUNNER_SHARED_SECRET;
 const viewerTokenSecret = process.env.HOSTED_VIEWER_SECRET ?? runnerSharedSecret;
 const instanceId = process.env.HOSTED_SITES_INSTANCE_ID ?? `${hostname()}:${process.pid}`;
-const redisUrl = process.env.HOSTED_SESSION_REDIS_URL ?? process.env.REDIS_URL;
+const redisUrl = process.env.HOSTED_SESSION_REDIS_URL;
 const sessionRedisTtlMs = Number(process.env.HOSTED_SESSION_REDIS_TTL_MS ?? 1000 * 60 * 60 * 6);
 
 const sessions = new Map<string, HostedSession>();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
       RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET:-}
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
-      ORCHESTRATOR_REDIS_URL: redis://redis:6379
+      ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379
       ORCHESTRATOR_MODE: api
       ORCHESTRATOR_PARTITION_COUNT: 16
     depends_on:
-      - redis
+      - orchestrator-redis
     restart: unless-stopped
 
   hosted-orchestrator-worker-0:
@@ -29,12 +29,12 @@ services:
       RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET:-}
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
-      ORCHESTRATOR_REDIS_URL: redis://redis:6379
+      ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379
       ORCHESTRATOR_MODE: worker
       ORCHESTRATOR_PARTITION_COUNT: 16
       ORCHESTRATOR_WORKER_PARTITIONS: 0,1,2,3,4,5,6,7
     depends_on:
-      - redis
+      - orchestrator-redis
     restart: unless-stopped
 
   hosted-orchestrator-worker-1:
@@ -45,12 +45,12 @@ services:
       RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET:-}
       SUPABASE_URL: ${SUPABASE_URL:-}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
-      ORCHESTRATOR_REDIS_URL: redis://redis:6379
+      ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379
       ORCHESTRATOR_MODE: worker
       ORCHESTRATOR_PARTITION_COUNT: 16
       ORCHESTRATOR_WORKER_PARTITIONS: 8,9,10,11,12,13,14,15
     depends_on:
-      - redis
+      - orchestrator-redis
     restart: unless-stopped
 
   hosted-sites:
@@ -63,12 +63,16 @@ services:
       HOSTED_ORCHESTRATOR_URL: http://hosted-orchestrator:3004
       AGENTBENCH_WEB_URL: ${AGENTBENCH_WEB_URL:-}
       RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET:-}
-      HOSTED_SESSION_REDIS_URL: redis://redis:6379
+      HOSTED_SESSION_REDIS_URL: redis://session-redis:6379
     depends_on:
-      - redis
+      - session-redis
     restart: unless-stopped
 
-  redis:
+  session-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  orchestrator-redis:
     image: redis:7-alpine
     restart: unless-stopped
 
@@ -83,5 +87,6 @@ services:
       - hosted-orchestrator-worker-0
       - hosted-orchestrator-worker-1
       - hosted-sites
-      - redis
+      - session-redis
+      - orchestrator-redis
     restart: unless-stopped

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,9 +73,9 @@ The deployment profile matters:
 
 ### Redis
 
-Redis has two logically separate responsibilities. Versioned session keys provide the shared runtime state used by hosted-sites replicas. Sixteen partitioned Streams form the orchestrator command transport. Stable entity hashing preserves order for one attempt/session while disjoint workers process partitions concurrently. Redis leases prevent overlapping worker ownership.
+Redis has two separate workload contracts. `HOSTED_SESSION_REDIS_URL` points hosted-sites at the session runtime cache, while `ORCHESTRATOR_REDIS_URL` points orchestrator API/workers at the command Stream deployment. Versioned session keys provide the shared runtime state used by hosted-sites replicas. Sixteen partitioned Streams form the orchestrator command transport. Stable entity hashing preserves order for one attempt/session while disjoint workers process partitions concurrently. Redis leases prevent overlapping worker ownership.
 
-The current deployment places both responsibilities in one Redis instance and separates them only by key namespace. It does not yet configure a persistent volume, AOF, independent memory policies, replication, or failover. Redis therefore provides shared runtime coordination, not a durable system of record. See [Consistency and Failure](./consistency-and-failure.md) for the exact guarantees and [Roadmap](./roadmap.md) for planned hardening.
+Local and server Compose run `session-redis` and `orchestrator-redis` as distinct services by default. The server Compose file keeps an explicit `redis-compat` profile for one-instance operator experiments, but production deployments do not use `REDIS_URL` fallback. The Redis services still do not configure AOF, independent memory policies, replication, or failover. Redis therefore provides runtime coordination, not a durable system of record. See [Consistency and Failure](./consistency-and-failure.md) for the exact guarantees and [Roadmap](./roadmap.md) for planned hardening.
 
 ### Supabase
 

--- a/docs/consistency-and-failure.md
+++ b/docs/consistency-and-failure.md
@@ -64,8 +64,9 @@ Hosted events, Web run events, snapshots, and access records travel through sepa
 | one orchestrator API exits | gateway/API retry can use another replica when deployed | in-flight HTTP response | retry with stable `x-command-id` where supported |
 | one worker exits | pending entries remain in the consumer group | command latency | restart worker; stale entries are reclaimed |
 | partition lease disappears | readiness reports missing partition; worker exits after lost renewal | command availability for that partition | restore one owner for the partition |
-| Redis connection interruption | session requests may use a local copy or orchestrator-mediated database recovery; command API can fail or time out | latest runtime state and unpersisted commands | restore Redis, then reconcile against PostgreSQL |
-| Redis container replacement | no configured persistent-volume guarantee | active sessions, Streams, replies, retry state | recover persisted snapshots; manually assess missing commands |
+| Session Redis interruption | session requests may use a local copy or orchestrator-mediated database recovery | latest runtime session state not yet snapshotted | restore session Redis, then recover from PostgreSQL snapshots where possible |
+| Orchestrator Redis interruption | command API can fail or time out; workers stop consuming Streams | unpersisted commands, replies, retry state | restore orchestrator Redis, then reconcile against PostgreSQL |
+| Redis container replacement | no configured persistent-volume guarantee for either Redis workload | active sessions, Streams, replies, retry state | recover persisted snapshots; manually assess missing commands |
 | snapshot command fails | Redis request may still complete | newest app-state recovery point | retry/reconcile; do not claim zero-RPO recovery |
 | terminal command repeats | PostgreSQL transaction/unique constraints return the winner | none after first commit | safe retry |
 | Web completion callback fails | outbox remains pending/dead after retries | Web status freshness | maintenance retry, inspect dead outbox row |
@@ -81,9 +82,9 @@ Hosted events, Web run events, snapshots, and access records travel through sepa
 
 ## Planned Hardening
 
-- [Issue #60](https://github.com/Kaiwen0418/agent-benchmark/issues/60): persistence, capacity policy, workload separation, observability, and HA.
+- [Issue #60](https://github.com/Kaiwen0418/agent-benchmark/issues/60): workload separation is complete; persistence, capacity policy, observability, and HA remain future hardening.
 - [Issue #61](https://github.com/Kaiwen0418/agent-benchmark/issues/61): revisioned atomic session mutation and stale-snapshot rejection.
 - [Issue #62](https://github.com/Kaiwen0418/agent-benchmark/issues/62): ACLs, token hashing, credential minimization, and network isolation.
 - [Issue #59](https://github.com/Kaiwen0418/agent-benchmark/issues/59): final service/database ownership boundaries.
 
-Until these issues are complete, documentation must describe Redis as shared runtime state and command transport, not as a zero-loss durable backbone.
+Until the remaining Redis hardening issues are complete, documentation must describe Redis as runtime state and command transport, not as a zero-loss durable backbone.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,7 +25,7 @@ Run multiple hosted-sites and orchestrator API replicas locally:
 docker-compose up -d --build --scale hosted-sites=4 --scale hosted-orchestrator=2
 ```
 
-Redis uses `HOSTED_SESSION_REDIS_URL=redis://redis:6379` for session cache and `ORCHESTRATOR_REDIS_URL=redis://redis:6379` for command Streams. Supabase remains the durable persistence store; orchestrator workers are its hosted-data writers.
+Redis workloads are configured independently. Hosted-sites uses `HOSTED_SESSION_REDIS_URL=redis://session-redis:6379` for the session cache. Orchestrator API/workers use `ORCHESTRATOR_REDIS_URL=redis://orchestrator-redis:6379` for command Streams, locks, and response envelopes. Supabase remains the durable persistence store; orchestrator workers are its hosted-data writers.
 
 The local Compose topology runs two workers: partitions `0-7` and `8-15`. Do not use `--scale` on a worker service because replicas would claim the same partitions. To add workers, define additional worker services and redistribute all partitions into disjoint sets. Readiness returns `503` while any partition has no active lease.
 
@@ -46,20 +46,22 @@ Do not publish a fixed host port for each hosted-sites replica. Nginx should rea
 
 `deploy-hosted-sites.yml` classifies each push before building or pulling images:
 
-- `apps/hosted-sites/**` builds, pulls, and recreates only hosted-sites.
-- `apps/hosted-orchestrator/**` builds one image, then pulls and recreates the orchestrator API and both workers.
+- `apps/hosted-sites/**` builds, pulls, and recreates only hosted-sites and the session-cache client path.
+- `apps/hosted-orchestrator/**` builds one image, then pulls and recreates only the orchestrator API and both command workers.
 - shared scoring/runtime packages rebuild both images.
 - Nginx changes recreate only the gateway.
-- Compose topology changes reconcile all services without pulling unaffected application images.
+- Compose topology changes pre-pull every required target image, then reconcile all services.
 
 Hosted-sites and orchestrator use independent image tags. Targeted deploys preserve the currently running replica counts, so scaling one service does not restart or resize the other. The orchestrator API and workers always use the same immutable image tag within one environment.
+
+Before replacing any running service, the deploy script authenticates to GHCR and pulls every required target image with bounded exponential-backoff retries. Transient registry/network failures such as timeouts, DNS failures, connection resets, 429s, and 5xx responses retry. Permanent authentication failures and missing manifests fail promptly. If the retry budget is exhausted, the script exits before `docker compose up`, leaving the previous healthy stack serving traffic.
 
 ## Production Topology
 
 The production deployment is split into:
 
 - web on Vercel
-- hosted-sites, orchestrator API/workers, Redis, and Nginx on a private Linux host
+- hosted-sites, orchestrator API/workers, session Redis, orchestrator Redis, and Nginx on a private Linux host
 - Supabase for durable application data
 - GHCR for hosted runtime images
 - Cloudflare Tunnel for environment-specific public ingress and TLS
@@ -158,3 +160,11 @@ Normal application deployments should not require SSH access. Manual interventio
 - broken host networking or unavailable external dependencies
 
 Inspect the self-hosted Actions job and container logs before changing server state manually.
+
+If GHCR remains unavailable after the retry budget:
+
+- confirm whether the final classification is `registry-auth`, `registry-missing-image`, or `registry-transient`;
+- for `registry-auth`, rotate or restore `GHCR_PAT`/`GHCR_USERNAME` before rerunning the workflow;
+- for `registry-missing-image`, verify the image build job produced the immutable tag before rerunning deploy;
+- for `registry-transient`, leave the current Compose stack running and rerun the workflow after registry/network recovery;
+- do not manually recreate application services until the required target images are present locally.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ This roadmap starts from the architecture that is already running. Completed wor
 - External agents own their browser; AgentBench does not run arbitrary agent code.
 - `apps/web` runs on Vercel and owns run creation, quota, live observability, replay, and artifacts.
 - The hosted stack runs behind Nginx and Cloudflare Tunnel on a private Linux host.
-- Redis provides the shared hosted-session cache and 16 partitioned orchestrator command Streams.
+- Redis is split into a hosted-session cache endpoint and an orchestrator command-Streams endpoint.
 - Supabase is the durable lifecycle, audit, and scoring store.
 - Hosted-orchestrator is the sole hosted lifecycle database owner; hosted-sites has no database credential and Web uses orchestrator APIs or public read models for hosted data.
 - Attempt initialization is database-first and protected by a unique hosted-attempt constraint plus a short Redis lease.
@@ -80,6 +80,7 @@ P0 completion criterion: after any single-process failure or command retry, the 
 - Separate liveness from readiness; readiness should cover Redis, partition ownership, and required Supabase access.
 - Define alert thresholds and an operator runbook for queue backlog, callback failure, migration failure, disk pressure, and Redis recovery.
 - Test backup/restore and disaster recovery for Supabase records and Redis-backed active sessions.
+- Deployment retries transient registry/network failures before replacing containers, and Redis session/command workloads are independently addressed for capacity and failure analysis.
 
 Completion criteria: an operator can identify a stuck attempt and its last durable command without reading unstructured container logs.
 

--- a/infra/docker/docker-compose.server.yml
+++ b/infra/docker/docker-compose.server.yml
@@ -9,7 +9,7 @@ x-orchestrator-environment: &orchestrator-environment
   RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET}
   SUPABASE_URL: ${SUPABASE_URL}
   SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
-  ORCHESTRATOR_REDIS_URL: ${ORCHESTRATOR_REDIS_URL:-redis://redis:6379}
+  ORCHESTRATOR_REDIS_URL: ${ORCHESTRATOR_REDIS_URL}
   ORCHESTRATOR_PARTITION_COUNT: ${ORCHESTRATOR_PARTITION_COUNT:-16}
   HOSTED_SESSION_SWEEP_INTERVAL_MS: ${HOSTED_SESSION_SWEEP_INTERVAL_MS:-60000}
   HOSTED_ACCESS_LOG_RETENTION_MS: ${HOSTED_ACCESS_LOG_RETENTION_MS:-1209600000}
@@ -21,7 +21,7 @@ services:
       <<: *orchestrator-environment
       ORCHESTRATOR_MODE: api
     depends_on:
-      - redis
+      - orchestrator-redis
     restart: unless-stopped
 
   hosted-orchestrator-worker-0:
@@ -31,7 +31,7 @@ services:
       ORCHESTRATOR_MODE: worker
       ORCHESTRATOR_WORKER_PARTITIONS: ${ORCHESTRATOR_WORKER_0_PARTITIONS:-0,1,2,3,4,5,6,7}
     depends_on:
-      - redis
+      - orchestrator-redis
     restart: unless-stopped
 
   hosted-orchestrator-worker-1:
@@ -41,7 +41,7 @@ services:
       ORCHESTRATOR_MODE: worker
       ORCHESTRATOR_WORKER_PARTITIONS: ${ORCHESTRATOR_WORKER_1_PARTITIONS:-8,9,10,11,12,13,14,15}
     depends_on:
-      - redis
+      - orchestrator-redis
     restart: unless-stopped
 
   hosted-sites:
@@ -55,14 +55,24 @@ services:
       HOSTED_SESSION_SWEEP_INTERVAL_MS: ${HOSTED_SESSION_SWEEP_INTERVAL_MS:-60000}
       HOSTED_SESSION_TERMINAL_RETENTION_MS: ${HOSTED_SESSION_TERMINAL_RETENTION_MS:-1800000}
       HOSTED_ACCESS_LOG_RETENTION_MS: ${HOSTED_ACCESS_LOG_RETENTION_MS:-1209600000}
-      HOSTED_SESSION_REDIS_URL: ${HOSTED_SESSION_REDIS_URL:-redis://redis:6379}
+      HOSTED_SESSION_REDIS_URL: ${HOSTED_SESSION_REDIS_URL}
       HOSTED_SESSION_REDIS_TTL_MS: ${HOSTED_SESSION_REDIS_TTL_MS:-21600000}
     depends_on:
-      - redis
+      - session-redis
+    restart: unless-stopped
+
+  session-redis:
+    image: ${HOSTED_SESSION_REDIS_IMAGE:-redis:7-alpine}
+    restart: unless-stopped
+
+  orchestrator-redis:
+    image: ${ORCHESTRATOR_REDIS_IMAGE:-redis:7-alpine}
     restart: unless-stopped
 
   redis:
     image: ${REDIS_IMAGE:-redis:7-alpine}
+    profiles:
+      - redis-compat
     restart: unless-stopped
 
   gateway:
@@ -77,5 +87,6 @@ services:
       - hosted-orchestrator-worker-0
       - hosted-orchestrator-worker-1
       - hosted-sites
-      - redis
+      - session-redis
+      - orchestrator-redis
     restart: unless-stopped

--- a/infra/scripts/classify-hosted-deploy-changes.sh
+++ b/infra/scripts/classify-hosted-deploy-changes.sh
@@ -39,6 +39,7 @@ if matches_any '^infra/nginx/'; then
 fi
 if matches_any '^infra/docker/docker-compose\.server\.yml$' \
   '^infra/scripts/deploy-hosted-stack\.sh$' \
+  '^infra/scripts/registry-retry\.sh$' \
   '^infra/scripts/verify-orchestrator-worker-recovery\.sh$' \
   '^infra/scripts/validate-orchestrator-partitions\.sh$'; then
   topology=true

--- a/infra/scripts/deploy-hosted-stack.sh
+++ b/infra/scripts/deploy-hosted-stack.sh
@@ -81,6 +81,8 @@ fi
 
 ENV_FILE="${RUNNER_TEMP:-/tmp}/agentbench-${DEPLOYMENT_ENVIRONMENT}.env.server"
 COMPOSE_FILE="infra/docker/docker-compose.server.yml"
+# shellcheck source=registry-retry.sh
+source "infra/scripts/registry-retry.sh"
 cat > "${ENV_FILE}" <<EOF
 COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}
 HOSTED_SITES_IMAGE=${HOSTED_IMAGE}
@@ -94,13 +96,14 @@ HOSTED_ORCHESTRATOR_URL=http://hosted-orchestrator:3004
 HOSTED_ORCHESTRATOR_PUBLIC_URL=${HOSTED_ORCHESTRATOR_PUBLIC_URL}
 SUPABASE_URL=${SUPABASE_URL}
 SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
-HOSTED_SESSION_REDIS_URL=redis://redis:6379
-ORCHESTRATOR_REDIS_URL=redis://redis:6379
+HOSTED_SESSION_REDIS_URL=redis://session-redis:6379
+ORCHESTRATOR_REDIS_URL=redis://orchestrator-redis:6379
 ORCHESTRATOR_PARTITION_COUNT=${ORCHESTRATOR_PARTITION_COUNT}
 ORCHESTRATOR_WORKER_0_PARTITIONS=${ORCHESTRATOR_WORKER_0_PARTITIONS}
 ORCHESTRATOR_WORKER_1_PARTITIONS=${ORCHESTRATOR_WORKER_1_PARTITIONS}
 HOSTED_SESSION_REDIS_TTL_MS=21600000
-REDIS_IMAGE=redis:7-alpine
+HOSTED_SESSION_REDIS_IMAGE=redis:7-alpine
+ORCHESTRATOR_REDIS_IMAGE=redis:7-alpine
 GATEWAY_HTTP_PORT=${GATEWAY_HTTP_PORT}
 GATEWAY_IMAGE=${GATEWAY_IMAGE}
 GATEWAY_PLATFORM=${GATEWAY_PLATFORM}
@@ -131,7 +134,7 @@ compose config > "${RUNNER_TEMP:-/tmp}/agentbench-${DEPLOYMENT_ENVIRONMENT}-comp
 
 dump_deploy_logs() {
   echo "---- deployment ----"
-  echo "environment=${DEPLOYMENT_ENVIRONMENT} project=${COMPOSE_PROJECT_NAME} channel=${IMAGE_CHANNEL} port=${GATEWAY_HTTP_PORT}"
+  echo "environment=${DEPLOYMENT_ENVIRONMENT} project=${COMPOSE_PROJECT_NAME} channel=${IMAGE_CHANNEL} port=${GATEWAY_HTTP_PORT} failure_stage=${failure_stage:-unknown}"
   echo "---- host architecture ----"
   uname -a || true
   echo "gateway image=${GATEWAY_IMAGE} platform=${GATEWAY_PLATFORM}"
@@ -146,15 +149,17 @@ dump_deploy_logs() {
   (ss -ltnp 2>/dev/null || netstat -ltnp 2>/dev/null || true) | grep -E ":${GATEWAY_HTTP_PORT}\\b" || true
   echo "---- compose logs ----"
   compose logs --tail=160 gateway hosted-sites hosted-orchestrator \
-    hosted-orchestrator-worker-0 hosted-orchestrator-worker-1 redis || true
+    hosted-orchestrator-worker-0 hosted-orchestrator-worker-1 session-redis orchestrator-redis || true
 }
 
 deploy_status=0
+failure_stage=preflight
 trap 'deploy_status=$?; if [[ "${deploy_status}" -ne 0 ]]; then dump_deploy_logs; fi; rm -f "${ENV_FILE}"' EXIT
 
 PREVIOUS_ORCHESTRATOR_IMAGE="$(service_image_evidence hosted-orchestrator)"
 
-printf '%s' "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+failure_stage=registry
+registry_retry_command "ghcr-login" bash -c 'printf "%s" "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin'
 HOSTED_REPLICAS="$(compose ps -q hosted-sites 2>/dev/null | wc -l | tr -d ' ')"
 HOSTED_REPLICAS="${HOSTED_REPLICAS:-1}"
 [[ "${HOSTED_REPLICAS}" -gt 0 ]] || HOSTED_REPLICAS=1
@@ -163,26 +168,72 @@ echo "Deploying ${DEPLOYMENT_ENVIRONMENT}: project=${COMPOSE_PROJECT_NAME}, chan
 echo "Targets: hosted-sites=${HOSTED_SITES_CHANGED}, orchestrator=${ORCHESTRATOR_CHANGED}, nginx=${INFRA_CHANGED}, topology=${TOPOLOGY_CHANGED}"
 echo "Image tags: hosted-sites=${HOSTED_SITES_IMAGE_TAG}, orchestrator=${HOSTED_ORCHESTRATOR_IMAGE_TAG}"
 
+declare -a pull_services=()
+gateway_pull_required=false
+
+append_pull_service() {
+  local service="$1"
+  local existing
+  for existing in "${pull_services[@]}"; do
+    if [[ "${existing}" == "${service}" ]]; then
+      return
+    fi
+  done
+  pull_services+=("${service}")
+}
+
 if [[ "${HOSTED_SITES_CHANGED}" == "true" ]]; then
-  compose pull hosted-sites
+  append_pull_service hosted-sites
+fi
+
+if [[ "${ORCHESTRATOR_CHANGED}" == "true" ]]; then
+  append_pull_service hosted-orchestrator
+  append_pull_service hosted-orchestrator-worker-0
+  append_pull_service hosted-orchestrator-worker-1
+fi
+
+if [[ "${INFRA_CHANGED}" == "true" ]]; then
+  append_pull_service session-redis
+  append_pull_service orchestrator-redis
+  gateway_pull_required=true
+fi
+
+if [[ "${TOPOLOGY_CHANGED}" == "true" ]]; then
+  append_pull_service session-redis
+  append_pull_service orchestrator-redis
+  append_pull_service hosted-sites
+  append_pull_service hosted-orchestrator
+  append_pull_service hosted-orchestrator-worker-0
+  append_pull_service hosted-orchestrator-worker-1
+  gateway_pull_required=true
+fi
+
+if [[ "${#pull_services[@]}" -gt 0 ]]; then
+  registry_retry_command "compose-pull" compose pull "${pull_services[@]}"
+fi
+
+if [[ "${gateway_pull_required}" == "true" ]]; then
+  registry_retry_command "gateway-pull" docker pull --platform "${GATEWAY_PLATFORM}" "${GATEWAY_IMAGE}"
+  docker run --rm --platform "${GATEWAY_PLATFORM}" --entrypoint nginx "${GATEWAY_IMAGE}" -v
+fi
+
+failure_stage=compose
+if [[ "${HOSTED_SITES_CHANGED}" == "true" ]]; then
   compose up -d --remove-orphans --no-deps --scale "hosted-sites=${HOSTED_REPLICAS}" hosted-sites
 fi
 
 if [[ "${ORCHESTRATOR_CHANGED}" == "true" ]]; then
-  compose pull hosted-orchestrator hosted-orchestrator-worker-0 hosted-orchestrator-worker-1
   compose up -d --remove-orphans --no-deps \
     hosted-orchestrator hosted-orchestrator-worker-0 hosted-orchestrator-worker-1
 fi
 
 if [[ "${INFRA_CHANGED}" == "true" ]]; then
-  docker pull --platform "${GATEWAY_PLATFORM}" "${GATEWAY_IMAGE}"
-  docker run --rm --platform "${GATEWAY_PLATFORM}" --entrypoint nginx "${GATEWAY_IMAGE}" -v
-  compose up -d --remove-orphans redis
+  compose up -d --remove-orphans session-redis orchestrator-redis
   compose up -d --remove-orphans --force-recreate --no-deps gateway
 fi
 
 if [[ "${TOPOLOGY_CHANGED}" == "true" ]]; then
-  compose up -d --remove-orphans redis
+  compose up -d --remove-orphans session-redis orchestrator-redis
   compose up -d --remove-orphans --no-deps --scale "hosted-sites=${HOSTED_REPLICAS}" hosted-sites
   compose up -d --remove-orphans --no-deps \
     hosted-orchestrator hosted-orchestrator-worker-0 hosted-orchestrator-worker-1
@@ -191,6 +242,7 @@ fi
 
 compose ps
 
+failure_stage=smoke
 gateway_running() {
   local gateway_id
   gateway_id="$(compose ps -q gateway 2>/dev/null)"
@@ -224,6 +276,7 @@ if [[ "${smoke_ready}" != "true" ]]; then
 fi
 
 if [[ "${VERIFY_ORCHESTRATOR_WORKER_RECOVERY}" == "true" ]]; then
+  failure_stage=worker-recovery
   WORKER_RECOVERY_ENV_FILE="${ENV_FILE}" \
   WORKER_RECOVERY_COMPOSE_FILE="${COMPOSE_FILE}" \
   PREVIOUS_ORCHESTRATOR_IMAGE="${PREVIOUS_ORCHESTRATOR_IMAGE}" \
@@ -232,3 +285,5 @@ if [[ "${VERIFY_ORCHESTRATOR_WORKER_RECOVERY}" == "true" ]]; then
   ORCHESTRATOR_WORKER_1_PARTITIONS="${ORCHESTRATOR_WORKER_1_PARTITIONS}" \
     bash infra/scripts/verify-orchestrator-worker-recovery.sh
 fi
+
+failure_stage=complete

--- a/infra/scripts/registry-retry.sh
+++ b/infra/scripts/registry-retry.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+registry_failure_classification() {
+  local log_file="$1"
+  local content
+  content="$(tr '[:upper:]' '[:lower:]' < "${log_file}" 2>/dev/null || true)"
+
+  if grep -Eq 'unauthorized|authentication required|denied:|permission_denied|invalid username|incorrect username|forbidden' <<< "${content}"; then
+    printf 'registry-auth'
+    return
+  fi
+
+  if grep -Eq 'manifest unknown|not found|name unknown|repository does not exist|pull access denied' <<< "${content}"; then
+    printf 'registry-missing-image'
+    return
+  fi
+
+  if grep -Eq 'timeout|timed out|i/o timeout|tls handshake timeout|connection reset|connection refused|temporary failure|server misbehaving|no such host|service unavailable|too many requests|429|500|502|503|504|unexpected eof|net/http' <<< "${content}"; then
+    printf 'registry-transient'
+    return
+  fi
+
+  printf 'registry-unknown'
+}
+
+registry_retry_command() {
+  local label="$1"
+  local attempts="${REGISTRY_RETRY_ATTEMPTS:-4}"
+  local base_delay="${REGISTRY_RETRY_BASE_DELAY_SECONDS:-2}"
+  shift
+
+  local start_epoch
+  start_epoch="$(date +%s)"
+  local attempt
+  local log_file
+  log_file="$(mktemp "${RUNNER_TEMP:-/tmp}/agentbench-registry-${label//[^A-Za-z0-9_.-]/_}.XXXXXX")"
+
+  for attempt in $(seq 1 "${attempts}"); do
+    : > "${log_file}"
+    echo "registry step '${label}' attempt ${attempt}/${attempts}"
+    if "$@" >"${log_file}" 2>&1; then
+      local elapsed
+      elapsed="$(( $(date +%s) - start_epoch ))"
+      echo "registry step '${label}' succeeded after ${attempt}/${attempts} attempt(s), elapsed=${elapsed}s"
+      rm -f "${log_file}"
+      return 0
+    fi
+
+    local classification
+    classification="$(registry_failure_classification "${log_file}")"
+    echo "registry step '${label}' failed attempt ${attempt}/${attempts}: classification=${classification}" >&2
+
+    case "${classification}" in
+      registry-auth | registry-missing-image)
+        echo "registry step '${label}' is not retryable; failing promptly." >&2
+        sed -n '1,80p' "${log_file}" >&2 || true
+        rm -f "${log_file}"
+        return 1
+        ;;
+    esac
+
+    if [[ "${attempt}" -ge "${attempts}" ]]; then
+      local elapsed
+      elapsed="$(( $(date +%s) - start_epoch ))"
+      echo "registry step '${label}' exhausted retry budget: classification=${classification}, attempts=${attempts}, elapsed=${elapsed}s" >&2
+      sed -n '1,120p' "${log_file}" >&2 || true
+      rm -f "${log_file}"
+      return 1
+    fi
+
+    sleep "$(( base_delay * 2 ** (attempt - 1) ))"
+  done
+}

--- a/infra/scripts/verify-orchestrator-worker-recovery.sh
+++ b/infra/scripts/verify-orchestrator-worker-recovery.sh
@@ -126,7 +126,7 @@ queue_recovery_command() {
   local partition="$1"
   local command_id="$2"
   local partition_key="$3"
-  compose exec -T redis redis-cli --raw XADD \
+  compose exec -T orchestrator-redis redis-cli --raw XADD \
     "agentbench:orchestrator:commands:p${partition}" '*' \
     commandId "${command_id}" \
     type maintenance.cleanup \
@@ -139,7 +139,7 @@ wait_for_command_result() {
   local result=""
   local attempt
   for attempt in $(seq 1 30); do
-    result="$(compose exec -T redis redis-cli --raw GET "agentbench:orchestrator:result:${command_id}" | tr -d '\r')"
+    result="$(compose exec -T orchestrator-redis redis-cli --raw GET "agentbench:orchestrator:result:${command_id}" | tr -d '\r')"
     if [[ -n "${result}" ]] && node -e '
       const result = JSON.parse(process.argv[1]);
       process.exit(result.commandId === process.argv[2] && result.statusCode === 200 ? 0 : 1);

--- a/scripts/test-deploy-classifier.sh
+++ b/scripts/test-deploy-classifier.sh
@@ -23,6 +23,7 @@ assert_classification '.github/workflows/deploy-hosted-sites.yml' $'hosted_sites
 assert_classification 'infra/nginx/hosted-sites.conf' $'hosted_sites=false\norchestrator=false\ninfra=true\ntopology=false'
 assert_classification 'infra/docker/docker-compose.server.yml' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
 assert_classification 'infra/scripts/deploy-hosted-stack.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
+assert_classification 'infra/scripts/registry-retry.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
 assert_classification 'infra/scripts/verify-orchestrator-worker-recovery.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
 assert_classification 'infra/scripts/validate-orchestrator-partitions.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
 assert_classification 'docs/deployment.md' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=false'

--- a/scripts/test-redis-topology.sh
+++ b/scripts/test-redis-topology.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "docker compose plugin or docker-compose is required for redis topology tests." >&2
+  exit 127
+fi
+
+if rg -n 'process\.env\.REDIS_URL|ORCHESTRATOR_REDIS_URL or REDIS_URL|HOSTED_SESSION_REDIS_URL \?\?' \
+  apps/hosted-sites/src apps/hosted-orchestrator/src >/tmp/agentbench-redis-fallbacks.txt; then
+  cat /tmp/agentbench-redis-fallbacks.txt >&2
+  echo "runtime code must not fall back to shared REDIS_URL" >&2
+  exit 1
+fi
+
+if ! rg -q '"hosted-sites:session:"' apps/hosted-sites/src/runtime/session-cache.ts; then
+  echo "hosted-sites session cache namespace changed or is missing" >&2
+  exit 1
+fi
+if ! rg -q 'agentbench:orchestrator:' apps/hosted-orchestrator/src/command-backbone.ts; then
+  echo "orchestrator command namespace changed or is missing" >&2
+  exit 1
+fi
+if rg -n 'agentbench:orchestrator:' apps/hosted-sites/src >/tmp/agentbench-redis-fallbacks.txt; then
+  cat /tmp/agentbench-redis-fallbacks.txt >&2
+  echo "hosted-sites must not issue orchestrator Redis commands" >&2
+  exit 1
+fi
+if rg -n 'hosted-sites:session:' apps/hosted-orchestrator/src >/tmp/agentbench-redis-fallbacks.txt; then
+  cat /tmp/agentbench-redis-fallbacks.txt >&2
+  echo "orchestrator must not issue hosted-sites session cache commands" >&2
+  exit 1
+fi
+
+local_config="$("${COMPOSE[@]}" -f docker-compose.yml config)"
+if ! grep -q 'HOSTED_SESSION_REDIS_URL: redis://session-redis:6379' <<< "${local_config}"; then
+  echo "local hosted-sites must use session-redis" >&2
+  exit 1
+fi
+if ! grep -q 'ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379' <<< "${local_config}"; then
+  echo "local orchestrator must use orchestrator-redis" >&2
+  exit 1
+fi
+
+server_env="$(mktemp)"
+trap 'rm -f "${server_env}" /tmp/agentbench-redis-fallbacks.txt' EXIT
+cat > "${server_env}" <<'EOF'
+COMPOSE_PROJECT_NAME=agentbench-test
+HOSTED_ORCHESTRATOR_IMAGE=ghcr.io/example/agentbench-hosted-orchestrator
+HOSTED_ORCHESTRATOR_IMAGE_TAG=test
+HOSTED_ORCHESTRATOR_PUBLIC_URL=https://orchestrator.example.test
+HOSTED_SITES_IMAGE=ghcr.io/example/agentbench-hosted-sites
+HOSTED_SITES_IMAGE_TAG=test
+HOSTED_SITES_PUBLIC_URL=https://hosted.example.test
+HOSTED_ORCHESTRATOR_URL=http://hosted-orchestrator:3004
+AGENTBENCH_WEB_URL=https://web.example.test
+RUNNER_SHARED_SECRET=test-secret
+SUPABASE_URL=https://supabase.example.test
+SUPABASE_SERVICE_ROLE_KEY=test-service-role
+HOSTED_SESSION_REDIS_URL=redis://session-redis:6379
+ORCHESTRATOR_REDIS_URL=redis://orchestrator-redis:6379
+ORCHESTRATOR_PARTITION_COUNT=16
+ORCHESTRATOR_WORKER_0_PARTITIONS=0,1,2,3,4,5,6,7
+ORCHESTRATOR_WORKER_1_PARTITIONS=8,9,10,11,12,13,14,15
+GATEWAY_HTTP_PORT=18080
+GATEWAY_IMAGE=nginx:1.27-alpine
+GATEWAY_PLATFORM=linux/amd64
+EOF
+
+server_config="$("${COMPOSE[@]}" --env-file "${server_env}" -f infra/docker/docker-compose.server.yml config)"
+if ! grep -q 'HOSTED_SESSION_REDIS_URL: redis://session-redis:6379' <<< "${server_config}"; then
+  echo "server hosted-sites must use session-redis" >&2
+  exit 1
+fi
+if ! grep -q 'ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379' <<< "${server_config}"; then
+  echo "server orchestrator must use orchestrator-redis" >&2
+  exit 1
+fi
+if grep -q 'redis://redis:6379' <<< "${server_config}"; then
+  echo "server compose must not use shared redis compatibility endpoint by default" >&2
+  exit 1
+fi
+
+echo "redis topology tests passed"

--- a/scripts/test-redis-topology.sh
+++ b/scripts/test-redis-topology.sh
@@ -13,38 +13,38 @@ else
   exit 127
 fi
 
-if rg -n 'process\.env\.REDIS_URL|ORCHESTRATOR_REDIS_URL or REDIS_URL|HOSTED_SESSION_REDIS_URL \?\?' \
+if grep -REn 'process\.env\.REDIS_URL|ORCHESTRATOR_REDIS_URL or REDIS_URL|HOSTED_SESSION_REDIS_URL \?\?' \
   apps/hosted-sites/src apps/hosted-orchestrator/src >/tmp/agentbench-redis-fallbacks.txt; then
   cat /tmp/agentbench-redis-fallbacks.txt >&2
   echo "runtime code must not fall back to shared REDIS_URL" >&2
   exit 1
 fi
 
-if ! rg -q '"hosted-sites:session:"' apps/hosted-sites/src/runtime/session-cache.ts; then
+if ! grep -q '"hosted-sites:session:"' apps/hosted-sites/src/runtime/session-cache.ts; then
   echo "hosted-sites session cache namespace changed or is missing" >&2
   exit 1
 fi
-if ! rg -q 'agentbench:orchestrator:' apps/hosted-orchestrator/src/command-backbone.ts; then
+if ! grep -q 'agentbench:orchestrator:' apps/hosted-orchestrator/src/command-backbone.ts; then
   echo "orchestrator command namespace changed or is missing" >&2
   exit 1
 fi
-if rg -n 'agentbench:orchestrator:' apps/hosted-sites/src >/tmp/agentbench-redis-fallbacks.txt; then
+if grep -RFn 'agentbench:orchestrator:' apps/hosted-sites/src >/tmp/agentbench-redis-fallbacks.txt; then
   cat /tmp/agentbench-redis-fallbacks.txt >&2
   echo "hosted-sites must not issue orchestrator Redis commands" >&2
   exit 1
 fi
-if rg -n 'hosted-sites:session:' apps/hosted-orchestrator/src >/tmp/agentbench-redis-fallbacks.txt; then
+if grep -RFn 'hosted-sites:session:' apps/hosted-orchestrator/src >/tmp/agentbench-redis-fallbacks.txt; then
   cat /tmp/agentbench-redis-fallbacks.txt >&2
   echo "orchestrator must not issue hosted-sites session cache commands" >&2
   exit 1
 fi
 
 local_config="$("${COMPOSE[@]}" -f docker-compose.yml config)"
-if ! grep -q 'HOSTED_SESSION_REDIS_URL: redis://session-redis:6379' <<< "${local_config}"; then
+if ! grep -Eq 'HOSTED_SESSION_REDIS_URL(: |=|=).*redis://session-redis:6379' <<< "${local_config}"; then
   echo "local hosted-sites must use session-redis" >&2
   exit 1
 fi
-if ! grep -q 'ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379' <<< "${local_config}"; then
+if ! grep -Eq 'ORCHESTRATOR_REDIS_URL(: |=|=).*redis://orchestrator-redis:6379' <<< "${local_config}"; then
   echo "local orchestrator must use orchestrator-redis" >&2
   exit 1
 fi
@@ -74,12 +74,13 @@ GATEWAY_IMAGE=nginx:1.27-alpine
 GATEWAY_PLATFORM=linux/amd64
 EOF
 
-server_config="$("${COMPOSE[@]}" --env-file "${server_env}" -f infra/docker/docker-compose.server.yml config)"
-if ! grep -q 'HOSTED_SESSION_REDIS_URL: redis://session-redis:6379' <<< "${server_config}"; then
+server_config="$(env -u HOSTED_SESSION_REDIS_URL -u ORCHESTRATOR_REDIS_URL \
+  "${COMPOSE[@]}" --env-file "${server_env}" -f infra/docker/docker-compose.server.yml config)"
+if ! grep -Eq 'HOSTED_SESSION_REDIS_URL(: |=|=).*redis://session-redis:6379' <<< "${server_config}"; then
   echo "server hosted-sites must use session-redis" >&2
   exit 1
 fi
-if ! grep -q 'ORCHESTRATOR_REDIS_URL: redis://orchestrator-redis:6379' <<< "${server_config}"; then
+if ! grep -Eq 'ORCHESTRATOR_REDIS_URL(: |=|=).*redis://orchestrator-redis:6379' <<< "${server_config}"; then
   echo "server orchestrator must use orchestrator-redis" >&2
   exit 1
 fi

--- a/scripts/test-registry-retry.sh
+++ b/scripts/test-registry-retry.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../infra/scripts/registry-retry.sh
+source "${ROOT_DIR}/infra/scripts/registry-retry.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+write_log() {
+  local name="$1"
+  local content="$2"
+  printf '%s\n' "${content}" > "${tmp_dir}/${name}.log"
+  registry_failure_classification "${tmp_dir}/${name}.log"
+}
+
+[[ "$(write_log timeout 'net/http: TLS handshake timeout')" == "registry-transient" ]]
+[[ "$(write_log auth 'denied: permission_denied')" == "registry-auth" ]]
+[[ "$(write_log manifest 'manifest unknown')" == "registry-missing-image" ]]
+
+flaky_count=0
+flaky_command() {
+  flaky_count=$((flaky_count + 1))
+  if [[ "${flaky_count}" -lt 3 ]]; then
+    echo "Get https://ghcr.io/v2/: net/http: TLS handshake timeout" >&2
+    return 1
+  fi
+  return 0
+}
+
+REGISTRY_RETRY_ATTEMPTS=4 REGISTRY_RETRY_BASE_DELAY_SECONDS=0 registry_retry_command "flaky" flaky_command >/dev/null
+[[ "${flaky_count}" -eq 3 ]]
+
+auth_count=0
+auth_command() {
+  auth_count=$((auth_count + 1))
+  echo "denied: permission_denied" >&2
+  return 1
+}
+
+if REGISTRY_RETRY_ATTEMPTS=4 REGISTRY_RETRY_BASE_DELAY_SECONDS=0 registry_retry_command "auth" auth_command >/dev/null 2>&1; then
+  echo "non-retryable auth failure unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "${auth_count}" -eq 1 ]]
+
+exhaust_count=0
+exhaust_command() {
+  exhaust_count=$((exhaust_count + 1))
+  echo "connection reset by peer" >&2
+  return 1
+}
+
+if REGISTRY_RETRY_ATTEMPTS=3 REGISTRY_RETRY_BASE_DELAY_SECONDS=0 registry_retry_command "exhaust" exhaust_command >/dev/null 2>&1; then
+  echo "retry exhaustion unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "${exhaust_count}" -eq 3 ]]
+
+echo "registry retry tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -7,8 +7,14 @@ cd "${ROOT_DIR}"
 echo "== Deployment classifier =="
 bash scripts/test-deploy-classifier.sh
 
+echo "== Registry retry helper =="
+bash scripts/test-registry-retry.sh
+
 echo "== Orchestrator topology =="
 bash scripts/test-orchestrator-topology.sh
+
+echo "== Redis topology =="
+bash scripts/test-redis-topology.sh
 
 echo "== Web secret boundary =="
 bash scripts/check-web-secret-boundary.sh

--- a/tests/e2e/smoke-local.sh
+++ b/tests/e2e/smoke-local.sh
@@ -62,6 +62,7 @@ HOSTED_SITES_PORT="${HOSTED_PORT}" \
 HOSTED_SITES_PUBLIC_URL="${HOSTED_URL}" \
 HOSTED_ORCHESTRATOR_URL="${ORCHESTRATOR_URL}" \
 RUNNER_SHARED_SECRET="${SECRET}" \
+HOSTED_SESSION_REDIS_URL="${REDIS_URL}" \
 pnpm --filter hosted-sites exec tsx src/server.ts >"${LOG_DIR}/hosted-sites.log" 2>&1 &
 HOSTED_PID=$!
 


### PR DESCRIPTION
## Summary
- close #52 by adding classified bounded retries around GHCR login/pulls and pre-pulling all target images before compose recreate
- close #60 by separating session Redis and orchestrator Redis URLs/services with no shared REDIS_URL runtime fallback
- update worker recovery, local smoke, deploy classification, and docs for the new topology

## Verification
- pnpm verify:ci
- pnpm smoke:local
- pnpm --filter hosted-sites build
- pnpm --filter hosted-orchestrator build