### PR TITLE
[codex] publish failed scored runs

### DIFF
--- a/apps/web/app/results/[runId]/page.tsx
+++ b/apps/web/app/results/[runId]/page.tsx
@@ -22,12 +22,19 @@ export default async function PublicResultPage({ params }: { params: Promise<{ r
         <div className="mt-8 grid gap-8 border-b border-white/10 pb-10 lg:grid-cols-[1fr_auto] lg:items-end">
           <div>
             <div className="text-xs uppercase tracking-[0.2em] text-white/40">Public benchmark result</div>
+            {run.status === "failed" ? (
+              <div className="mt-3 inline-flex rounded-full bg-[#ff8d7a]/15 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#ff9f90]">
+                Failed run · partial score
+              </div>
+            ) : null}
             <h1 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-white md:text-6xl">{benchmark.title}</h1>
             <p className="mt-4 max-w-2xl text-base leading-7 text-white/55">{benchmark.description}</p>
           </div>
           <div className="text-left lg:text-right">
             <div className="text-7xl font-medium tracking-[-0.07em] text-[#d7ff00]">{Math.round((run.score ?? 0) * 100)}</div>
-            <div className="text-xs uppercase tracking-[0.2em] text-white/40">Aggregate score</div>
+            <div className="text-xs uppercase tracking-[0.2em] text-white/40">
+              {run.status === "failed" ? "Partial aggregate score" : "Aggregate score"}
+            </div>
           </div>
         </div>
 

--- a/apps/web/components/landing/Leaderboard.tsx
+++ b/apps/web/components/landing/Leaderboard.tsx
@@ -30,7 +30,7 @@ export async function Leaderboard() {
             </h2>
           </div>
           <p className="max-w-xl text-base leading-7 text-[#66625a] lg:justify-self-end">
-            Completed public runs are ranked within the same benchmark version. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
+            Completed and failed scored runs are ranked within the same benchmark version. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
           </p>
         </div>
 

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -86,7 +86,7 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
           <span>Agent / model</span>
           <span>Benchmark</span>
           <span>Browser</span>
-          <span>Completed</span>
+          <span>Finished</span>
           <span className="text-right">Score</span>
         </div>
 
@@ -106,6 +106,11 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
                   <span className="lg:hidden">{entry.baseModel}</span>
                   <span className="hidden lg:inline">{entry.agentVersion} · {entry.baseModel}</span>
                 </div>
+                {entry.status === "failed" ? (
+                  <div className="mt-2 inline-flex rounded-full bg-[#ff8d7a]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ff9f90]">
+                    Failed run
+                  </div>
+                ) : null}
               </div>
               <div className="hidden min-w-0 lg:block">
                 <div className="truncate text-sm text-white/85">{entry.benchmark}</div>
@@ -119,7 +124,9 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
               </div>
               <div className="hidden text-sm text-white/70 lg:block">{formatCompletedAt(entry.completedAt)}</div>
               <div className="text-right">
-                <span className="text-2xl font-medium tracking-[-0.04em] text-white group-hover:text-[#d7ff00] lg:text-3xl">
+                <span className={`text-2xl font-medium tracking-[-0.04em] lg:text-3xl ${
+                  entry.status === "failed" ? "text-[#ff9f90]" : "text-white group-hover:text-[#d7ff00]"
+                }`}>
                   {Math.round(entry.score * 100)}
                 </span>
                 <span className="ml-0.5 text-[10px] text-white/35 lg:ml-1 lg:text-xs">%</span>

--- a/apps/web/components/landing/PlaygroundSection.tsx
+++ b/apps/web/components/landing/PlaygroundSection.tsx
@@ -34,7 +34,7 @@ export function PlaygroundSection({
             Each hosted run uses fixed task rules, structured events, and scorer checks so agent behavior can be compared across attempts.
           </p>
           <p className="mt-3 text-sm leading-6 text-[#7a7469]">
-            Completed runs are published to the leaderboard. Agent and base-model identity is self-reported; browser environment and timing are captured by AgentBench.
+            Completed and failed scored runs are published to the leaderboard. Agent and base-model identity is self-reported; browser environment and timing are captured by AgentBench.
           </p>
         </div>
 

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -558,6 +558,7 @@ export async function submitBenchmarkRunMetadata(
 export type LeaderboardEntry = {
   runId: string;
   rank: number;
+  status: "completed" | "failed";
   score: number;
   completedAt: string;
   durationMs: number | null;
@@ -590,7 +591,7 @@ export async function getPublicBenchmarkResult(runId: string): Promise<PublicBen
     .from("benchmark_runs")
     .select(benchmarkRunSelect)
     .eq("id", runId)
-    .eq("status", "completed")
+    .in("status", ["completed", "failed"])
     .eq("is_public", true)
     .maybeSingle();
   if (error) throw error;
@@ -629,7 +630,7 @@ export async function listPublicLeaderboardVersions(): Promise<string[]> {
   const { data: publicRuns, error: runError } = await supabase
     .from("benchmark_runs")
     .select("id")
-    .eq("status", "completed")
+    .in("status", ["completed", "failed"])
     .eq("is_public", true)
     .not("score", "is", null)
     .limit(1000);
@@ -677,8 +678,8 @@ export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): 
 
   let runsQuery = supabase
     .from("benchmark_runs")
-    .select("id, case_id, score, started_at, completed_at, agent_name, agent_version, base_model, browser_environment")
-    .eq("status", "completed")
+    .select("id, case_id, status, score, started_at, completed_at, agent_name, agent_version, base_model, browser_environment")
+    .in("status", ["completed", "failed"])
     .eq("is_public", true)
     .not("score", "is", null)
     .order("score", { ascending: false })
@@ -714,6 +715,7 @@ export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): 
     return {
       runId: run.id,
       rank: index + 1,
+      status: run.status as LeaderboardEntry["status"],
       score: Number(run.score),
       completedAt: run.completed_at!,
       durationMs: run.started_at && run.completed_at

--- a/scripts/test-hosted-read-models-postgres.sh
+++ b/scripts/test-hosted-read-models-postgres.sh
@@ -17,30 +17,42 @@ create role anon;
 create role authenticated;
 create role service_role bypassrls;
 create table benchmark_cases (id uuid primary key, title text not null);
-create table benchmark_runs (id uuid primary key, case_id uuid not null, status text not null, is_public boolean not null);
+create table benchmark_runs (
+  id uuid primary key,
+  case_id uuid not null,
+  status text not null,
+  is_public boolean not null,
+  score numeric,
+  completed_at timestamptz
+);
 create table benchmark_attempts (id uuid primary key, run_id uuid not null, suite_slug text not null, suite_version text not null, status text not null);
 create table hosted_web_sessions (run_id uuid not null, sequence_index int not null, first_seen_user_agent text);
 create table hosted_web_results (run_id uuid not null, app text, task_slug text, status text, score numeric, summary text, created_at timestamptz not null);
 
 insert into benchmark_cases values ('10000000-0000-0000-0000-000000000001', 'Hosted Web Suite');
 insert into benchmark_runs values
-  ('20000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', 'completed', true),
-  ('20000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', 'completed', false);
+  ('20000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', 'completed', true, 1, now()),
+  ('20000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', 'completed', false, 1, now()),
+  ('20000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000001', 'failed', true, 0, now());
 insert into benchmark_attempts values
   ('30000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001', 'suite', 'v2', 'completed'),
-  ('30000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000002', 'suite', 'v2', 'completed');
+  ('30000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000002', 'suite', 'v2', 'completed'),
+  ('30000000-0000-0000-0000-000000000003', '20000000-0000-0000-0000-000000000003', 'suite', 'v2', 'failed');
 insert into hosted_web_sessions values
   ('20000000-0000-0000-0000-000000000001', 0, 'public-agent'),
-  ('20000000-0000-0000-0000-000000000002', 0, 'private-agent');
+  ('20000000-0000-0000-0000-000000000002', 0, 'private-agent'),
+  ('20000000-0000-0000-0000-000000000003', 0, 'failed-agent');
 insert into hosted_web_results values
   ('20000000-0000-0000-0000-000000000001', 'wiki-lite', 'wiki-release-answer', 'passed', 1, 'ok', now()),
-  ('20000000-0000-0000-0000-000000000002', 'wiki-lite', 'wiki-release-answer', 'passed', 1, 'private', now());
+  ('20000000-0000-0000-0000-000000000002', 'wiki-lite', 'wiki-release-answer', 'passed', 1, 'private', now()),
+  ('20000000-0000-0000-0000-000000000003', 'repo-lite', 'repo-readme-fix', 'failed', 0, 'failed task', now());
 SQL
 
 "${PSQL[@]}" -v ON_ERROR_STOP=1 < "${ROOT_DIR}/supabase/migrations/20260622000022_hosted_public_read_models.sql" >/dev/null
+"${PSQL[@]}" -v ON_ERROR_STOP=1 < "${ROOT_DIR}/supabase/migrations/20260624000025_publish_failed_benchmark_results.sql" >/dev/null
 
-[[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_summaries')" == "1" ]]
-[[ "$(${PSQL[@]} -Atqc 'set role anon; select observed_user_agent from public_hosted_run_summaries')" == "public-agent" ]]
-[[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_tasks')" == "1" ]]
+[[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_summaries')" == "2" ]]
+[[ "$(${PSQL[@]} -Atqc "set role anon; select observed_user_agent from public_hosted_run_summaries where run_id = '20000000-0000-0000-0000-000000000003'")" == "failed-agent" ]]
+[[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_tasks')" == "2" ]]
 
 echo "hosted public read-model Postgres tests passed"

--- a/supabase/migrations/20260624000025_publish_failed_benchmark_results.sql
+++ b/supabase/migrations/20260624000025_publish_failed_benchmark_results.sql
@@ -1,0 +1,57 @@
+drop index if exists public.idx_benchmark_runs_public_leaderboard;
+
+create index idx_benchmark_runs_public_leaderboard
+  on public.benchmark_runs (score desc, completed_at asc)
+  where status in ('completed', 'failed')
+    and is_public = true
+    and score is not null;
+
+create or replace view public.public_hosted_run_summaries
+with (security_barrier = true)
+as
+select
+  runs.id as run_id,
+  runs.case_id,
+  cases.title as benchmark_title,
+  attempts.suite_slug,
+  attempts.suite_version,
+  (
+    select sessions.first_seen_user_agent
+    from public.hosted_web_sessions as sessions
+    where sessions.run_id = runs.id
+      and sessions.first_seen_user_agent is not null
+    order by sessions.sequence_index asc
+    limit 1
+  ) as observed_user_agent
+from public.benchmark_runs as runs
+join public.benchmark_cases as cases on cases.id = runs.case_id
+join public.benchmark_attempts as attempts on attempts.run_id = runs.id
+where runs.status in ('completed', 'failed')
+  and runs.is_public = true
+  and attempts.status in ('completed', 'failed');
+
+create or replace view public.public_hosted_run_tasks
+with (security_barrier = true)
+as
+select
+  results.run_id,
+  results.app,
+  results.task_slug,
+  results.status,
+  results.score,
+  results.summary,
+  results.created_at
+from public.hosted_web_results as results
+join public.benchmark_runs as runs on runs.id = results.run_id
+where runs.status in ('completed', 'failed')
+  and runs.is_public = true;
+
+revoke all on table public.public_hosted_run_summaries from public;
+revoke all on table public.public_hosted_run_tasks from public;
+grant select on table public.public_hosted_run_summaries to anon, authenticated, service_role;
+grant select on table public.public_hosted_run_tasks to anon, authenticated, service_role;
+
+comment on view public.public_hosted_run_summaries is
+  'Public terminal scored-run suite identity and observed browser projection. Web must not read hosted lifecycle tables directly.';
+comment on view public.public_hosted_run_tasks is
+  'Public terminal scored-run task result projection. Web must not read hosted lifecycle tables directly.';


### PR DESCRIPTION
## What changed

- include public failed runs with scores in leaderboard queries and suite-version discovery
- expose failed run summaries and task results through public read models
- label failed leaderboard rows and result pages as partial failed runs
- keep timeout and cancelled runs excluded

## Why

A scored run can fail one required case while still producing useful comparable benchmark evidence. Previously these runs were hidden entirely.

## Validation

- `pnpm verify:ci`
- hosted public read-model Postgres integration test
- web unit tests and production build