### PR TITLE
[codex] streamline run metadata and ranking filters

### DIFF
--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -5,26 +5,16 @@ import { benchmarkOptions } from "./data";
 import { RunConnectionCard } from "./RunConnectionCard";
 import { RunDetailTabs } from "./RunDetailTabs";
 import { usePlaygroundStore } from "@/lib/playground-store";
-import { AgentIdentityFields } from "@/components/run/AgentIdentityFields";
+import { SiteSelect } from "@/components/ui/SiteSelect";
 
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
-  const agentSelection = usePlaygroundStore((state) => state.agentSelection);
-  const customAgent = usePlaygroundStore((state) => state.customAgent);
-  const agentVersion = usePlaygroundStore((state) => state.agentVersion);
-  const modelSelection = usePlaygroundStore((state) => state.modelSelection);
-  const customModel = usePlaygroundStore((state) => state.customModel);
   const phase = usePlaygroundStore((state) => state.phase);
   const quota = usePlaygroundStore((state) => state.quota);
   const quotaLoading = usePlaygroundStore((state) => state.quotaLoading);
   const runError = usePlaygroundStore((state) => state.runError);
   const score = usePlaygroundStore((state) => state.score);
   const setBenchmark = usePlaygroundStore((state) => state.setBenchmark);
-  const setAgentSelection = usePlaygroundStore((state) => state.setAgentSelection);
-  const setCustomAgent = usePlaygroundStore((state) => state.setCustomAgent);
-  const setAgentVersion = usePlaygroundStore((state) => state.setAgentVersion);
-  const setModelSelection = usePlaygroundStore((state) => state.setModelSelection);
-  const setCustomModel = usePlaygroundStore((state) => state.setCustomModel);
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
   const startRun = usePlaygroundStore((state) => state.startRun);
   const stopRun = usePlaygroundStore((state) => state.stopRun);
