### PR TITLE
[codex] Add wiki policy hosted testcase

### DIFF
--- a/apps/hosted-orchestrator/tests/unit/case-revisions.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/case-revisions.test.ts
@@ -6,7 +6,7 @@ import { resolveBenchmarkCaseRevision } from "../../src/case-revisions.js";
 const row = {
   id: "revision-1",
   case_id: "case-1",
-  revision: "hosted-web-suite-v2",
+  revision: "hosted-web-suite-v3",
   content_hash: "a".repeat(64),
   manifest: hostedWebSuiteMetadata,
 };

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v2");
+  assert.equal(suite.suiteVersion, "v3");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
@@ -45,7 +45,7 @@ test("wiki question variants declare typed answer contracts", () => {
     const config = variant.taskConfig as Record<string, unknown>;
     assert.equal("expectedAnswer" in config, false);
     const contract = config.answerContract as Record<string, unknown>;
-    assert.match(String(contract.kind), /^(date|duration|currency)$/);
+    assert.match(String(contract.kind), /^(date|duration|currency|text)$/);
     assert.equal(typeof contract.canonicalValue, "string");
     assert.match(String(contract.normalization), /^(trim|trim-casefold|trim-casefold-punctuation)$/);
     assert.equal(contract.sourceArticleSlug, config.targetArticleSlug);
@@ -55,7 +55,7 @@ test("wiki question variants declare typed answer contracts", () => {
 test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
-  const selectedByApp = new Map<string, Set<string>>();
+  const selectedBySession = new Map<string, Set<string>>();
   for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
@@ -63,18 +63,20 @@ test("scheduled development seeds cover every declared variant", () => {
     );
     for (const session of generated.sessions) {
       const generation = session.metadata.questionGeneration as Record<string, unknown>;
-      const selected = selectedByApp.get(session.app) ?? new Set<string>();
+      const key = `${session.app}/${session.taskSlug}`;
+      const selected = selectedBySession.get(key) ?? new Set<string>();
       selected.add(String(generation.variantId));
-      selectedByApp.set(session.app, selected);
+      selectedBySession.set(key, selected);
     }
   }
 
   for (const session of sessions) {
     const variants = (session.metadata as Record<string, unknown>).questionVariants as Array<Record<string, unknown>>;
+    const key = `${String(session.app)}/${String(session.taskSlug)}`;
     assert.deepEqual(
-      selectedByApp.get(String(session.app)),
+      selectedBySession.get(key),
       new Set(variants.map((variant) => String(variant.id))),
-      String(session.app),
+      key,
     );
   }
 });

--- a/apps/hosted-sites/src/apps/wiki-lite/answer-contract.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/answer-contract.ts
@@ -1,7 +1,7 @@
 import { configString, readQuestionSchemaVersion, readTaskConfig } from "../../runtime/question-config.js";
 import type { WikiArticle } from "./types.js";
 
-export type WikiAnswerKind = "date" | "duration" | "currency";
+export type WikiAnswerKind = "date" | "duration" | "currency" | "text";
 export type WikiAnswerNormalization = "trim" | "trim-casefold" | "trim-casefold-punctuation";
 
 export type WikiAnswerContract = {
@@ -12,7 +12,7 @@ export type WikiAnswerContract = {
   legacy: boolean;
 };
 
-const answerKinds = new Set<WikiAnswerKind>(["date", "duration", "currency"]);
+const answerKinds = new Set<WikiAnswerKind>(["date", "duration", "currency", "text"]);
 const normalizationPolicies = new Set<WikiAnswerNormalization>([
   "trim",
   "trim-casefold",

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,11 +29,12 @@ The homepage is now centered on one primary path:
 - run status starts at `waiting_for_agent`
 - the UI allocates a hosted attempt with one or more ordered hosted sessions
 - the connect page and JSON config expose an attempt-level hosted suite URL plus per-session details
-- the default benchmark case is a four-step hosted suite:
+- the default benchmark case is a five-session hosted suite:
   - `shopping-lite`
   - `forum-lite`
   - `repo-lite`
-  - `wiki-lite`
+  - `wiki-lite` release lookup
+  - `wiki-lite` policy lookup
 - for hosted-web runs, the agent uses the hosted suite URL as the main task surface
 - hosted-sites writes per-session results and the aggregated attempt score
 

--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -8,7 +8,7 @@ export const benchmarkOptions: Array<{
   {
     value: "hosted-web-suite",
     label: "Hosted Web Suite",
-    description: "Four-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite with server-side scoring.",
+    description: "Five-session hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite with server-side scoring.",
   },
 ];
 
@@ -48,7 +48,7 @@ export const docsSteps = [
   {
     step: "02",
     title: "Run the hosted suite",
-    body: "Use the same shopping-lite, forum-lite, repo-lite, and wiki-lite tasks across agents so results stay comparable.",
+    body: "Use the same shopping-lite, forum-lite, repo-lite, and wiki-lite release and policy tasks across agents so results stay comparable.",
   },
   {
     step: "03",

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -44,7 +44,7 @@ CI should enumerate declared variants directly instead of relying on a few rando
 - Every semantic variant produces the same result across all layouts and light/dark themes.
 - Route tests cover mutation, redirect, terminal rejection, and persisted-score behavior.
 - Orchestrator integration covers failed finalization, duplicate completion, suite aggregation, and callback idempotency.
-- Full lifecycle smoke reports selected variant IDs and verifies four persisted session results plus one aggregate score.
+- Full lifecycle smoke reports selected variant IDs and verifies one persisted session result per suite session plus one aggregate score.
 - A development-only scheduled sweep covers the complete pool without consuming production guest quota.
 
 CI must fail when a declared variant lacks both positive and negative scorer coverage. Development E2E must show that Web, hosted-sites, orchestrator, Redis, and Supabase converge on one terminal score.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,7 +97,7 @@ The current suite contains:
 - `shopping-lite`: constrained checkout
 - `forum-lite`: reply to and moderate a safety thread
 - `repo-lite`: update installation instructions and create a merge request
-- `wiki-lite`: retrieve and submit a release-history date
+- `wiki-lite`: retrieve and submit release-history and policy answers
 
 Create a standalone local session:
 

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -41,16 +41,17 @@ flowchart TD
 
 ## Current Hosted Testcases
 
-The production `hosted-web-suite` case runs `hosted-web-suite-v1` version `v2`. All four sessions are required and have weight 1. `shopping-constrained-checkout` is the first session task slug, not the benchmark case slug.
+The production `hosted-web-suite` case runs `hosted-web-suite-v1` version `v3`. All five sessions are required and have weight 1. `shopping-constrained-checkout` is the first session task slug, not the benchmark case slug.
 
-| App | Variants |
-| --- | --- |
-| `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard` |
-| `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory` |
-| `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install` |
-| `wiki-lite` | `release-date`, `dispatch-window`, `charger-price` |
+| Task | App | Variants |
+| --- | --- | --- |
+| `shopping-constrained-checkout` | `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard` |
+| `forum-battery-moderation` | `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory` |
+| `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install` |
+| `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price` |
+| `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff` |
 
-Each app has three semantic variants and ten presentation combinations (`5 layouts x 2 themes`). Presentation must never affect actions or scoring. See [Benchmark Scoring And Testing](./benchmark-testing.md) for required matrix coverage.
+Each task has three semantic variants and ten presentation combinations (`5 layouts x 2 themes`). Presentation must never affect actions or scoring. See [Benchmark Scoring And Testing](./benchmark-testing.md) for required matrix coverage.
 
 ## Core Rules
 

--- a/docs/hosted-web-benchmark.md
+++ b/docs/hosted-web-benchmark.md
@@ -22,7 +22,7 @@ Current apps:
 - `shopping-lite`: constrained product checkout
 - `forum-lite`: reply to and lock a safety thread
 - `repo-lite`: edit README and create a merge request
-- `wiki-lite`: retrieve and submit an exact date
+- `wiki-lite`: retrieve and submit release-history and policy answers
 
 Each session defines app, task and seed versions, order, weight, required flag, goal, and start path.
 

--- a/packages/test-cases/src/apps/wiki-lite.ts
+++ b/packages/test-cases/src/apps/wiki-lite.ts
@@ -5,3 +5,9 @@ export const wikiQuestionVariants = wikiQuestionVariantSchema.array().parse([
   { id: "dispatch-window", goal: "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit only the duration without surrounding words.", taskConfig: { targetArticleSlug: "shipping-policy", answerContract: { kind: "duration", canonicalValue: "two business days", normalization: "trim-casefold", sourceArticleSlug: "shipping-policy" } } },
   { id: "charger-price", goal: "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit only the exact price.", taskConfig: { targetArticleSlug: "usb-c-charger-faq", answerContract: { kind: "currency", canonicalValue: "$24.99", normalization: "trim", sourceArticleSlug: "usb-c-charger-faq" } } },
 ]);
+
+export const wikiPolicyQuestionVariants = wikiQuestionVariantSchema.array().parse([
+  { id: "adapter-restriction", goal: "Use the hosted wiki to find who restricted lab power adapters are reserved for, then submit only the group name.", taskConfig: { targetArticleSlug: "power-adapters", answerContract: { kind: "text", canonicalValue: "internal certification teams", normalization: "trim-casefold-punctuation", sourceArticleSlug: "power-adapters" } } },
+  { id: "standard-dispatch", goal: "Use the hosted wiki to find the standard shipping dispatch window, then submit only the duration.", taskConfig: { targetArticleSlug: "shipping-policy", answerContract: { kind: "duration", canonicalValue: "two business days", normalization: "trim-casefold", sourceArticleSlug: "shipping-policy" } } },
+  { id: "express-cutoff", goal: "Use the hosted wiki to find the express order same-day shipping cutoff time, then submit only the time.", taskConfig: { targetArticleSlug: "shipping-policy", answerContract: { kind: "text", canonicalValue: "3pm", normalization: "trim-casefold-punctuation", sourceArticleSlug: "shipping-policy" } } },
+]);

--- a/packages/test-cases/src/schemas.ts
+++ b/packages/test-cases/src/schemas.ts
@@ -29,7 +29,7 @@ export const repoTaskConfigSchema = z.object({
 });
 
 export const wikiAnswerContractSchema = z.object({
-  kind: z.enum(["date", "duration", "currency"]),
+  kind: z.enum(["date", "duration", "currency", "text"]),
   canonicalValue: z.string().min(1),
   normalization: z.enum(["trim", "trim-casefold", "trim-casefold-punctuation"]),
   sourceArticleSlug: z.string().min(1),

--- a/packages/test-cases/src/suites/hosted-web-v2.ts
+++ b/packages/test-cases/src/suites/hosted-web-v2.ts
@@ -1,27 +1,28 @@
 import { forumQuestionVariants } from "../apps/forum-lite.js";
 import { repoQuestionVariants } from "../apps/repo-lite.js";
 import { shoppingQuestionVariants } from "../apps/shopping-lite.js";
-import { wikiQuestionVariants } from "../apps/wiki-lite.js";
+import { wikiPolicyQuestionVariants, wikiQuestionVariants } from "../apps/wiki-lite.js";
 import { hostedSuiteMetadataSchema } from "../schemas.js";
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v2",
+  suiteVersion: "v3",
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v1", seedVersion: "shopping-lite-v1", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v1", seedVersion: "forum-lite-v1", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
     { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v1", seedVersion: "repo-lite-v1", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v2", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
+    { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v1", seedVersion: "wiki-lite-v3", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v2";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",
   slug: "hosted-web-suite",
   title: "Hosted Web Suite",
-  description: "Run a four-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite.",
+  description: "Run a five-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite.",
   category: "browser",
   difficulty: "easy",
   provider: "hosted-web" as const,

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -8,7 +8,6 @@ test("hosted catalog is valid and has unique app/task definitions", () => {
   assert.deepEqual(hostedWebSuiteCase.metadata, {});
   const suite = hostedSuiteMetadataSchema.parse(hostedWebSuiteMetadata);
   assert.ok(suite.sessions.length > 0);
-  assert.equal(new Set(suite.sessions.map((session) => session.app)).size, suite.sessions.length);
   assert.equal(new Set(suite.sessions.map((session) => session.taskSlug)).size, suite.sessions.length);
   assert.ok(suite.sessions.every((session, index) => session.sequenceIndex === index));
   assert.ok(suite.sessions.every((session) => session.metadata.questionVariants.length >= 2));
@@ -28,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v2");
+  assert.equal(first.revision, "hosted-web-suite-v3");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,7 +4,7 @@ values (
   '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005',
   'hosted-web-suite',
   'Hosted Web Suite',
-  'Run a four-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite.',
+  'Run a five-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite.',
   'browser',
   'easy',
   'hosted-web',
@@ -22,10 +22,10 @@ set
 
 select public.publish_benchmark_case_revision(
   '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005',
-  'hosted-web-suite-v2',
+  'hosted-web-suite-v3',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v2",
+  "suiteVersion": "v3",
   "sessions": [
     {
       "app": "shopping-lite",
@@ -217,10 +217,64 @@ select public.publish_benchmark_case_revision(
           }
         ]
       }
+    },
+    {
+      "app": "wiki-lite",
+      "taskSlug": "wiki-policy-answer",
+      "title": "Wiki Policy Lookup",
+      "startPath": "/wiki",
+      "taskVersion": "v1",
+      "seedVersion": "wiki-lite-v3",
+      "sequenceIndex": 4,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "adapter-restriction",
+            "goal": "Use the hosted wiki to find who restricted lab power adapters are reserved for, then submit only the group name.",
+            "taskConfig": {
+              "targetArticleSlug": "power-adapters",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "internal certification teams",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "power-adapters"
+              }
+            }
+          },
+          {
+            "id": "standard-dispatch",
+            "goal": "Use the hosted wiki to find the standard shipping dispatch window, then submit only the duration.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "duration",
+                "canonicalValue": "two business days",
+                "normalization": "trim-casefold",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          },
+          {
+            "id": "express-cutoff",
+            "goal": "Use the hosted wiki to find the express order same-day shipping cutoff time, then submit only the time.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "3pm",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }$catalog$::jsonb,
-  '2ca49e204251e7d55ceead92ab6ffa98ff854d38fbb1e9dc448eeaf66245f406'
+  '1800ad49697562245e84fda67dc306f0790c86bc892284a7a9bb7f928bcf7be3'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
## Summary

- add a fifth hosted-suite session, `wiki-policy-answer`, reusing `wiki-lite` with a new policy-answer variant pool
- publish the catalog as immutable release `hosted-web-suite-v3` / suite version `v3`
- extend wiki answer contracts with `text` answers and update docs/UI copy for the five-session suite

## Validation

- `pnpm --filter @agentbench/test-cases test`
- `pnpm catalog:check`
- `pnpm --filter hosted-sites test`
- `pnpm --filter hosted-sites build`
- `pnpm --filter hosted-orchestrator test`
- `pnpm --filter hosted-orchestrator build`
- `pnpm --filter web test`
- `pnpm --filter web build`
- `SMOKE_MODE=full-pass bash tests/e2e/hosted-lifecycle-smoke.sh` with local Redis, passing with `sessions=5`
- pre-push `pnpm verify:push`
