### PR TITLE
Reduce hosted suite change coupling

### DIFF
--- a/apps/hosted-sites/src/apps/forum-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/definition.ts
@@ -1,7 +1,7 @@
-import { createForumRoutes } from "../../routes/forum.js";
 import { isStateRecord, readStateArray, type HostedAppDefinition } from "../../runtime/app-definition.js";
 import { evaluateForum } from "./evaluate.js";
 import { buildForumFinalState } from "./final-state.js";
+import { createForumRoutes } from "./routes.js";
 import { forumSeedModerations, forumSeedThreads, getForumDefaultGoal, getForumStartPath } from "./seed.js";
 import type { ForumPost, ForumThread, ModerationAction } from "./types.js";
 

--- a/apps/hosted-sites/src/apps/forum-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/routes.ts
@@ -1,28 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { HostedWebScoreResult } from "@agentbench/scoring";
-import { addReplyToThread, lockThread } from "../apps/forum-lite/actions.js";
-import { renderForumIndex, renderThread } from "../apps/forum-lite/render.js";
-import { redirect, sendJson } from "../runtime/http.js";
-import { isHostedSessionForApp, type HostedSession } from "../runtime/types.js";
+import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
+import { redirect, sendJson } from "../../runtime/http.js";
+import { isHostedSessionForApp } from "../../runtime/types.js";
+import { addReplyToThread, lockThread } from "./actions.js";
+import { renderForumIndex, renderThread } from "./render.js";
 