@@ -150,33 +140,26 @@ export function ConnectAgentCard() {
       <div className="space-y-4">
         <label className="block">
           <span className="mb-2 block text-[13px] text-[#5d574d]">Benchmark</span>
-          <select
+          <SiteSelect
             value={benchmark}
             onChange={(event) => setBenchmark(event.target.value as typeof benchmark)}
-            className="w-full rounded-[1rem] border border-[#d8d1c4] bg-white px-4 py-2.5 text-sm text-[#111111] outline-none transition focus:border-[#111111]"
+            compact
           >
             {benchmarkOptions.map((item) => (
               <option key={item.value} value={item.value}>
                 {item.label}
               </option>
             ))}
-          </select>
+          </SiteSelect>
         </label>
 
         <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
           {benchmarkOptions.find((item) => item.value === benchmark)?.description}
         </div>
 
-        <AgentIdentityFields
-          value={{ agentSelection, customAgent, agentVersion, modelSelection, customModel }}
-          onChange={(value) => {
-            setAgentSelection(value.agentSelection);
-            setCustomAgent(value.customAgent);
-            setAgentVersion(value.agentVersion);
-            setModelSelection(value.modelSelection);
-            setCustomModel(value.customModel);
-          }}
-        />
+        <p className="text-[12px] leading-5 text-[#777064]">
+          Agent identity, model, and optional metadata are registered on the connection page after the run is created.
+        </p>
 
         {runError ? (
           <div className="rounded-[1rem] border border-[#ead2ca] bg-[#fff0eb] p-3 text-[13px] leading-6 text-[#8a4334]">

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { LeaderboardEntry } from "@/lib/db";
 import { LEADERBOARD_MAX_ENTRIES, LEADERBOARD_PAGE_SIZE, paginateLeaderboard } from "@/lib/leaderboard-pagination";
+import { SiteSelect } from "@/components/ui/SiteSelect";
 
 export type LeaderboardBoard = {
   version: string;
@@ -44,6 +45,8 @@ function PlaceholderRow({ position }: { position: number }) {
 export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
   const [activeVersion, setActiveVersion] = useState(boards[0]?.version ?? "all");
   const [page, setPage] = useState(1);
+  const latestBoard = boards[0];
+  const otherBoards = boards.slice(1);
   const activeBoard = boards.find((board) => board.version === activeVersion) ?? boards[0];
   const pagination = paginateLeaderboard(activeBoard?.entries ?? [], page);
   const { entries, page: currentPage, pageCount, pageEntries, placeholderPositions } = pagination;
@@ -56,24 +59,35 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
   return (
     <div>
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-        <div className="flex flex-wrap gap-2" role="tablist" aria-label="Benchmark version">
-          {boards.map((board) => {
-            const active = board.version === activeVersion;
-            return (
-              <button
-                key={board.version}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                onClick={() => selectVersion(board.version)}
-                className={active
-                  ? "rounded-full bg-[#111111] px-4 py-2 text-xs font-medium text-white"
-                  : "rounded-full border border-[#d8d0c2] bg-white/55 px-4 py-2 text-xs text-[#625c52] transition-colors hover:border-[#111111] hover:text-[#111111]"}
-              >
-                {board.version === "all" ? "All versions" : `Suite ${board.version}`}
-              </button>
-            );
-          })}
+        <div className="flex flex-wrap items-center gap-2" aria-label="Benchmark version">
+          {latestBoard ? (
+            <button
+              type="button"
+              aria-pressed={latestBoard.version === activeVersion}
+              onClick={() => selectVersion(latestBoard.version)}
+              className={latestBoard.version === activeVersion
+                ? "rounded-[0.6rem] bg-[#111111] px-4 py-2.5 text-xs font-medium text-white"
+                : "rounded-[0.6rem] border border-[#d8d0c2] bg-white/55 px-4 py-2.5 text-xs text-[#625c52] transition-colors hover:border-[#111111] hover:text-[#111111]"}
+            >
+              {latestBoard.version === "all" ? "All versions" : `Suite ${latestBoard.version}`}
+            </button>
+          ) : null}
+          {otherBoards.length > 0 ? (
+            <SiteSelect
+              compact
+              aria-label="Other benchmark suites"
+              value={otherBoards.some((board) => board.version === activeVersion) ? activeVersion : ""}
+              onChange={(event) => selectVersion(event.target.value)}
+              className="min-w-[10rem] bg-white/55 py-2.5 text-xs text-[#625c52]"
+            >
+              <option value="" disabled>Other suites</option>
+              {otherBoards.map((board) => (
+                <option key={board.version} value={board.version}>
+                  Suite {board.version}
+                </option>
+              ))}
+            </SiteSelect>
+          ) : null}
         </div>
         <div className="text-xs uppercase tracking-[0.16em] text-[#8a8378]">
           Top {Math.min(entries.length, LEADERBOARD_MAX_ENTRIES)} · {LEADERBOARD_PAGE_SIZE} per page

--- a/apps/web/components/run/AgentIdentityFields.tsx
+++ b/apps/web/components/run/AgentIdentityFields.tsx
@@ -8,6 +8,7 @@ import {
   OTHER_OPTION_VALUE,
   type AgentCatalog,
 } from "@/lib/agent-catalog";
+import { SiteSelect } from "@/components/ui/SiteSelect";
 
 export type AgentIdentityDraft = {
   agentSelection: string;
@@ -69,24 +70,25 @@ export function AgentIdentityFields({
 
   const inputClass =
     "mt-2 w-full rounded-[0.9rem] border border-[#d8d1c4] bg-white px-3.5 py-3 text-sm text-[#111111] outline-none transition focus:border-[#111111] disabled:cursor-not-allowed disabled:bg-[#eeeae2] disabled:text-[#777168]";
+  const selectClass = "mt-2";
 
   return (
     <div className={`grid gap-4 md:grid-cols-3 ${className}`}>
       <label className="text-xs font-medium text-[#4f4a43]">
         Agent
-        <select
+        <SiteSelect
           required
           value={value.agentSelection}
           onChange={(event) => onChange({ ...value, agentSelection: event.target.value })}
           disabled={disabled}
-          className={inputClass}
+          className={selectClass}
         >
           <option value="" disabled>Select an agent</option>
           {catalog.agents.map((option) => (
             <option key={option.value} value={option.value}>{option.label}</option>
           ))}
           <option value={OTHER_OPTION_VALUE}>Other</option>
-        </select>
+        </SiteSelect>
         {value.agentSelection === OTHER_OPTION_VALUE ? (
           <input
             required
@@ -113,12 +115,12 @@ export function AgentIdentityFields({
       </label>
       <label className="text-xs font-medium text-[#4f4a43]">
         Base model
-        <select
+        <SiteSelect
           required
           value={value.modelSelection}
           onChange={(event) => onChange({ ...value, modelSelection: event.target.value })}
           disabled={disabled}
-          className={inputClass}
+          className={selectClass}
         >
           <option value="" disabled>Select a model</option>
           {catalog.models.map((option) => (
@@ -127,7 +129,7 @@ export function AgentIdentityFields({
             </option>
           ))}
           <option value={OTHER_OPTION_VALUE}>Other</option>
-        </select>
+        </SiteSelect>
         {value.modelSelection === OTHER_OPTION_VALUE ? (
           <input
             required

--- a/apps/web/components/ui/SiteSelect.tsx
+++ b/apps/web/components/ui/SiteSelect.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { SelectHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+type SiteSelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
+  compact?: boolean;
+};
+
+export function SiteSelect({ className, compact = false, children, ...props }: SiteSelectProps) {
+  return (
+    <span className="relative block">
+      <select
+        {...props}
+        className={cn(
+          "w-full appearance-none rounded-[0.6rem] border border-[#d8d1c4] bg-white pr-10 text-sm text-[#111111] outline-none transition",
+          "focus:border-[#111111] disabled:cursor-not-allowed disabled:bg-[#eeeae2] disabled:text-[#777168]",
+          compact ? "px-3.5 py-2.5" : "px-3.5 py-3",
+          className,
+        )}
+      >
+        {children}
+      </select>
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 20 20"
+        fill="none"
+        className="pointer-events-none absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#665f54]"
+      >
+        <path d="m6 8 4 4 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+  );
+}

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -13,7 +13,6 @@ import {
   deriveHostedScoring,
   type HostedSessionBreakdown,
 } from "./hosted-scoring";
-import { resolveAgentIdentity } from "./agent-catalog";
 
 export type PlaygroundBenchmark = "hosted-web-suite";
 
@@ -40,11 +39,6 @@ type PlaygroundStore = {
   endpoint: string;
   apiKey: string;
   benchmark: PlaygroundBenchmark;
-  agentSelection: string;
-  customAgent: string;
-  agentVersion: string;
-  modelSelection: string;
-  customModel: string;
   currentRunId: string | null;
   currentExecutionMode: RunExecutionMode | null;
   liveViewUrl: string | null;
@@ -66,11 +60,6 @@ type PlaygroundStore = {
   setEndpoint: (value: string) => void;
   setApiKey: (value: string) => void;
   setBenchmark: (value: PlaygroundBenchmark) => void;
-  setAgentSelection: (value: string) => void;
-  setCustomAgent: (value: string) => void;
-  setAgentVersion: (value: string) => void;
-  setModelSelection: (value: string) => void;
-  setCustomModel: (value: string) => void;
   setActiveTab: (value: PanelTab) => void;
   setLiveSlide: (index: number) => void;
   fetchQuota: () => Promise<void>;
@@ -93,11 +82,6 @@ const initialState = {
   endpoint: "",
   apiKey: "",
   benchmark: "hosted-web-suite" as PlaygroundBenchmark,
-  agentSelection: "",
-  customAgent: "",
-  agentVersion: "latest",
-  modelSelection: "",
-  customModel: "",
   currentRunId: null,
   currentExecutionMode: null,
   liveViewUrl: null,
@@ -547,11 +531,6 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
   setEndpoint: (value) => set({ endpoint: value }),
   setApiKey: (value) => set({ apiKey: value }),
   setBenchmark: (value) => set({ benchmark: value }),
-  setAgentSelection: (value) => set({ agentSelection: value }),
-  setCustomAgent: (value) => set({ customAgent: value }),
-  setAgentVersion: (value) => set({ agentVersion: value }),
-  setModelSelection: (value) => set({ modelSelection: value }),
-  setCustomModel: (value) => set({ customModel: value }),
   setActiveTab: (value) => set({ activeTab: value }),
   setLiveSlide: (index) => set({ liveSlide: index }),
   fetchQuota: async () => {
@@ -589,14 +568,6 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
     try {
       const state = get();
       const benchmark = state.benchmark;
-      const agent = resolveAgentIdentity(state);
-      if (!agent) {
-        set({
-          quotaLoading: false,
-          runError: "Select an agent and base model, and provide an agent version.",
-        });
-        return;
-      }
       const response = await fetch("/api/runs", {
         method: "POST",
         headers: {
@@ -607,7 +578,6 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
           caseId: BENCHMARK_CASE_IDS[benchmark],
           executionMode: mode,
           isPublic: true,
-          agent,
         }),
       });
 


### PR DESCRIPTION
## What changed

- Move agent identity and optional metadata registration out of the playground and keep it on the connection page.
- Standardize benchmark, agent, model, and leaderboard selects with a shared site-styled control and tighter corners.
- Keep the latest suite version visible while grouping older leaderboard versions under an Other suites selector.

## Why

The playground duplicated connection metadata and native select styling was inconsistent with the rest of the site. Showing every suite version also made the leaderboard filter increasingly noisy.

## Validation

- `pnpm --filter web test`
- Repository pre-push verification, including integration tests, coverage gates, local hosted smoke, and production builds
