### PR TITLE
[codex] add guided agent metadata and suite progression

### DIFF
--- a/apps/hosted-sites/src/templates.ts
+++ b/apps/hosted-sites/src/templates.ts
@@ -34,6 +34,9 @@ export function layout(params: {
   const uiTheme = readUiTheme(params.session.metadata);
   const isViewer = params.session.accessMode === "viewer";
   const isTerminal = params.session.status === "completed" || params.session.status === "failed" || params.session.status === "expired";
+  const connectionUrl = params.session.runId
+    ? `${(process.env.AGENTBENCH_WEB_URL ?? "http://localhost:3000").replace(/\/$/, "")}/runs/${encodeURIComponent(params.session.runId)}/connect`
+    : null;
   const taskHomePath = params.session.startPath ?? params.defaultStartPathForApp(params.session.app);
   const taskHomeSeparator = taskHomePath.includes("?") ? "&" : "?";
   const appNav = `<a href="${escapeHtml(taskHomePath)}${taskHomeSeparator}session=${encodeURIComponent(params.session.token)}">Task home</a>`;
@@ -331,7 +334,7 @@ export function layout(params: {
   <body class="ui-${uiVariant} theme-${uiTheme}${isViewer ? " viewer-readonly" : ""}${isTerminal ? " terminal-readonly" : ""}" data-ui-variant="${uiVariant}" data-ui-theme="${uiTheme}">
     <div class="shell">
     ${isViewer ? '<div class="viewer-banner">Live read-only session view</div>' : ""}
-    ${isTerminal ? `<div class="viewer-banner">Session ${escapeHtml(params.session.status)} · persisted result is read-only</div>` : ""}
+    ${isTerminal ? `<div class="viewer-banner">Case ${escapeHtml(params.session.status)} · return to the AgentBench Connection Page to continue${connectionUrl ? ` · <a href="${escapeHtml(connectionUrl)}">Return to Connection Page</a>` : ""}</div>` : ""}
     <header>
       <div class="heading">
         <span class="layout-badge">${escapeHtml(params.session.app)} · ${uiVariant} · ${uiTheme}</span>

--- a/apps/hosted-sites/tests/unit/templates.test.ts
+++ b/apps/hosted-sites/tests/unit/templates.test.ts
@@ -68,6 +68,7 @@ test("viewer layout disables navigation and mutations while retaining the read-o
 test("terminal layout disables forms and does not emit telemetry", () => {
   const session = makeSession("workspace", "light");
   session.status = "failed";
+  session.runId = "run-1";
   const html = layout({
     title: "Terminal task",
     session,
@@ -77,6 +78,7 @@ test("terminal layout disables forms and does not emit telemetry", () => {
   });
 
   assert.match(html, /terminal-readonly/);
-  assert.match(html, /persisted result is read-only/);
+  assert.match(html, /return to the AgentBench Connection Page to continue/);
+  assert.match(html, /href="http:\/\/localhost:3000\/runs\/run-1\/connect"/);
   assert.doesNotMatch(html, /abTelemetry/);
 });

--- a/apps/web/app/api/agent-options/route.ts
+++ b/apps/web/app/api/agent-options/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { agentCatalog } from "@/lib/agent-catalog";
+
+export async function GET() {
+  return NextResponse.json(agentCatalog, {
+    headers: {
+      "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/apps/web/app/api/runs/route.ts
+++ b/apps/web/app/api/runs/route.ts
@@ -7,6 +7,7 @@ import {
   isDevQuotaBypassed,
 } from "@/lib/auth";
 import { BenchmarkCaseUnavailableError, createBenchmarkRun, getQuotaStatus } from "@/lib/db";
+import { captureBrowserEnvironment } from "@/lib/run-metadata";
 
 export async function POST(request: Request) {
   const json = await request.json();
@@ -74,6 +75,8 @@ export async function POST(request: Request) {
       guestId: guest?.guestId ?? null,
       executionMode: input.executionMode,
       isPublic: input.isPublic,
+      agent: input.agent,
+      browserEnvironment: captureBrowserEnvironment(request.headers),
     });
   } catch (error) {
     if (error instanceof BenchmarkCaseUnavailableError) {

--- a/apps/web/app/runs/[runId]/connect/page.tsx
+++ b/apps/web/app/runs/[runId]/connect/page.tsx
@@ -1,16 +1,7 @@
-import { headers } from "next/headers";
 import { notFound } from "next/navigation";
-import { RunMetadataForm } from "@/components/run/RunMetadataForm";
+import { RunConnectClient } from "@/components/run/RunConnectClient";
 import { getBenchmarkCase, getBenchmarkRun } from "@/lib/db";
-import { buildRunConnectPayload } from "@/lib/run-connect";
-
-function getOrigin(host: string | null, proto: string | null) {
-  if (!host) {
-    return "http://localhost:3000";
-  }
-
-  return `${proto ?? "https"}://${host}`;
-}
+import { hasRegisteredRunMetadata } from "@/lib/run-metadata";
 
 export default async function RunConnectPage({
   params,
@@ -25,144 +16,20 @@ export default async function RunConnectPage({
   }
 
   const benchmarkCase = await getBenchmarkCase(run.caseId);
-  const headerStore = await headers();
-  const origin = getOrigin(headerStore.get("x-forwarded-host") ?? headerStore.get("host"), headerStore.get("x-forwarded-proto"));
-  const payload = await buildRunConnectPayload({
-    run,
-    benchmarkCase,
-    origin,
-  });
   const metadata = { ...run.metadata };
   delete metadata.identityReportedAt;
+  delete metadata.identitySource;
   const metadataLocked = ["completed", "failed", "cancelled", "timeout"].includes(run.status);
 
   return (
-    <main className="min-h-screen bg-[#f5f0e6] px-6 py-10 text-[#111111] md:px-10">
-      <div className="mx-auto max-w-4xl">
-        <div className="rounded-[2rem] border border-[#d8d1c4] bg-[#faf7f1] p-6 shadow-[0_24px_80px_rgba(17,17,17,0.08)] md:p-8">
-          <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">AgentBench Run Connection</div>
-          <h1 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-[#111111] md:text-5xl">
-            {payload.benchmark.title}
-          </h1>
-          <p className="mt-4 max-w-3xl text-lg leading-8 text-[#66625a]">{payload.benchmark.goal}</p>
-          {payload.status === "timeout" || payload.status === "failed" ? (
-            <div className="mt-6 rounded-[1.4rem] border border-[#e3b4aa] bg-[#fff7f4] p-5">
-              <div className="text-xs uppercase tracking-[0.18em] text-[#8a2d1f]">
-                {payload.status === "timeout" ? "Run timed out" : "Run failed"}
-              </div>
-              <p className="mt-2 text-sm leading-7 text-[#5b3d37]">
-                {payload.errorMessage ?? "This run no longer has an active hosted session."}
-              </p>
-            </div>
-          ) : null}
-
-          <RunMetadataForm
-            runId={run.id}
-            initialAgent={run.agent}
-            initialMetadata={metadata}
-            locked={metadataLocked}
-          />
-
-          <div className="mt-8 grid gap-5 md:grid-cols-[1.1fr_0.9fr]">
-            <section className="rounded-[1.4rem] border border-[#ddd6ca] bg-white p-5">
-              <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Instructions For Agents</div>
-              <ol className="mt-4 space-y-3 text-sm leading-7 text-[#302d29]">
-                {payload.instructions.map((step) => (
-                  <li key={step}>{step}</li>
-                ))}
-              </ol>
-            </section>
-
-            <section className="rounded-[1.4rem] border border-[#ddd6ca] bg-[#f1eee7] p-5">
-              <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">
-                {payload.hostedWeb.available ? "Hosted Suite" : "Local Demo Note"}
-              </div>
-              <p className="mt-4 text-sm leading-7 text-[#4f4a43]">{payload.hostedNote.note}</p>
-              <div className="mt-5 rounded-[1rem] bg-[#111111] px-4 py-3 text-sm text-white">
-                {payload.hostedWeb.available ? (
-                  <>
-                    Suite: <span className="font-medium">{payload.hostedWeb.suiteSlug ?? "hosted-web"}</span>
-                    <br />
-                    Attempt: <span className="font-medium">{payload.hostedWeb.attemptId ?? "not allocated"}</span>
-                    <br />
-                    Active Session: <span className="font-medium">{payload.hostedWeb.activeSessionId ?? "not allocated"}</span>
-                    <br />
-                    Progress: <span className="font-medium">
-                      {payload.hostedWeb.progress.total > 0 && payload.hostedWeb.progress.currentIndex !== null
-                        ? `${payload.hostedWeb.progress.currentIndex + 1} / ${payload.hostedWeb.progress.total}`
-                        : `${payload.hostedWeb.progress.completed} / ${payload.hostedWeb.progress.total}`}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    Status: <span className="font-medium">{payload.status}</span>
-                  </>
-                )}
-              </div>
-              {payload.hostedWeb.orchestratorUrl ? (
-                <a
-                  href={payload.hostedWeb.orchestratorUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-4 inline-flex rounded-full bg-[#111111] px-5 py-2.5 text-sm font-medium text-white"
-                >
-                  Open Active Benchmark
-                </a>
-              ) : null}
-            </section>
-          </div>
-
-          <section className="mt-6 rounded-[1.4rem] border border-[#ddd6ca] bg-white p-5">
-            {payload.hostedWeb.available ? (
-              <div className="mb-5 grid gap-3">
-                {payload.hostedWeb.sessions.map((session) => (
-                  <div
-                    key={session.sessionId}
-                    className="flex items-start justify-between gap-3 rounded-[1rem] border border-[#e4ddd1] bg-[#faf7f1] px-4 py-3"
-                  >
-                    <div>
-                      <div className="text-sm font-medium text-[#111111]">
-                        {session.title ?? session.taskSlug}
-                      </div>
-                      <div className="mt-1 text-xs text-[#6b655b]">
-                        Session {session.sequenceIndex + 1} · {session.app}
-                      </div>
-                      <div className="mt-2 text-sm leading-7 text-[#4f4a43]">{session.goal}</div>
-                    </div>
-                    <div className={`rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${
-                      session.status === "completed"
-                        ? "bg-[#e8f7ec] text-[#1f6b35]"
-                        : session.status === "failed" || session.status === "expired"
-                          ? "bg-[#fff1ed] text-[#8a2d1f]"
-                          : session.status === "active"
-                            ? "bg-[#eef6ff] text-[#245a8a]"
-                            : "bg-[#efede6] text-[#4d483f]"
-                    }`}>
-                      {session.status.replaceAll("-", " ")}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : null}
-            <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Prompt</div>
-            <pre className="mt-4 overflow-x-auto whitespace-pre-wrap rounded-[1rem] bg-[#f6f3ed] p-4 text-sm leading-7 text-[#25221d]">
-              {payload.prompt}
-            </pre>
-          </section>
-
-          <section className="mt-6 rounded-[1.4rem] border border-[#ddd6ca] bg-white p-5">
-            <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Machine Readable Config</div>
-            <pre className="mt-4 overflow-x-auto rounded-[1rem] bg-[#111111] p-4 text-xs leading-6 text-[#d7ff00]">
-              {JSON.stringify(payload, null, 2)}
-            </pre>
-          </section>
-        </div>
-      </div>
-      <script
-        id="agentbench-run-config"
-        type="application/json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }}
-      />
-    </main>
+    <RunConnectClient
+      runId={run.id}
+      benchmarkTitle={benchmarkCase?.title ?? "AgentBench Run"}
+      benchmarkGoal={benchmarkCase?.description ?? "Complete the benchmark objective."}
+      initialAgent={run.agent}
+      initialMetadata={metadata}
+      initiallyRegistered={hasRegisteredRunMetadata(run)}
+      metadataLocked={metadataLocked}
+    />
   );
 }

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -5,15 +5,26 @@ import { benchmarkOptions } from "./data";
 import { RunConnectionCard } from "./RunConnectionCard";
 import { RunDetailTabs } from "./RunDetailTabs";
 import { usePlaygroundStore } from "@/lib/playground-store";
+import { AgentIdentityFields } from "@/components/run/AgentIdentityFields";
 
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
+  const agentSelection = usePlaygroundStore((state) => state.agentSelection);
+  const customAgent = usePlaygroundStore((state) => state.customAgent);
+  const agentVersion = usePlaygroundStore((state) => state.agentVersion);
+  const modelSelection = usePlaygroundStore((state) => state.modelSelection);
+  const customModel = usePlaygroundStore((state) => state.customModel);
   const phase = usePlaygroundStore((state) => state.phase);
   const quota = usePlaygroundStore((state) => state.quota);
   const quotaLoading = usePlaygroundStore((state) => state.quotaLoading);
   const runError = usePlaygroundStore((state) => state.runError);
   const score = usePlaygroundStore((state) => state.score);
   const setBenchmark = usePlaygroundStore((state) => state.setBenchmark);
+  const setAgentSelection = usePlaygroundStore((state) => state.setAgentSelection);
+  const setCustomAgent = usePlaygroundStore((state) => state.setCustomAgent);
+  const setAgentVersion = usePlaygroundStore((state) => state.setAgentVersion);
+  const setModelSelection = usePlaygroundStore((state) => state.setModelSelection);
+  const setCustomModel = usePlaygroundStore((state) => state.setCustomModel);
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
   const startRun = usePlaygroundStore((state) => state.startRun);
   const stopRun = usePlaygroundStore((state) => state.stopRun);
@@ -155,6 +166,17 @@ export function ConnectAgentCard() {
         <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
           {benchmarkOptions.find((item) => item.value === benchmark)?.description}
         </div>
+
+        <AgentIdentityFields
+          value={{ agentSelection, customAgent, agentVersion, modelSelection, customModel }}
+          onChange={(value) => {
+            setAgentSelection(value.agentSelection);
+            setCustomAgent(value.customAgent);
+            setAgentVersion(value.agentVersion);
+            setModelSelection(value.modelSelection);
+            setCustomModel(value.customModel);
+          }}
+        />
 
         {runError ? (
           <div className="rounded-[1rem] border border-[#ead2ca] bg-[#fff0eb] p-3 text-[13px] leading-6 text-[#8a4334]">

--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -10,6 +10,7 @@ type RunConnectPayload = {
   runId: string;
   status: string;
   errorMessage: string | null;
+  metadataRequired: boolean;
   prompt: string;
   connectUrl: string;
   configUrl: string;
@@ -335,6 +336,10 @@ export function RunConnectionCard() {
             ))}
           </div>
           <RunDetailTabs />
+        </div>
+      ) : payload.metadataRequired ? (
+        <div className="mt-4 rounded-[1.2rem] border border-[#dfd8cb] bg-[#fbf8f3] p-4 text-sm leading-7 text-[#3f3b34]">
+          Submit agent metadata on the connection page before the hosted suite is allocated.
         </div>
       ) : null}
     </div>

--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -19,7 +19,12 @@ export const docsBlocks = {
   -d '{
     "caseId": "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",
     "executionMode": "external-agent",
-    "isPublic": true
+    "isPublic": true,
+    "agent": {
+      "name": "Codex",
+      "version": "latest",
+      "baseModel": "GPT-5"
+    }
   }'`,
   response: `{
   "runId": "run_9f3kx8",

--- a/apps/web/components/run/AgentIdentityFields.tsx
+++ b/apps/web/components/run/AgentIdentityFields.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type { AgentIdentity } from "@agentbench/protocol";
+import { useEffect, useState } from "react";
+import {
+  agentCatalog as fallbackCatalog,
+  catalogSelection,
+  OTHER_OPTION_VALUE,
+  type AgentCatalog,
+} from "@/lib/agent-catalog";
+
+export type AgentIdentityDraft = {
+  agentSelection: string;
+  customAgent: string;
+  agentVersion: string;
+  modelSelection: string;
+  customModel: string;
+};
+
+export function identityDraftFromAgent(agent: AgentIdentity | null): AgentIdentityDraft {
+  const agentSelection = catalogSelection(agent?.name ?? "", fallbackCatalog.agents);
+  const modelSelection = catalogSelection(agent?.baseModel ?? "", fallbackCatalog.models);
+
+  return {
+    agentSelection,
+    customAgent: agentSelection === OTHER_OPTION_VALUE ? agent?.name ?? "" : "",
+    agentVersion: agent?.version ?? "latest",
+    modelSelection,
+    customModel: modelSelection === OTHER_OPTION_VALUE ? agent?.baseModel ?? "" : "",
+  };
+}
+
+export function AgentIdentityFields({
+  value,
+  onChange,
+  disabled = false,
+  className = "",
+}: {
+  value: AgentIdentityDraft;
+  onChange: (value: AgentIdentityDraft) => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const [catalog, setCatalog] = useState<AgentCatalog>(fallbackCatalog);
+
+  useEffect(() => {
+    let active = true;
+
+    void fetch("/api/agent-options", { cache: "force-cache" })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("Unable to load agent options");
+        }
+        return response.json() as Promise<AgentCatalog>;
+      })
+      .then((result) => {
+        if (active) {
+          setCatalog(result);
+        }
+      })
+      .catch(() => {
+        // The bundled catalog keeps the form usable if the options endpoint is unavailable.
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const inputClass =
+    "mt-2 w-full rounded-[0.9rem] border border-[#d8d1c4] bg-white px-3.5 py-3 text-sm text-[#111111] outline-none transition focus:border-[#111111] disabled:cursor-not-allowed disabled:bg-[#eeeae2] disabled:text-[#777168]";
+
+  return (
+    <div className={`grid gap-4 md:grid-cols-3 ${className}`}>
+      <label className="text-xs font-medium text-[#4f4a43]">
+        Agent
+        <select
+          required
+          value={value.agentSelection}
+          onChange={(event) => onChange({ ...value, agentSelection: event.target.value })}
+          disabled={disabled}
+          className={inputClass}
+        >
+          <option value="" disabled>Select an agent</option>
+          {catalog.agents.map((option) => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
+          <option value={OTHER_OPTION_VALUE}>Other</option>
+        </select>
+        {value.agentSelection === OTHER_OPTION_VALUE ? (
+          <input
+            required
+            maxLength={120}
+            value={value.customAgent}
+            onChange={(event) => onChange({ ...value, customAgent: event.target.value })}
+            disabled={disabled}
+            placeholder="Agent name"
+            className={inputClass}
+          />
+        ) : null}
+      </label>
+      <label className="text-xs font-medium text-[#4f4a43]">
+        Agent version
+        <input
+          required
+          maxLength={120}
+          value={value.agentVersion}
+          onChange={(event) => onChange({ ...value, agentVersion: event.target.value })}
+          disabled={disabled}
+          placeholder="latest or exact version"
+          className={inputClass}
+        />
+      </label>
+      <label className="text-xs font-medium text-[#4f4a43]">
+        Base model
+        <select
+          required
+          value={value.modelSelection}
+          onChange={(event) => onChange({ ...value, modelSelection: event.target.value })}
+          disabled={disabled}
+          className={inputClass}
+        >
+          <option value="" disabled>Select a model</option>
+          {catalog.models.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label} · {option.provider}
+            </option>
+          ))}
+          <option value={OTHER_OPTION_VALUE}>Other</option>
+        </select>
+        {value.modelSelection === OTHER_OPTION_VALUE ? (
+          <input
+            required
+            maxLength={160}
+            value={value.customModel}
+            onChange={(event) => onChange({ ...value, customModel: event.target.value })}
+            disabled={disabled}
+            placeholder="Model name"
+            className={inputClass}
+          />
+        ) : null}
+      </label>
+    </div>
+  );
+}

--- a/apps/web/components/run/RunConnectClient.tsx
+++ b/apps/web/components/run/RunConnectClient.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import type { AgentIdentity } from "@agentbench/protocol";
+import { useCallback, useEffect, useState } from "react";
+import { RunMetadataForm } from "./RunMetadataForm";
+
+type RunConnectPayload = {
+  runId: string;
+  status: string;
+  errorMessage: string | null;
+  metadataRequired: boolean;
+  prompt: string;
+  benchmark: {
+    title: string;
+    goal: string;
+  };
+  instructions: string[];
+  hostedNote: {
+    note: string;
+  };
+  hostedWeb: {
+    available: boolean;
+    attemptId: string | null;
+    suiteSlug: string | null;
+    suiteVersion: string | null;
+    orchestratorUrl: string | null;
+    activeSessionId: string | null;
+    progress: {
+      currentIndex: number | null;
+      total: number;
+      completed: number;
+    };
+    sessions: Array<{
+      sessionId: string;
+      app: string;
+      taskSlug: string;
+      sequenceIndex: number;
+      goal: string;
+      title: string | null;
+      status: string;
+    }>;
+  };
+};
+
+type ConnectionError = {
+  message: string;
+};
+
+function sessionTone(status: string) {
+  if (status === "completed") {
+    return "bg-[#e8f7ec] text-[#1f6b35]";
+  }
+  if (status === "failed" || status === "expired") {
+    return "bg-[#fff1ed] text-[#8a2d1f]";
+  }
+  if (status === "active") {
+    return "bg-[#eef6ff] text-[#245a8a]";
+  }
+  return "bg-[#efede6] text-[#4d483f]";
+}
+
+export function RunConnectClient({
+  runId,
+  benchmarkTitle,
+  benchmarkGoal,
+  initialAgent,
+  initialMetadata,
+  initiallyRegistered,
+  metadataLocked,
+}: {
+  runId: string;
+  benchmarkTitle: string;
+  benchmarkGoal: string;
+  initialAgent: AgentIdentity | null;
+  initialMetadata: Record<string, unknown>;
+  initiallyRegistered: boolean;
+  metadataLocked: boolean;
+}) {
+  const [registered, setRegistered] = useState(initiallyRegistered);
+  const [payload, setPayload] = useState<RunConnectPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadConnection = useCallback(async (quiet = false) => {
+    if (!quiet) {
+      setRefreshing(true);
+    }
+
+    try {
+      const response = await fetch(`/api/runs/${runId}/connect`, { cache: "no-store" });
+      const result = await response.json().catch(() => null) as RunConnectPayload | ConnectionError | null;
+      if (!response.ok) {
+        throw new Error(result && "message" in result ? result.message : "Unable to load the active benchmark.");
+      }
+
+      const nextPayload = result as RunConnectPayload;
+      setPayload(nextPayload);
+      setRegistered(!nextPayload.metadataRequired);
+      setError(null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Unable to load the active benchmark.");
+    } finally {
+      if (!quiet) {
+        setRefreshing(false);
+      }
+    }
+  }, [runId]);
+
+  useEffect(() => {
+    if (!registered) {
+      return;
+    }
+
+    void loadConnection();
+  }, [loadConnection, registered]);
+
+  useEffect(() => {
+    if (!registered || !payload) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      void loadConnection(true);
+    }, 2000);
+
+    return () => window.clearInterval(interval);
+  }, [loadConnection, payload, registered]);
+
+  const activeSession = payload?.hostedWeb.sessions.find(
+    (session) => session.sessionId === payload.hostedWeb.activeSessionId,
+  ) ?? null;
+  const isTerminal =
+    payload?.status === "completed" ||
+    payload?.status === "failed" ||
+    payload?.status === "cancelled" ||
+    payload?.status === "timeout";
+  const actionLabel = payload && payload.hostedWeb.progress.completed > 0
+    ? "Proceed to next case"
+    : "Open first case";
+
+  return (
+    <main className="min-h-screen bg-[#f5f0e6] px-6 py-10 text-[#111111] md:px-10">
+      <div className="mx-auto max-w-4xl">
+        <div className="rounded-[2rem] border border-[#d8d1c4] bg-[#faf7f1] p-6 shadow-[0_24px_80px_rgba(17,17,17,0.08)] md:p-8">
+          <div className="text-xs uppercase tracking-[0.24em] text-[#726b5f]">AgentBench Run Connection</div>
+          <h1 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-[#111111] md:text-5xl">
+            {benchmarkTitle}
+          </h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-[#66625a]">{benchmarkGoal}</p>
+
+          <RunMetadataForm
+            runId={runId}
+            initialAgent={initialAgent}
+            initialMetadata={initialMetadata}
+            locked={metadataLocked}
+            onSaved={() => {
+              setRegistered(true);
+              setPayload(null);
+            }}
+          />
+
+          {!registered ? (
+            <section className="mt-8 rounded-[1.4rem] border border-[#d8d1c4] bg-white p-5">
+              <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Metadata required</div>
+              <p className="mt-3 text-sm leading-7 text-[#4f4a43]">
+                Submit the agent identity above to allocate the suite and reveal the active case.
+              </p>
+            </section>
+          ) : null}
+
+          {registered && !payload ? (
+            <section className="mt-8 rounded-[1.4rem] border border-[#d8d1c4] bg-white p-5">
+              <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Loading suite</div>
+              <p className="mt-3 text-sm leading-7 text-[#4f4a43]">
+                {error ?? "Allocating the hosted suite and resolving the active case."}
+              </p>
+              {error ? (
+                <button
+                  type="button"
+                  onClick={() => void loadConnection()}
+                  className="mt-4 rounded-full bg-[#111111] px-5 py-2.5 text-sm font-medium text-white"
+                >
+                  Retry
+                </button>
+              ) : null}
+            </section>
+          ) : null}
+
+          {payload ? (
+            <>
+              {error ? (
+                <div className="mt-6 rounded-[1rem] border border-[#ead2ca] bg-[#fff0eb] p-3 text-sm text-[#8a4334]">
+                  Refresh failed: {error}. Retrying automatically.
+                </div>
+              ) : null}
+
+              <div className="mt-8 grid gap-5 md:grid-cols-[1.1fr_0.9fr]">
+                <section className="rounded-[1.4rem] border border-[#ddd6ca] bg-white p-5">
+                  <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Instructions For Agents</div>
+                  <ol className="mt-4 space-y-3 text-sm leading-7 text-[#302d29]">
+                    {payload.instructions.map((step) => <li key={step}>{step}</li>)}
+                  </ol>
+                </section>
+
+                <section className="rounded-[1.4rem] border border-[#ddd6ca] bg-[#f1eee7] p-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Hosted Suite</div>
+                    <div className="text-[11px] uppercase tracking-[0.16em] text-[#756e62]">
+                      {refreshing ? "Refreshing" : "Live"}
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm leading-7 text-[#4f4a43]">{payload.hostedNote.note}</p>
+                  <div className="mt-5 rounded-[1rem] bg-[#111111] px-4 py-3 text-sm text-white">
+                    Suite: <span className="font-medium">{payload.hostedWeb.suiteSlug ?? "hosted-web"}</span>
+                    <br />
+                    Active Case: <span className="font-medium">
+                      {activeSession ? activeSession.title ?? activeSession.taskSlug : "none"}
+                    </span>
+                    <br />
+                    Progress: <span className="font-medium">
+                      {payload.hostedWeb.progress.completed} / {payload.hostedWeb.progress.total}
+                    </span>
+                  </div>
+                  {payload.hostedWeb.orchestratorUrl && activeSession && !isTerminal ? (
+                    <a
+                      href={payload.hostedWeb.orchestratorUrl}
+                      className="mt-4 inline-flex rounded-full bg-[#111111] px-5 py-2.5 text-sm font-medium text-white"
+                    >
+                      {actionLabel}
+                    </a>
+                  ) : (
+                    <div className="mt-4 rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-3 text-sm text-[#4f4a43]">
+                      {isTerminal ? "The suite is complete." : "Waiting for the next active case."}
+                    </div>
+                  )}
+                </section>
+              </div>
+
+              <section className="mt-6 rounded-[1.4rem] border border-[#ddd6ca] bg-white p-5">
+                <div className="mb-5 grid gap-3">
+                  {payload.hostedWeb.sessions.map((session) => (
+                    <div
+                      key={session.sessionId}
+                      className="flex items-start justify-between gap-3 rounded-[1rem] border border-[#e4ddd1] bg-[#faf7f1] px-4 py-3"
+                    >
+                      <div>
+                        <div className="text-sm font-medium text-[#111111]">{session.title ?? session.taskSlug}</div>
+                        <div className="mt-1 text-xs text-[#6b655b]">Case {session.sequenceIndex + 1} · {session.app}</div>
+                        {session.status === "active" ? (
+                          <div className="mt-2 text-sm leading-7 text-[#4f4a43]">{session.goal}</div>
+                        ) : null}
+                      </div>
+                      <div className={`rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${sessionTone(session.status)}`}>
+                        {session.status.replaceAll("-", " ")}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="text-xs uppercase tracking-[0.18em] text-[#756e62]">Current Prompt</div>
+                <pre className="mt-4 overflow-x-auto whitespace-pre-wrap rounded-[1rem] bg-[#f6f3ed] p-4 text-sm leading-7 text-[#25221d]">
+                  {payload.prompt}
+                </pre>
+              </section>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/run/RunMetadataForm.tsx
+++ b/apps/web/components/run/RunMetadataForm.tsx
@@ -2,28 +2,25 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-
-type AgentIdentity = {
-  name: string;
-  version: string;
-  baseModel: string;
-};
+import type { AgentIdentity } from "@agentbench/protocol";
+import { resolveAgentIdentity } from "@/lib/agent-catalog";
+import { AgentIdentityFields, identityDraftFromAgent } from "./AgentIdentityFields";
 
 export function RunMetadataForm({
   runId,
   initialAgent,
   initialMetadata,
   locked,
+  onSaved,
 }: {
   runId: string;
   initialAgent: AgentIdentity | null;
   initialMetadata: Record<string, unknown>;
   locked: boolean;
+  onSaved?: (agent: AgentIdentity, metadata: Record<string, unknown>) => void;
 }) {
   const router = useRouter();
-  const [name, setName] = useState(initialAgent?.name ?? "");
-  const [version, setVersion] = useState(initialAgent?.version ?? "");
-  const [baseModel, setBaseModel] = useState(initialAgent?.baseModel ?? "");
+  const [identity, setIdentity] = useState(() => identityDraftFromAgent(initialAgent));
   const [metadata, setMetadata] = useState(() => JSON.stringify(initialMetadata, null, 2));
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState<{ tone: "success" | "error"; text: string } | null>(null);
@@ -45,12 +42,18 @@ export function RunMetadataForm({
       return;
     }
 
+    const resolvedIdentity = resolveAgentIdentity(identity);
+    if (!resolvedIdentity) {
+      setMessage({ tone: "error", text: "Agent, version, and base model are required." });
+      return;
+    }
+
     setSubmitting(true);
     try {
       const response = await fetch(`/api/runs/${runId}/metadata`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, version, baseModel, metadata: parsedMetadata }),
+        body: JSON.stringify({ ...resolvedIdentity, metadata: parsedMetadata }),
       });
       const result = await response.json().catch(() => null);
 
@@ -59,6 +62,7 @@ export function RunMetadataForm({
       }
 
       setMessage({ tone: "success", text: "Agent metadata saved. You can start the benchmark." });
+      onSaved?.(resolvedIdentity, parsedMetadata as Record<string, unknown>);
       router.refresh();
     } catch (error) {
       setMessage({ tone: "error", text: error instanceof Error ? error.message : "Unable to save agent metadata." });
@@ -77,20 +81,7 @@ export function RunMetadataForm({
         Register the agent identity before opening the active benchmark.
       </p>
       <form onSubmit={submit} className="mt-5">
-        <div className="grid gap-4 md:grid-cols-3">
-          <label className="text-xs font-medium text-[#4f4a43]">
-            Agent name
-            <input required maxLength={120} value={name} onChange={(event) => setName(event.target.value)} disabled={locked} className={inputClass} />
-          </label>
-          <label className="text-xs font-medium text-[#4f4a43]">
-            Agent version
-            <input required maxLength={120} value={version} onChange={(event) => setVersion(event.target.value)} disabled={locked} className={inputClass} />
-          </label>
-          <label className="text-xs font-medium text-[#4f4a43]">
-            Base model
-            <input required maxLength={160} value={baseModel} onChange={(event) => setBaseModel(event.target.value)} disabled={locked} className={inputClass} />
-          </label>
-        </div>
+        <AgentIdentityFields value={identity} onChange={setIdentity} disabled={locked} />
         <label className="mt-4 block text-xs font-medium text-[#4f4a43]">
           Additional metadata (JSON)
           <textarea

--- a/apps/web/lib/agent-catalog.ts
+++ b/apps/web/lib/agent-catalog.ts
@@ -1,0 +1,64 @@
+import type { AgentIdentity } from "@agentbench/protocol";
+
+export type AgentCatalogOption = {
+  value: string;
+  label: string;
+};
+
+export type ModelCatalogOption = AgentCatalogOption & {
+  provider: string;
+};
+
+export type AgentCatalog = {
+  agents: AgentCatalogOption[];
+  models: ModelCatalogOption[];
+};
+
+export const OTHER_OPTION_VALUE = "__other__";
+
+export const agentCatalog: AgentCatalog = {
+  agents: [
+    { value: "Codex", label: "Codex" },
+    { value: "Claude Code", label: "Claude Code" },
+    { value: "Cursor", label: "Cursor" },
+    { value: "OpenHands", label: "OpenHands" },
+    { value: "Cline", label: "Cline" },
+    { value: "Aider", label: "Aider" },
+    { value: "Browser Use", label: "Browser Use" },
+  ],
+  models: [
+    { value: "GPT-5", label: "GPT-5", provider: "OpenAI" },
+    { value: "Claude Sonnet", label: "Claude Sonnet", provider: "Anthropic" },
+    { value: "Claude Opus", label: "Claude Opus", provider: "Anthropic" },
+    { value: "Gemini 2.5 Pro", label: "Gemini 2.5 Pro", provider: "Google" },
+    { value: "Gemini 2.5 Flash", label: "Gemini 2.5 Flash", provider: "Google" },
+    { value: "DeepSeek", label: "DeepSeek", provider: "DeepSeek" },
+    { value: "Qwen", label: "Qwen", provider: "Alibaba Cloud" },
+    { value: "Llama", label: "Llama", provider: "Meta" },
+  ],
+};
+
+export function catalogSelection(value: string, options: AgentCatalogOption[]) {
+  if (!value) {
+    return "";
+  }
+  return options.some((option) => option.value === value) ? value : OTHER_OPTION_VALUE;
+}
+
+export function resolveCatalogValue(selection: string, customValue: string) {
+  return (selection === OTHER_OPTION_VALUE ? customValue : selection).trim();
+}
+
+export function resolveAgentIdentity(input: {
+  agentSelection: string;
+  customAgent: string;
+  agentVersion: string;
+  modelSelection: string;
+  customModel: string;
+}): AgentIdentity | null {
+  const name = resolveCatalogValue(input.agentSelection, input.customAgent);
+  const version = input.agentVersion.trim();
+  const baseModel = resolveCatalogValue(input.modelSelection, input.customModel);
+
+  return name && version && baseModel ? { name, version, baseModel } : null;
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -11,7 +11,7 @@ import type { Database } from "@agentbench/shared";
 import path from "node:path";
 import fs from "node:fs";
 import { createSupabaseAdminClient } from "./supabase/admin";
-import { buildRunMetadataUpdate, parseBrowserEnvironment } from "./run-metadata";
+import { buildInitialRunMetadata, buildRunMetadataUpdate, parseBrowserEnvironment } from "./run-metadata";
 import { completableRunStatuses, terminalRunStatuses } from "./run-lifecycle";
 
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
@@ -245,6 +245,8 @@ export async function createBenchmarkRun(params: {
   guestId: string | null;
   executionMode: BenchmarkRun["executionMode"];
   isPublic: boolean;
+  agent?: BenchmarkRun["agent"];
+  browserEnvironment: NonNullable<BenchmarkRun["browserEnvironment"]>;
 }): Promise<BenchmarkRun> {
   const supabase = getSupabase();
   const benchmarkCase = await getBenchmarkCase(params.caseId);
@@ -252,6 +254,11 @@ export async function createBenchmarkRun(params: {
     throw new BenchmarkCaseUnavailableError();
   }
   const initialStatus = params.executionMode === "external-agent" ? "waiting_for_agent" : "queued";
+  const initialMetadata = buildInitialRunMetadata({
+    agent: params.agent ?? undefined,
+    browserEnvironment: params.browserEnvironment,
+    now: new Date().toISOString(),
+  });
 
   const { data, error } = await supabase
     .from("benchmark_runs")
@@ -262,6 +269,7 @@ export async function createBenchmarkRun(params: {
       execution_mode: params.executionMode,
       status: initialStatus,
       is_public: params.isPublic,
+      ...initialMetadata,
     })
     .select(benchmarkRunSelect)
     .single();
@@ -273,7 +281,11 @@ export async function createBenchmarkRun(params: {
   await supabase.from("run_events").insert({
     run_id: data.id,
     type: "run.created",
-    payload: { status: initialStatus, executionMode: params.executionMode },
+    payload: {
+      status: initialStatus,
+      executionMode: params.executionMode,
+      agent: params.agent ?? null,
+    },
   });
 
   return mapRunRow(data);

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -13,6 +13,7 @@ import {
   deriveHostedScoring,
   type HostedSessionBreakdown,
 } from "./hosted-scoring";
+import { resolveAgentIdentity } from "./agent-catalog";
 
 export type PlaygroundBenchmark = "hosted-web-suite";
 
@@ -39,6 +40,11 @@ type PlaygroundStore = {
   endpoint: string;
   apiKey: string;
   benchmark: PlaygroundBenchmark;
+  agentSelection: string;
+  customAgent: string;
+  agentVersion: string;
+  modelSelection: string;
+  customModel: string;
   currentRunId: string | null;
   currentExecutionMode: RunExecutionMode | null;
   liveViewUrl: string | null;
@@ -60,6 +66,11 @@ type PlaygroundStore = {
   setEndpoint: (value: string) => void;
   setApiKey: (value: string) => void;
   setBenchmark: (value: PlaygroundBenchmark) => void;
+  setAgentSelection: (value: string) => void;
+  setCustomAgent: (value: string) => void;
+  setAgentVersion: (value: string) => void;
+  setModelSelection: (value: string) => void;
+  setCustomModel: (value: string) => void;
   setActiveTab: (value: PanelTab) => void;
   setLiveSlide: (index: number) => void;
   fetchQuota: () => Promise<void>;
@@ -82,6 +93,11 @@ const initialState = {
   endpoint: "",
   apiKey: "",
   benchmark: "hosted-web-suite" as PlaygroundBenchmark,
+  agentSelection: "",
+  customAgent: "",
+  agentVersion: "latest",
+  modelSelection: "",
+  customModel: "",
   currentRunId: null,
   currentExecutionMode: null,
   liveViewUrl: null,
@@ -531,6 +547,11 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
   setEndpoint: (value) => set({ endpoint: value }),
   setApiKey: (value) => set({ apiKey: value }),
   setBenchmark: (value) => set({ benchmark: value }),
+  setAgentSelection: (value) => set({ agentSelection: value }),
+  setCustomAgent: (value) => set({ customAgent: value }),
+  setAgentVersion: (value) => set({ agentVersion: value }),
+  setModelSelection: (value) => set({ modelSelection: value }),
+  setCustomModel: (value) => set({ customModel: value }),
   setActiveTab: (value) => set({ activeTab: value }),
   setLiveSlide: (index) => set({ liveSlide: index }),
   fetchQuota: async () => {
@@ -566,7 +587,16 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
     });
 
     try {
-      const benchmark = get().benchmark;
+      const state = get();
+      const benchmark = state.benchmark;
+      const agent = resolveAgentIdentity(state);
+      if (!agent) {
+        set({
+          quotaLoading: false,
+          runError: "Select an agent and base model, and provide an agent version.",
+        });
+        return;
+      }
       const response = await fetch("/api/runs", {
         method: "POST",
         headers: {
@@ -577,6 +607,7 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
           caseId: BENCHMARK_CASE_IDS[benchmark],
           executionMode: mode,
           isPublic: true,
+          agent,
         }),
       });
 

--- a/apps/web/lib/run-connect.ts
+++ b/apps/web/lib/run-connect.ts
@@ -1,5 +1,6 @@
 import type { BenchmarkCase, BenchmarkRun } from "@agentbench/protocol";
 import { getOrCreateHostedWebAttemptConnection, isHostedWebCase } from "./hosted-web";
+import { hasRegisteredRunMetadata } from "./run-metadata";
 
 function getGoal(benchmarkCase: BenchmarkCase | null) {
   if (!benchmarkCase) {
@@ -15,8 +16,9 @@ export async function buildRunConnectPayload(params: {
   origin: string;
 }) {
   const { run, benchmarkCase, origin } = params;
+  const metadataRequired = !hasRegisteredRunMetadata(run);
   const hostedWeb =
-    benchmarkCase && isHostedWebCase(benchmarkCase)
+    !metadataRequired && benchmarkCase && isHostedWebCase(benchmarkCase)
       ? await getOrCreateHostedWebAttemptConnection({ run, benchmarkCase })
       : null;
   const connectUrl = `${origin}/runs/${run.id}/connect`;
@@ -36,6 +38,7 @@ export async function buildRunConnectPayload(params: {
     runId: run.id,
     status: run.status,
     errorMessage: run.errorMessage,
+    metadataRequired,
     benchmark: {
       id: benchmarkCase?.id ?? run.caseId,
       slug: benchmarkCase?.slug ?? null,
@@ -48,7 +51,8 @@ export async function buildRunConnectPayload(params: {
           `Open the hosted benchmark site for run ${run.id}.`,
           `This suite contains ${hostedWeb.sessions.length} hosted session${hostedWeb.sessions.length === 1 ? "" : "s"}.`,
           "Register the agent name, version, base model, and optional metadata in the form on this page.",
-          "Start from the active hosted URL and progress through the ordered suite.",
+          "Open only the active hosted case shown on this page.",
+          "After each case completes, return here and proceed to the next active case.",
           "Use only the session URLs allocated for this run.",
           "Stop after the active objective is completed or clearly blocked.",
         ]

--- a/apps/web/lib/run-metadata.ts
+++ b/apps/web/lib/run-metadata.ts
@@ -1,4 +1,4 @@
-import type { BrowserEnvironment, SubmitRunMetadataInput } from "@agentbench/protocol";
+import type { AgentIdentity, BrowserEnvironment, SubmitRunMetadataInput } from "@agentbench/protocol";
 import type { Database } from "@agentbench/shared";
 
 function browserFromUserAgent(userAgent: string) {
@@ -67,8 +67,44 @@ export function buildRunMetadataUpdate(params: {
     agent_version: params.input.version,
     base_model: params.input.baseModel,
     browser_environment: params.browserEnvironment,
-    metadata: { ...params.currentMetadata, ...params.input.metadata, identityReportedAt: params.now },
+    metadata: {
+      ...params.currentMetadata,
+      ...params.input.metadata,
+      identityReportedAt: params.now,
+      identitySource: "connection-page",
+    },
     started_at: params.startedAt ?? params.now,
     status: params.currentStatus === "waiting_for_agent" ? "agent_connected" : params.currentStatus,
+  };
+}
+
+export function hasRegisteredRunMetadata(run: {
+  agent: AgentIdentity | null;
+  status: string;
+  metadata: Record<string, unknown>;
+}) {
+  return Boolean(
+    run.agent &&
+    (run.metadata.identitySource === "connection-page" || run.status !== "waiting_for_agent"),
+  );
+}
+
+export function buildInitialRunMetadata(params: {
+  agent: AgentIdentity | undefined;
+  browserEnvironment: BrowserEnvironment;
+  now: string;
+}): Database["public"]["Tables"]["benchmark_runs"]["Update"] {
+  if (!params.agent) {
+    return {
+      browser_environment: params.browserEnvironment,
+    };
+  }
+
+  return {
+    agent_name: params.agent.name,
+    agent_version: params.agent.version,
+    base_model: params.agent.baseModel,
+    browser_environment: params.browserEnvironment,
+    metadata: { identityReportedAt: params.now, identitySource: "run-creation" },
   };
 }

--- a/apps/web/tests/unit/agent-catalog.test.ts
+++ b/apps/web/tests/unit/agent-catalog.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  agentCatalog,
+  catalogSelection,
+  OTHER_OPTION_VALUE,
+  resolveAgentIdentity,
+} from "../../lib/agent-catalog";
+
+test("agent and model catalog values are unique", () => {
+  assert.equal(new Set(agentCatalog.agents.map((option) => option.value)).size, agentCatalog.agents.length);
+  assert.equal(new Set(agentCatalog.models.map((option) => option.value)).size, agentCatalog.models.length);
+});
+
+test("known catalog values remain selected", () => {
+  assert.equal(catalogSelection("", agentCatalog.agents), "");
+  assert.equal(catalogSelection("Codex", agentCatalog.agents), "Codex");
+  assert.equal(catalogSelection("Private Agent", agentCatalog.agents), OTHER_OPTION_VALUE);
+});
+
+test("resolves catalog and custom identity values", () => {
+  assert.deepEqual(
+    resolveAgentIdentity({
+      agentSelection: "Codex",
+      customAgent: "",
+      agentVersion: "1.2.3",
+      modelSelection: OTHER_OPTION_VALUE,
+      customModel: "private-model-v2",
+    }),
+    { name: "Codex", version: "1.2.3", baseModel: "private-model-v2" },
+  );
+});
+
+test("rejects incomplete identity drafts", () => {
+  assert.equal(
+    resolveAgentIdentity({
+      agentSelection: OTHER_OPTION_VALUE,
+      customAgent: "",
+      agentVersion: "latest",
+      modelSelection: "GPT-5",
+      customModel: "",
+    }),
+    null,
+  );
+});

--- a/apps/web/tests/unit/run-metadata.test.ts
+++ b/apps/web/tests/unit/run-metadata.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildRunMetadataUpdate, captureBrowserEnvironment, parseBrowserEnvironment } from "../../lib/run-metadata";
+import {
+  buildInitialRunMetadata,
+  buildRunMetadataUpdate,
+  captureBrowserEnvironment,
+  hasRegisteredRunMetadata,
+  parseBrowserEnvironment,
+} from "../../lib/run-metadata";
 
 test("captures Chromium browser metadata without exposing it to leaderboard callers", () => {
   const environment = captureBrowserEnvironment(new Headers({
@@ -53,6 +59,7 @@ test("first agent registration starts and connects a waiting run", () => {
   assert.deepEqual(patch.metadata, {
     source: "agent",
     identityReportedAt: "2026-06-19T12:00:00.000Z",
+    identitySource: "connection-page",
   });
 });
 
@@ -68,4 +75,34 @@ test("repeated registration preserves the original start time", () => {
 
   assert.equal(patch.started_at, "2026-06-19T11:59:00.000Z");
   assert.equal(patch.status, "running");
+});
+
+test("run creation persists selected identity without connecting the agent", () => {
+  const insert = buildInitialRunMetadata({
+    agent: { name: "Codex", version: "latest", baseModel: "GPT-5" },
+    browserEnvironment: { browser: "Chrome", browserVersion: "126", platform: "macOS", mobile: false },
+    now: "2026-06-24T12:00:00.000Z",
+  });
+
+  assert.equal(insert.agent_name, "Codex");
+  assert.equal(insert.agent_version, "latest");
+  assert.equal(insert.base_model, "GPT-5");
+  assert.deepEqual(insert.metadata, {
+    identityReportedAt: "2026-06-24T12:00:00.000Z",
+    identitySource: "run-creation",
+  });
+});
+
+test("run creation identity does not unlock the hosted suite before connection registration", () => {
+  assert.equal(hasRegisteredRunMetadata({
+    agent: { name: "Codex", version: "latest", baseModel: "GPT-5" },
+    status: "waiting_for_agent",
+    metadata: { identitySource: "run-creation" },
+  }), false);
+
+  assert.equal(hasRegisteredRunMetadata({
+    agent: { name: "Codex", version: "latest", baseModel: "GPT-5" },
+    status: "agent_connected",
+    metadata: { identitySource: "connection-page" },
+  }), true);
 });

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,6 +20,7 @@ Hosted task requests use an opaque session token in `?session=<token>` or in the
 | `GET` | `/api/runs/:runId/stream` | SSE snapshots, heartbeat, terminal event | run visibility rules |
 | `GET` | `/api/runs/:runId/artifacts` | List artifacts | run visibility rules |
 | `GET` | `/api/runs/:runId/artifacts/file?path=...` | Read local artifact file | run visibility rules |
+| `GET` | `/api/agent-options` | List curated agent and model options | public |
 
 ### Create Run
 
@@ -29,11 +30,16 @@ Content-Type: application/json
 
 {
   "caseId": "uuid",
-  "executionMode": "external-agent"
+  "executionMode": "external-agent",
+  "agent": {
+    "name": "Codex",
+    "version": "latest",
+    "baseModel": "GPT-5"
+  }
 }
 ```
 
-Response: `201 { run, quota }`. Quota exhaustion returns `403` with `trial_limit_reached` or `daily_limit_reached`.
+Response: `201 { run, quota }`. The service persists the self-reported identity and captures the request browser environment. `GET /api/agent-options` provides curated choices, but clients may submit other non-empty values. Quota exhaustion returns `403` with `trial_limit_reached` or `daily_limit_reached`.
 
 ### Connect Run
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -34,7 +34,7 @@ erDiagram
 
 ### `benchmark_case_revisions`
 
-An immutable, service-role-only release record containing `revision`, SHA-256 `content_hash`, and the complete validated private `manifest`. Publication is atomic and idempotent through `publish_benchmark_case_revision`; normal updates and deletes are rejected. Historical attempts keep their revision foreign key when the case's current revision changes.
+An immutable, service-role-only release record containing `revision`, SHA-256 `content_hash`, and the complete validated private `manifest`. Catalog publication is atomic and idempotent through `publish_benchmark_case_catalog`, which synchronizes the public case identity before selecting the immutable revision. Normal revision updates and deletes are rejected. Historical attempts keep their revision foreign key when the case's current revision changes.
 
 ### `benchmark_runs`
 

--- a/docs/data-ownership.md
+++ b/docs/data-ownership.md
@@ -9,7 +9,7 @@ This document defines who may read, mutate, and recover each state family. Owner
 | `profiles`, Supabase Auth identity | Web control plane | Supabase Auth / Web | Web | User identity and plan data |
 | `benchmark_cases` | Web control plane | release/admin workflow | Web, orchestrator service-role code | Case identity, visibility, display fields, and current revision pointer |
 | `public_benchmark_cases` | Web control plane | database projection | anonymous/authenticated clients, Web | Display-safe discovery only |
-| `benchmark_case_revisions` | benchmark release workflow | `publish_benchmark_case_revision` | orchestrator, Web service-role recovery | Immutable private manifest for historical interpretation |
+| `benchmark_case_revisions` | benchmark release workflow | `publish_benchmark_case_catalog` | orchestrator, Web service-role recovery | Immutable private manifest plus synchronized public case identity |
 | `benchmark_runs` | Web control plane | Web | Web, public read models | User-facing run lifecycle |
 | `run_events`, `artifacts` | Web control plane | Web internal APIs | Web UI and public read models | Live observability and output artifacts |
 | `benchmark_attempts` | hosted orchestrator | orchestrator workers and transactional RPCs | orchestrator only; Web uses orchestrator APIs/public read models | Canonical hosted attempt lifecycle and active-session pointer |

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -183,6 +183,7 @@ export const createRunInputSchema = z.object({
   caseId: z.string().uuid(),
   executionMode: runExecutionModeSchema.default("external-agent"),
   isPublic: z.boolean().default(true),
+  agent: agentIdentitySchema.optional(),
 });
 
 export type CreateRunInput = z.infer<typeof createRunInputSchema>;

--- a/packages/test-cases/scripts/publish.ts
+++ b/packages/test-cases/scripts/publish.ts
@@ -11,7 +11,7 @@ if (!supabaseUrl || !serviceRoleKey) {
 const release = createHostedWebCatalogRelease();
 hostedSuiteMetadataSchema.parse(release.manifest);
 
-const response = await fetch(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/rpc/publish_benchmark_case_revision`, {
+const response = await fetch(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/rpc/publish_benchmark_case_catalog`, {
   method: "POST",
   headers: {
     apikey: serviceRoleKey,
@@ -19,7 +19,7 @@ const response = await fetch(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/rpc/publ
     "Content-Type": "application/json",
   },
   body: JSON.stringify({
-    target_case_id: release.caseId,
+    target_case: release.benchmarkCase,
     target_revision: release.revision,
     target_manifest: release.manifest,
     target_content_hash: release.contentHash,

--- a/packages/test-cases/src/release.ts
+++ b/packages/test-cases/src/release.ts
@@ -5,6 +5,7 @@ export function createHostedWebCatalogRelease() {
   const manifest = hostedWebSuiteMetadata;
   return {
     caseId: hostedWebSuiteCase.id,
+    benchmarkCase: hostedWebSuiteCase,
     revision: hostedWebSuiteRevision,
     manifest,
     contentHash: createHash("sha256").update(JSON.stringify(manifest)).digest("hex"),

--- a/packages/test-cases/src/seed-sql.ts
+++ b/packages/test-cases/src/seed-sql.ts
@@ -1,38 +1,13 @@
 import { hostedWebSuiteCase } from "./index.js";
 import { createHostedWebCatalogRelease } from "./release.js";
 
-function sqlString(value: string) {
-  return `'${value.replaceAll("'", "''")}'`;
-}
-
 export function generateSupabaseSeedSql() {
   const release = createHostedWebCatalogRelease();
   const manifest = JSON.stringify(release.manifest, null, 2);
 
   return `-- Generated from packages/test-cases. Run \`pnpm catalog:generate\`; do not edit by hand.
-insert into public.benchmark_cases (id, slug, title, description, category, difficulty, provider, is_public)
-values (
-  '${hostedWebSuiteCase.id}',
-  ${sqlString(hostedWebSuiteCase.slug)},
-  ${sqlString(hostedWebSuiteCase.title)},
-  ${sqlString(hostedWebSuiteCase.description)},
-  ${sqlString(hostedWebSuiteCase.category)},
-  ${sqlString(hostedWebSuiteCase.difficulty)},
-  '${hostedWebSuiteCase.provider}',
-  true
-)
-on conflict (id) do update
-set
-  slug = excluded.slug,
-  title = excluded.title,
-  description = excluded.description,
-  category = excluded.category,
-  difficulty = excluded.difficulty,
-  provider = excluded.provider,
-  is_public = excluded.is_public;
-
-select public.publish_benchmark_case_revision(
-  '${hostedWebSuiteCase.id}',
+select public.publish_benchmark_case_catalog(
+  $case$${JSON.stringify(hostedWebSuiteCase, null, 2)}$case$::jsonb,
   '${release.revision}',
   $catalog$${manifest}$catalog$::jsonb,
   '${release.contentHash}'

--- a/scripts/test-case-revisions-postgres.sh
+++ b/scripts/test-case-revisions-postgres.sh
@@ -144,6 +144,8 @@ fi
 
 "${PSQL[@]}" -v ON_ERROR_STOP=1 \
   < "${ROOT_DIR}/supabase/migrations/20260622000021_unify_benchmark_case_model.sql" >/dev/null
+"${PSQL[@]}" -v ON_ERROR_STOP=1 \
+  < "${ROOT_DIR}/supabase/migrations/20260624000024_publish_benchmark_case_catalog.sql" >/dev/null
 
 [[ "$(${PSQL[@]} -Atqc "select slug from public.benchmark_cases where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'")" == "hosted-web-suite" ]]
 [[ "$(${PSQL[@]} -Atqc "select metadata from public.benchmark_cases where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'")" == "{}" ]]
@@ -162,5 +164,27 @@ post_migration_revision="$(${PSQL[@]} -Atqc "
 ")"
 [[ "${post_migration_revision}" == "${published_revision}" ]]
 [[ "$(${PSQL[@]} -Atqc "select metadata from public.benchmark_cases where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'")" == "{}" ]]
+
+"${PSQL[@]}" -v ON_ERROR_STOP=1 -c "
+  update public.benchmark_cases
+  set description = 'Run a four-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite.'
+  where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005';
+" >/dev/null
+"${PSQL[@]}" -v ON_ERROR_STOP=1 \
+  < "${ROOT_DIR}/supabase/migrations/20260624000024_publish_benchmark_case_catalog.sql" >/dev/null
+[[ "$(${PSQL[@]} -Atqc "select description from public.benchmark_cases where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'")" == "Run the published deterministic hosted-web benchmark suite." ]]
+
+catalog_revision="$(${PSQL[@]} -Atqc "
+  set role service_role;
+  select public.publish_benchmark_case_catalog(
+    '{\"id\":\"7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005\",\"slug\":\"hosted-web-suite\",\"title\":\"Hosted Web Suite\",\"description\":\"Current dynamic suite\",\"category\":\"browser\",\"difficulty\":\"easy\",\"provider\":\"hosted-web\",\"isPublic\":true}'::jsonb,
+    'v3',
+    '{\"suiteSlug\":\"hosted-suite\",\"suiteVersion\":\"v3\",\"sessions\":[]}'::jsonb,
+    repeat('d', 64)
+  );
+")"
+[[ -n "${catalog_revision}" ]]
+[[ "$(${PSQL[@]} -Atqc "select description from public.benchmark_cases where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'")" == "Current dynamic suite" ]]
+[[ "$(${PSQL[@]} -Atqc "select current_revision_id from public.benchmark_cases where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'")" == "${catalog_revision}" ]]
 
 echo "benchmark case revision Postgres tests passed"

--- a/supabase/migrations/20260624000024_publish_benchmark_case_catalog.sql
+++ b/supabase/migrations/20260624000024_publish_benchmark_case_catalog.sql
@@ -1,0 +1,83 @@
+-- Publish public case identity and its immutable private revision atomically.
+create or replace function public.publish_benchmark_case_catalog(
+  target_case jsonb,
+  target_revision text,
+  target_manifest jsonb,
+  target_content_hash text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  target_case_id uuid;
+  revision_id uuid;
+begin
+  if target_case is null or jsonb_typeof(target_case) <> 'object' then
+    raise exception 'case must be a JSON object' using errcode = '22023';
+  end if;
+
+  target_case_id := (target_case ->> 'id')::uuid;
+  if target_case_id is null
+    or nullif(btrim(target_case ->> 'slug'), '') is null
+    or nullif(btrim(target_case ->> 'title'), '') is null
+    or nullif(btrim(target_case ->> 'description'), '') is null
+    or nullif(btrim(target_case ->> 'category'), '') is null
+    or nullif(btrim(target_case ->> 'difficulty'), '') is null
+    or nullif(btrim(target_case ->> 'provider'), '') is null then
+    raise exception 'case identity fields are required' using errcode = '22023';
+  end if;
+
+  insert into public.benchmark_cases (
+    id,
+    slug,
+    title,
+    description,
+    category,
+    difficulty,
+    provider,
+    metadata,
+    is_public
+  )
+  values (
+    target_case_id,
+    target_case ->> 'slug',
+    target_case ->> 'title',
+    target_case ->> 'description',
+    target_case ->> 'category',
+    target_case ->> 'difficulty',
+    target_case ->> 'provider',
+    '{}'::jsonb,
+    coalesce((target_case ->> 'isPublic')::boolean, true)
+  )
+  on conflict (id) do update
+  set
+    slug = excluded.slug,
+    title = excluded.title,
+    description = excluded.description,
+    category = excluded.category,
+    difficulty = excluded.difficulty,
+    provider = excluded.provider,
+    is_public = excluded.is_public;
+
+  revision_id := public.publish_benchmark_case_revision(
+    target_case_id,
+    target_revision,
+    target_manifest,
+    target_content_hash
+  );
+
+  return revision_id;
+end;
+$$;
+
+revoke all on function public.publish_benchmark_case_catalog(jsonb, text, jsonb, text)
+  from public, anon, authenticated;
+grant execute on function public.publish_benchmark_case_catalog(jsonb, text, jsonb, text)
+  to service_role;
+
+update public.benchmark_cases
+set description = 'Run the published deterministic hosted-web benchmark suite.'
+where id = '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005'
+  and description = 'Run a four-step hosted suite across shopping-lite, forum-lite, repo-lite, and wiki-lite.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,27 +1,16 @@
 -- Generated from packages/test-cases. Run `pnpm catalog:generate`; do not edit by hand.
-insert into public.benchmark_cases (id, slug, title, description, category, difficulty, provider, is_public)
-values (
-  '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005',
-  'hosted-web-suite',
-  'Hosted Web Suite',
-  'Run the published deterministic hosted-web benchmark suite.',
-  'browser',
-  'easy',
-  'hosted-web',
-  true
-)
-on conflict (id) do update
-set
-  slug = excluded.slug,
-  title = excluded.title,
-  description = excluded.description,
-  category = excluded.category,
-  difficulty = excluded.difficulty,
-  provider = excluded.provider,
-  is_public = excluded.is_public;
-
-select public.publish_benchmark_case_revision(
-  '7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005',
+select public.publish_benchmark_case_catalog(
+  $case${
+  "id": "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",
+  "slug": "hosted-web-suite",
+  "title": "Hosted Web Suite",
+  "description": "Run the published deterministic hosted-web benchmark suite.",
+  "category": "browser",
+  "difficulty": "easy",
+  "provider": "hosted-web",
+  "metadata": {},
+  "isPublic": true
+}$case$::jsonb,
   'hosted-web-suite-v3.0.2',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",


### PR DESCRIPTION
## What changed

- add backend-provided agent/model options with an Other path and persist identity/browser metadata at run creation
- require connection-page metadata registration before allocating and revealing the hosted suite
- refresh active case state dynamically and require users to return to the connection page before proceeding
- show a return-to-connection prompt on completed hosted cases
- publish public benchmark case metadata atomically with revisions and repair the stale four-step description

## Why

Runs could be created without usable agent metadata, the connection page exposed stale active-session state until a manual refresh, and the published suite description remained coupled to an obsolete four-case layout.

## Validation

- `pnpm verify:ci`
- browser E2E for metadata gating and immediate post-submit suite loading
- Postgres revision/catalog integration tests
- web and hosted-sites production builds