-type ForumRoutesDeps = {
-  publicBaseUrl: string;
-  defaultStartPathForApp: (app: string) => string;
-  makeId: (prefix: string) => string;
-  getSession: (url: URL, request: IncomingMessage) => Promise<HostedSession | null>;
-  persistSessionSnapshot: (session: HostedSession) => Promise<void>;
-  recordEvent: (session: HostedSession, payload: Record<string, unknown>) => Promise<void>;
-  forwardRunEvent: (session: HostedSession, type: string, payload: Record<string, unknown>) => Promise<void>;
-  completeSession: (session: HostedSession, result: HostedWebScoreResult) => Promise<HostedWebScoreResult | null>;
-  evaluateSession: (session: HostedSession) => HostedWebScoreResult;
-  resolveSessionResult: (session: HostedSession) => Promise<HostedWebScoreResult>;
-  rejectTerminalMutation: (session: HostedSession, response: ServerResponse) => boolean;
-  readForm: (request: IncomingMessage) => Promise<URLSearchParams>;
-  badRequest: (response: ServerResponse, message: string) => void;
-  notFound: (response: ServerResponse) => void;
-};
-
-export function createForumRoutes(deps: ForumRoutesDeps) {
+export function createForumRoutes(deps: HostedAppRouteDeps) {
   async function getForumSession(url: URL, request: IncomingMessage) {
     const session = await deps.getSession(url, request);
     return session && isHostedSessionForApp(session, "forum-lite") ? session : null;

--- a/apps/hosted-sites/src/apps/forum-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/test-support.ts
@@ -1,6 +1,11 @@
 import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const forumLiteTestSupport: HostedAppTestSupport<"forum-lite"> = {
+  exampleTaskConfig: {
+    targetThreadId: "thr-battery",
+    expectedReplyValue: "https://support.example.com/recall/battery-2026",
+    expectedLockReason: "safety escalation",
+  },
   applyPassingState(session, config) {
     const threadId = configString(config, "targetThreadId");
     const thread = session.state.threads.find((candidate) => candidate.id === threadId);

--- a/apps/hosted-sites/src/apps/notes-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/definition.ts
@@ -1,7 +1,7 @@
-import { createNotesRoutes } from "../../routes/notes.js";
 import { isStateRecord, readStateArray, type HostedAppDefinition } from "../../runtime/app-definition.js";
 import { evaluateNotes } from "./evaluate.js";
 import { buildNotesFinalState } from "./final-state.js";
+import { createNotesRoutes } from "./routes.js";
 import { getNotesDefaultGoal, getNotesStartPath } from "./seed.js";
 import type { Note } from "./types.js";
 

--- a/apps/hosted-sites/src/apps/notes-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/routes.ts
@@ -1,28 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { HostedWebScoreResult } from "@agentbench/scoring";
-import { createNote } from "../apps/notes-lite/actions.js";
-import { renderNotesIndex } from "../apps/notes-lite/render.js";
-import { redirect, sendJson } from "../runtime/http.js";
-import { isHostedSessionForApp, type HostedSession } from "../runtime/types.js";
+import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
+import { redirect, sendJson } from "../../runtime/http.js";
+import { isHostedSessionForApp } from "../../runtime/types.js";
+import { createNote } from "./actions.js";
+import { renderNotesIndex } from "./render.js";
 
-type NotesRoutesDeps = {
-  publicBaseUrl: string;
-  defaultStartPathForApp: (app: string) => string;
-  now: () => string;
-  makeId: (prefix: string) => string;
-  getSession: (url: URL, request: IncomingMessage) => Promise<HostedSession | null>;
-  persistSessionSnapshot: (session: HostedSession) => Promise<void>;
-  recordEvent: (session: HostedSession, payload: Record<string, unknown>) => Promise<void>;
-  forwardRunEvent: (session: HostedSession, type: string, payload: Record<string, unknown>) => Promise<void>;
-  completeSession: (session: HostedSession, result: HostedWebScoreResult) => Promise<HostedWebScoreResult | null>;
-  evaluateSession: (session: HostedSession) => HostedWebScoreResult;
-  resolveSessionResult: (session: HostedSession) => Promise<HostedWebScoreResult>;
-  rejectTerminalMutation: (session: HostedSession, response: ServerResponse) => boolean;
-  readForm: (request: IncomingMessage) => Promise<URLSearchParams>;
-  badRequest: (response: ServerResponse, message: string) => void;
-};
-
-export function createNotesRoutes(deps: NotesRoutesDeps) {
+export function createNotesRoutes(deps: HostedAppRouteDeps) {
   async function getNotesSession(url: URL, request: IncomingMessage) {
     const session = await deps.getSession(url, request);
     return session && isHostedSessionForApp(session, "notes-lite") ? session : null;

--- a/apps/hosted-sites/src/apps/notes-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/test-support.ts
@@ -1,6 +1,11 @@
 import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const notesLiteTestSupport: HostedAppTestSupport<"notes-lite"> = {
+  exampleTaskConfig: {
+    expectedTitle: "Support follow-up",
+    expectedBody: "Email Mira after the replacement adapter ships.",
+    expectedTag: "support",
+  },
   applyPassingState: (session, config) => {
     session.state.notes.push({
       id: "note-smoke-pass",

--- a/apps/hosted-sites/src/apps/repo-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/definition.ts
@@ -1,7 +1,7 @@
-import { createRepoRoutes } from "../../routes/repo.js";
 import { isStateRecord, readStateArray, type HostedAppDefinition } from "../../runtime/app-definition.js";
 import { evaluateRepo } from "./evaluate.js";
 import { buildRepoFinalState } from "./final-state.js";
+import { createRepoRoutes } from "./routes.js";
 import { getRepoDefaultGoal, getRepoStartPath, repoSeedFiles, repoSeedIssues, repoSeedMergeRequests } from "./seed.js";
 import type { RepoFile, RepoIssue, RepoMergeRequest } from "./types.js";
 

--- a/apps/hosted-sites/src/apps/repo-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/routes.ts
@@ -1,28 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { HostedWebScoreResult } from "@agentbench/scoring";
-import { createMergeRequest, updateFileContent } from "../apps/repo-lite/actions.js";
-import { renderFileEdit, renderMRDetail, renderNewMR, renderRepoIndex } from "../apps/repo-lite/render.js";
-import { redirect, sendJson } from "../runtime/http.js";
-import { isHostedSessionForApp, type HostedSession } from "../runtime/types.js";
+import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
+import { redirect, sendJson } from "../../runtime/http.js";
+import { isHostedSessionForApp } from "../../runtime/types.js";
+import { createMergeRequest, updateFileContent } from "./actions.js";
+import { renderFileEdit, renderMRDetail, renderNewMR, renderRepoIndex } from "./render.js";
 
-type RepoRoutesDeps = {
-  publicBaseUrl: string;
-  defaultStartPathForApp: (app: string) => string;
-  makeId: (prefix: string) => string;
-  getSession: (url: URL, request: IncomingMessage) => Promise<HostedSession | null>;
-  persistSessionSnapshot: (session: HostedSession) => Promise<void>;
-  recordEvent: (session: HostedSession, payload: Record<string, unknown>) => Promise<void>;
-  forwardRunEvent: (session: HostedSession, type: string, payload: Record<string, unknown>) => Promise<void>;
-  completeSession: (session: HostedSession, result: HostedWebScoreResult) => Promise<HostedWebScoreResult | null>;
-  evaluateSession: (session: HostedSession) => HostedWebScoreResult;
-  resolveSessionResult: (session: HostedSession) => Promise<HostedWebScoreResult>;
-  rejectTerminalMutation: (session: HostedSession, response: ServerResponse) => boolean;
-  readForm: (request: IncomingMessage) => Promise<URLSearchParams>;
-  badRequest: (response: ServerResponse, message: string) => void;
-  notFound: (response: ServerResponse) => void;
-};
-
-export function createRepoRoutes(deps: RepoRoutesDeps) {
+export function createRepoRoutes(deps: HostedAppRouteDeps) {
   async function getRepoSession(url: URL, request: IncomingMessage) {
     const session = await deps.getSession(url, request);
     return session && isHostedSessionForApp(session, "repo-lite") ? session : null;

--- a/apps/hosted-sites/src/apps/repo-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/test-support.ts
@@ -1,6 +1,13 @@
 import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const repoLiteTestSupport: HostedAppTestSupport<"repo-lite"> = {
+  exampleTaskConfig: {
+    filePath: "README.md",
+    expectedText: "pnpm install",
+    forbiddenText: "npm install",
+    expectedMrTitle: "Fix install instructions",
+    expectedTargetBranch: "main",
+  },
   applyPassingState(session, config) {
     const filePath = configString(config, "filePath");
     const file = session.state.files.find((candidate) => candidate.path === filePath);

--- a/apps/hosted-sites/src/apps/shopping-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/definition.ts
@@ -1,7 +1,7 @@
-import { createShoppingRoutes } from "../../routes/shopping.js";
 import { isStateRecord, readStateArray, type HostedAppDefinition } from "../../runtime/app-definition.js";
 import { evaluateShopping } from "./evaluate.js";
 import { buildShoppingFinalState } from "./final-state.js";
+import { createShoppingRoutes } from "./routes.js";
 import { getShoppingDefaultGoal, getShoppingStartPath, shoppingSeedProducts } from "./seed.js";
 import type { CartItem, Order, Product } from "./types.js";
 

--- a/apps/hosted-sites/src/apps/shopping-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/routes.ts
@@ -1,29 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { HostedWebScoreResult } from "@agentbench/scoring";
-import { addProductToCart, submitCheckoutOrder } from "../apps/shopping-lite/actions.js";
-import { renderCart, renderOrder, renderProducts } from "../apps/shopping-lite/render.js";
-import { redirect, sendJson } from "../runtime/http.js";
-import { isHostedSessionForApp, type HostedSession } from "../runtime/types.js";
+import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
+import { redirect, sendJson } from "../../runtime/http.js";
+import { isHostedSessionForApp } from "../../runtime/types.js";
+import { addProductToCart, submitCheckoutOrder } from "./actions.js";
+import { renderCart, renderOrder, renderProducts } from "./render.js";
 
-type ShoppingRoutesDeps = {
-  publicBaseUrl: string;
-  defaultStartPathForApp: (app: string) => string;
-  now: () => string;
-  makeId: (prefix: string) => string;
-  getSession: (url: URL, request: IncomingMessage) => Promise<HostedSession | null>;
-  persistSessionSnapshot: (session: HostedSession) => Promise<void>;
-  recordEvent: (session: HostedSession, payload: Record<string, unknown>) => Promise<void>;
-  forwardRunEvent: (session: HostedSession, type: string, payload: Record<string, unknown>) => Promise<void>;
-  completeSession: (session: HostedSession, result: HostedWebScoreResult) => Promise<HostedWebScoreResult | null>;
-  evaluateSession: (session: HostedSession) => HostedWebScoreResult;
-  resolveSessionResult: (session: HostedSession) => Promise<HostedWebScoreResult>;
-  rejectTerminalMutation: (session: HostedSession, response: ServerResponse) => boolean;
-  readForm: (request: IncomingMessage) => Promise<URLSearchParams>;
-  badRequest: (response: ServerResponse, message: string) => void;
-  notFound: (response: ServerResponse) => void;
-};
-
-export function createShoppingRoutes(deps: ShoppingRoutesDeps) {
+export function createShoppingRoutes(deps: HostedAppRouteDeps) {
   async function getShoppingSession(url: URL, request: IncomingMessage) {
     const session = await deps.getSession(url, request);
     return session && isHostedSessionForApp(session, "shopping-lite") ? session : null;

--- a/apps/hosted-sites/src/apps/shopping-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/test-support.ts
@@ -1,6 +1,13 @@
 import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const shoppingLiteTestSupport: HostedAppTestSupport<"shopping-lite"> = {
+  exampleTaskConfig: {
+    targetCategory: "charger",
+    quantity: 1,
+    maxTotal: 30,
+    shippingMethod: "standard",
+    avoidRestricted: true,
+  },
   applyPassingState(session, config) {
     const category = configString(config, "targetCategory");
     const maxTotal = Number(config.maxTotal);

--- a/apps/hosted-sites/src/apps/wiki-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/definition.ts
@@ -1,7 +1,7 @@
-import { createWikiRoutes } from "../../routes/wiki.js";
 import { isStateRecord, readStateArray, type HostedAppDefinition } from "../../runtime/app-definition.js";
 import { evaluateWiki } from "./evaluate.js";
 import { buildWikiFinalState } from "./final-state.js";
+import { createWikiRoutes } from "./routes.js";
 import { getWikiDefaultGoal, getWikiStartPath, wikiSeedArticles } from "./seed.js";
 import type { WikiAnswerSubmission, WikiArticle } from "./types.js";
 

--- a/apps/hosted-sites/src/apps/wiki-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/routes.ts
@@ -1,28 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { HostedWebScoreResult } from "@agentbench/scoring";
-import { markArticleViewed, submitWikiAnswer } from "../apps/wiki-lite/actions.js";
-import { renderWikiArticle, renderWikiIndex } from "../apps/wiki-lite/render.js";
-import { redirect, sendJson } from "../runtime/http.js";
-import { isHostedSessionForApp, type HostedSession } from "../runtime/types.js";
+import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
+import { redirect, sendJson } from "../../runtime/http.js";
+import { isHostedSessionForApp } from "../../runtime/types.js";
+import { markArticleViewed, submitWikiAnswer } from "./actions.js";
+import { renderWikiArticle, renderWikiIndex } from "./render.js";
 
-type WikiRoutesDeps = {
-  publicBaseUrl: string;
-  defaultStartPathForApp: (app: string) => string;
-  now: () => string;
-  getSession: (url: URL, request: IncomingMessage) => Promise<HostedSession | null>;
-  persistSessionSnapshot: (session: HostedSession) => Promise<void>;
-  recordEvent: (session: HostedSession, payload: Record<string, unknown>) => Promise<void>;
-  forwardRunEvent: (session: HostedSession, type: string, payload: Record<string, unknown>) => Promise<void>;
-  completeSession: (session: HostedSession, result: HostedWebScoreResult) => Promise<HostedWebScoreResult | null>;
-  evaluateSession: (session: HostedSession) => HostedWebScoreResult;
-  resolveSessionResult: (session: HostedSession) => Promise<HostedWebScoreResult>;
-  rejectTerminalMutation: (session: HostedSession, response: ServerResponse) => boolean;
-  readForm: (request: IncomingMessage) => Promise<URLSearchParams>;
-  badRequest: (response: ServerResponse, message: string) => void;
-  notFound: (response: ServerResponse) => void;
-};
-
-export function createWikiRoutes(deps: WikiRoutesDeps) {
+export function createWikiRoutes(deps: HostedAppRouteDeps) {
   async function getWikiSession(url: URL, request: IncomingMessage) {
     const session = await deps.getSession(url, request);
     return session && isHostedSessionForApp(session, "wiki-lite") ? session : null;

--- a/apps/hosted-sites/src/apps/wiki-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/test-support.ts
@@ -1,6 +1,15 @@
 import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const wikiLiteTestSupport: HostedAppTestSupport<"wiki-lite"> = {
+  exampleTaskConfig: {
+    targetArticleSlug: "agentbench-release-history",
+    answerContract: {
+      kind: "date",
+      canonicalValue: "June 1, 2026",
+      normalization: "trim-casefold-punctuation",
+      sourceArticleSlug: "agentbench-release-history",
+    },
+  },
   applyPassingState(session, config) {
     const contract = config.answerContract as Record<string, unknown>;
     const slug = configString(config, "targetArticleSlug");

--- a/apps/hosted-sites/src/runtime/test-support.ts
+++ b/apps/hosted-sites/src/runtime/test-support.ts
@@ -1,6 +1,7 @@
 import type { HostedAppId, HostedSessionFor } from "./types.js";
 
 export type HostedAppTestSupport<TApp extends HostedAppId = HostedAppId> = {
+  exampleTaskConfig: Record<string, unknown>;
   applyPassingState: (session: HostedSessionFor<TApp>, config: Record<string, unknown>) => void;
   breakPassingState: (session: HostedSessionFor<TApp>) => void;
 };

--- a/apps/hosted-sites/src/templates.ts
+++ b/apps/hosted-sites/src/templates.ts
@@ -34,17 +34,9 @@ export function layout(params: {
   const uiTheme = readUiTheme(params.session.metadata);
   const isViewer = params.session.accessMode === "viewer";
   const isTerminal = params.session.status === "completed" || params.session.status === "failed" || params.session.status === "expired";
-  const appNav =
-    params.session.app === "wiki-lite"
-        ? `<a href="/wiki?session=${encodeURIComponent(params.session.token)}">Knowledge base</a>`
-        : params.session.app === "forum-lite"
-          ? `<a href="/forum?session=${encodeURIComponent(params.session.token)}">All threads</a>`
-          : params.session.app === "repo-lite"
-            ? `<a href="/repo?session=${encodeURIComponent(params.session.token)}">Repository</a>`
-            : params.session.app === "notes-lite"
-              ? `<a href="/notes?session=${encodeURIComponent(params.session.token)}">Notes</a>`
-              : `<a href="/shopping?session=${encodeURIComponent(params.session.token)}">Catalog</a>
-                 <a href="/shopping/cart?session=${encodeURIComponent(params.session.token)}">Cart</a>`;
+  const taskHomePath = params.session.startPath ?? params.defaultStartPathForApp(params.session.app);
+  const taskHomeSeparator = taskHomePath.includes("?") ? "&" : "?";
+  const appNav = `<a href="${escapeHtml(taskHomePath)}${taskHomeSeparator}session=${encodeURIComponent(params.session.token)}">Task home</a>`;
   const telemetry = isViewer || isTerminal ? "" : `
     <script>
       window.AgentBenchHostedSession = ${JSON.stringify({

--- a/apps/hosted-sites/tests/unit/app-registry.test.ts
+++ b/apps/hosted-sites/tests/unit/app-registry.test.ts
@@ -18,29 +18,14 @@ import type { HostedAppId, HostedSessionFor } from "../../src/runtime/types.js";
 
 const expectedApps = listHostedAppDefinitions().map((definition) => definition.id);
 
-function taskConfigForApp(app: HostedAppId) {
-  const configs = {
-    "shopping-lite": { targetCategory: "charger", quantity: 1, maxTotal: 30, shippingMethod: "standard", avoidRestricted: true },
-    "wiki-lite": {
-      targetArticleSlug: "agentbench-release-history",
-      answerContract: {
-        kind: "date",
-        canonicalValue: "June 1, 2026",
-        normalization: "trim-casefold-punctuation",
-        sourceArticleSlug: "agentbench-release-history",
-      },
-    },
-    "forum-lite": { targetThreadId: "thr-battery", expectedReplyValue: "https://support.example.com/recall/battery-2026", expectedLockReason: "safety escalation" },
-    "repo-lite": { filePath: "README.md", expectedText: "pnpm install", forbiddenText: "npm install", expectedMrTitle: "Fix install instructions", expectedTargetBranch: "main" },
-    "notes-lite": { expectedTitle: "Support follow-up", expectedBody: "Email Mira after the replacement adapter ships.", expectedTag: "support" },
-  } satisfies Record<HostedAppId, Record<string, unknown>>;
+function taskMetadataForApp(app: HostedAppId) {
   return {
     questionGeneration: {
       schemaVersion: 3,
       generationSeed: "registry-test",
       variantId: `${app}-test`,
       uiVariant: "workspace",
-      taskConfig: configs[app],
+      taskConfig: hostedAppTestSupport[app].exampleTaskConfig,
     },
   };
 }
@@ -66,7 +51,7 @@ function makeSession<TApp extends HostedAppId>(app: TApp): HostedSessionFor<TApp
     goal: defaultGoalForSession(app, `${app}-task`),
     startPath: defaultStartPathForApp(app),
     seedVersion: `${app}-v1`,
-    metadata: taskConfigForApp(app),
+    metadata: taskMetadataForApp(app),
     status: "active",
     expiresAt: null,
     accessCount: 0,
@@ -186,7 +171,7 @@ test("app registry composes one route handler per hosted app", () => {
 test("app registry dispatches evaluation and final state through definitions", () => {
   for (const app of expectedApps) {
     const session = makeSession(app);
-    hostedAppTestSupport[app].applyPassingState(session, taskConfigForApp(app).questionGeneration.taskConfig);
+    hostedAppTestSupport[app].applyPassingState(session, hostedAppTestSupport[app].exampleTaskConfig);
     const result = evaluateSession(session);
     const finalState = buildFinalState(session);
 

--- a/apps/hosted-sites/tests/unit/routes/api.test.ts
+++ b/apps/hosted-sites/tests/unit/routes/api.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import test from "node:test";
 import { createApiRoutes } from "../../../src/routes/api.js";
-import { createShoppingRoutes } from "../../../src/routes/shopping.js";
+import { createShoppingRoutes } from "../../../src/apps/shopping-lite/routes.js";
 import { buildInitialSessionState, defaultGoalForSession, defaultStartPathForApp, evaluateSession } from "../../../src/runtime/app-registry.js";
 import { badRequest, notFound, readForm, readJson, sendJson } from "../../../src/runtime/http.js";
 import type { HostedSession } from "../../../src/runtime/types.js";

--- a/apps/hosted-sites/tests/unit/templates.test.ts
+++ b/apps/hosted-sites/tests/unit/templates.test.ts
@@ -40,7 +40,8 @@ for (const uiVariant of ["workspace", "sidebar", "compact", "dashboard", "editor
       assert.match(html, new RegExp(`data-ui-variant="${uiVariant}"`));
       assert.match(html, new RegExp(`data-ui-theme="${uiTheme}"`));
       assert.match(html, new RegExp(`${uiVariant} · ${uiTheme}`));
-      assert.match(html, /Knowledge base/);
+      assert.match(html, /Task home/);
+      assert.match(html, /href="\/wiki\?session=tok_layout"/);
       assert.doesNotMatch(html, /Release History|Battery Thread|Edit README/);
     });
   }

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,13 +29,7 @@ The homepage is now centered on one primary path:
 - run status starts at `waiting_for_agent`
 - the UI allocates a hosted attempt with one or more ordered hosted sessions
 - the connect page and JSON config expose an attempt-level hosted suite URL plus per-session details
-- the default benchmark case is a six-session hosted suite:
-  - `shopping-lite`
-  - `forum-lite`
-  - `repo-lite`
-  - `wiki-lite` release lookup
-  - `wiki-lite` policy lookup
-  - `notes-lite`
+- the default benchmark case resolves its ordered sessions from the published catalog revision
 - for hosted-web runs, the agent uses the hosted suite URL as the main task surface
 - hosted-sites writes per-session results and the aggregated attempt score
 

--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -8,7 +8,7 @@ export const benchmarkOptions: Array<{
   {
     value: "hosted-web-suite",
     label: "Hosted Web Suite",
-    description: "Six-session hosted suite across shopping-lite, forum-lite, repo-lite, wiki-lite, and notes-lite with server-side scoring.",
+    description: "Versioned multi-session benchmark with deterministic tasks and server-side scoring.",
   },
 ];
 
@@ -48,7 +48,7 @@ export const docsSteps = [
   {
     step: "02",
     title: "Run the hosted suite",
-    body: "Use the same shopping-lite, forum-lite, repo-lite, wiki-lite, and notes-lite tasks across agents so results stay comparable.",
+    body: "Run the same published suite revision across agents so results stay comparable as the catalog evolves.",
   },
   {
     step: "03",

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 ## Development
 
 - [Hosted Site App Authoring](./hosted-site-app-authoring.md)
+- [Hosted App Extensibility](./hosted-app-extensibility.md)
 - [Deployment and Scaling](./deployment.md)
 - [Security](./security.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ flowchart LR
 
 ### `apps/hosted-sites`
 
-- serves `shopping-lite`, `forum-lite`, `repo-lite`, `wiki-lite`, and `notes-lite`
+- serves dynamically discovered hosted app definitions
 - validates session tokens and app ownership
 - mutates session-scoped task state
 - emits telemetry and task signals

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -32,13 +32,7 @@ Do not use broad substring acceptance. Normalization may ignore declared present
 
 CI should enumerate declared variants directly instead of relying on a few random seeds.
 
-| App | Positive and negative coverage |
-| --- | --- |
-| `shopping-lite` | Every category and shipping method; quantity/price boundaries; restricted item, wrong quantity, and empty-cart failures. |
-| `forum-lite` | Every thread/value/reason tuple; wrong thread, missing reply, wrong reason, lock-before-reply, and writes after lock. |
-| `repo-lite` | Every package-manager/title/branch tuple; forbidden text retained, wrong file/title/branch, and duplicate MR. |
-| `wiki-lite` | Every article/answer-kind tuple; canonical answer, declared normalization, near miss, wrong article, empty answer, and duplicate submission. |
-| `notes-lite` | Every generated note tuple; exact title/body/tag match, wrong tag, missing body, and terminal mutation rejection. |
+Each app-local `test-support.ts` supplies a representative valid config plus passing and failing state builders. The generic matrix imports the published catalog, discovers every app and semantic variant, and applies those builders across presentation combinations. App-specific tests remain responsible for business boundaries that cannot be expressed by the generic matrix, such as quantity limits, duplicate submissions, ordering constraints, and terminal mutation rejection.
 
 ## Cross-Cutting Coverage
 
@@ -64,7 +58,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 
 ## Commands And Scheduled Coverage
 
-- `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for all 15 current variants, and repeats each passing state across all five layouts and both themes.
+- `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
 - `Hosted Variant Sweep` runs four deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, and `full-pool-4` cover every current variant without using Web guest quota.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -162,17 +162,7 @@ type HostedSessionBase = {
 };
 ```
 
-App-specific state is a discriminated union:
-
-| App | State fields |
-| --- | --- |
-| `shopping-lite` | `products`, `cart`, `orders` |
-| `wiki-lite` | `wikiArticles`, `wikiAnswerSubmissions` |
-| `forum-lite` | `threads`, `moderationActions` |
-| `repo-lite` | `files`, `issues`, `mergeRequests` |
-| `notes-lite` | `notes` |
-
-A session never carries another app's state fields. Redis validation rejects mismatched app/state payloads.
+App-specific state is a generated discriminated union. Each app owns its state in `apps/hosted-sites/src/apps/<app-slug>/types.ts`, and `runtime/generated-app-types.ts` is the generated cross-app map. A session never carries another app's state fields; Redis validation rejects mismatched app/state payloads.
 
 The Redis envelope currently contains the raw write token, generated private task configuration inside `metadata`, and may contain a callback secret. Redis must therefore remain private. Token hashing, credential minimization, and ACL separation are tracked in [Issue #62](https://github.com/Kaiwen0418/agent-benchmark/issues/62).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,13 +92,7 @@ The default direct-process ports are:
 
 ## Hosted Web Suite
 
-The current suite contains:
-
-- `shopping-lite`: constrained checkout
-- `forum-lite`: reply to and moderate a safety thread
-- `repo-lite`: update installation instructions and create a merge request
-- `wiki-lite`: retrieve and submit release-history and policy answers
-- `notes-lite`: create a generated follow-up note
+The current ordered suite is defined by the published testcase catalog. See the single authoritative [current testcase table](./hosted-site-app-authoring.md#current-hosted-testcases) instead of duplicating the changing app list here.
 
 Create a standalone local session:
 

--- a/docs/hosted-app-extensibility.md
+++ b/docs/hosted-app-extensibility.md
@@ -1,0 +1,25 @@
+# Hosted App Extensibility
+
+## Current Boundary
+
+Hosted-sites discovers each `src/apps/<app-slug>` directory and generates the cross-app type, definition, and test-support registries. App routes live beside their state, actions, renderer, evaluator, and smoke driver. Shared templates use only the session start path and contain no app-specific navigation branches.
+
+Adding a new app still requires implementing app-specific behavior. That is intentional: HTTP transitions, state mutations, evidence, and scoring semantics differ and should remain reviewed TypeScript rather than generated code.
+
+## Recommended Next Steps
+
+1. Move testcase schemas and variant pools into `packages/test-cases/src/apps/<app-slug>/`, then generate the cross-app Zod registry. Suite files should only compose ordered app tasks.
+2. Add `pnpm create-hosted-app <app-slug>` to scaffold the required hosted-sites and testcase files, placeholder tests, and smoke driver.
+3. Generate the current testcase table in `hosted-site-app-authoring.md` from the published catalog so suite changes do not require prose edits.
+4. Add small route factories only for repeated protocols such as a single terminal form submission. Keep complex routes explicit.
+5. Make CI compare discovered hosted apps with testcase app definitions and fail on missing schema, test support, driver, or catalog coverage.
+
+## Do Not Generate
+
+- business mutations and validation rules;
+- evaluator acceptance criteria;
+- final evidence selection;
+- task goals or hidden answers;
+- multi-step route behavior.
+
+Generating these would hide benchmark semantics in templates and make review less reliable. Automation should generate registries, consistency checks, and file skeletons, not correctness-critical behavior.

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -41,7 +41,7 @@ flowchart TD
 
 ## Current Hosted Testcases
 
-The production `hosted-web-suite` case runs `hosted-web-suite-v1` version `v3.0.1`. All six sessions are required and have weight 1. `shopping-constrained-checkout` is the first session task slug, not the benchmark case slug.
+This is the only documentation table that enumerates the changing suite contents. The catalog source remains authoritative; update this summary when publishing a revision instead of copying the list into other documents.
 
 | Task | App | Variants |
 | --- | --- | --- |
@@ -131,28 +131,27 @@ apps/hosted-sites/src/apps/<app-slug>/
   types.ts
   seed.ts
   actions.ts
+  routes.ts
   render.ts
   evaluate.ts
   final-state.ts
   test-support.ts
   test-driver.mjs
-
-apps/hosted-sites/src/routes/<route-name>.ts
 ```
 
 - `types.ts`: compact app domain types.
 - `seed.ts`: deterministic fixtures and defaults.
 - `actions.ts`: pure business mutations with explicit inputs.
+- `routes.ts`: app-local HTTP parsing, persistence, telemetry, rendering, and redirects.
 - `render.ts`: HTML for the required task surface.
 - `evaluate.ts`: evaluator-level `HostedWebScoreResult`.
 - `final-state.ts`: compact, redacted result evidence.
-- `test-support.ts`: unit-test helpers that build passing and failing states for declared variants.
+- `test-support.ts`: representative task config plus unit-test helpers that build passing and failing states for declared variants.
 - `test-driver.mjs`: E2E smoke driver that completes one generated session through HTTP routes.
 - `definition.ts`: composes app hooks.
-- `routes`: HTTP parsing, persistence, telemetry, rendering.
 - `runtime/generated-app-*.ts`: generated static imports for app definitions, app state types, and test support.
 
-Do not add app branches to `server.ts`, `session-cache.ts`, or a central evaluation dispatcher. Run `pnpm --filter hosted-sites generate-registry` after adding an app directory; `pnpm --filter hosted-sites test` and `build` fail if the generated registry is stale.
+Do not add app branches to `server.ts`, `templates.ts`, `session-cache.ts`, or a central evaluation dispatcher. Run `pnpm --filter hosted-sites generate-registry` after adding an app directory; `pnpm --filter hosted-sites test` and `build` fail if the generated registry is stale.
 
 ## Add Existing Apps To A Suite
 
@@ -178,6 +177,8 @@ Adding a new app should be localized to one app directory plus catalog schema/so
 7. Add the app's question variant schema and suite session in `packages/test-cases`, then regenerate the catalog seed.
 
 After this, runtime dispatch, Redis state validation, unit variant matrix coverage, and E2E smoke completion are app-definition driven rather than central switch driven.
+
+See [Hosted App Extensibility](./hosted-app-extensibility.md) for the remaining automation boundary and recommended scaffold/catalog-registry work.
 
 ## Scoring
 

--- a/docs/hosted-web-benchmark.md
+++ b/docs/hosted-web-benchmark.md
@@ -17,15 +17,7 @@ benchmark run
     aggregate attempt score
 ```
 
-Current apps:
-
-- `shopping-lite`: constrained product checkout
-- `forum-lite`: reply to and lock a safety thread
-- `repo-lite`: edit README and create a merge request
-- `wiki-lite`: retrieve and submit release-history and policy answers
-- `notes-lite`: create a generated follow-up note
-
-Each session defines app, task and seed versions, order, weight, required flag, goal, and start path.
+The published testcase catalog defines the current app list and ordered sessions. See the single authoritative [current testcase table](./hosted-site-app-authoring.md#current-hosted-testcases). Each session defines app, task and seed versions, order, weight, required flag, goal, and start path.
 
 ## Session Isolation
 


### PR DESCRIPTION
## Summary
- remove app-specific suite details from frontend copy and duplicate docs
- colocate hosted app routes and test fixtures with each app definition
- replace template app branches with generic task-home navigation
- document the remaining catalog registry and scaffolding automation boundary

## Verification
- pnpm --filter hosted-sites test
- pnpm --filter hosted-sites build
- pnpm --filter web build