### PR TITLE
[codex] restore select menu backgrounds

### DIFF
--- a/apps/web/components/ui/SiteSelect.tsx
+++ b/apps/web/components/ui/SiteSelect.tsx
@@ -7,14 +7,16 @@ type SiteSelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
   compact?: boolean;
 };
 
-export function SiteSelect({ className, compact = false, children, ...props }: SiteSelectProps) {
+export function SiteSelect({ className, compact = false, children, style, ...props }: SiteSelectProps) {
   return (
     <span className="relative block">
       <select
         {...props}
+        style={{ colorScheme: "light", ...style }}
         className={cn(
           "w-full appearance-none rounded-[0.6rem] border border-[#d8d1c4] bg-white pr-10 text-sm text-[#111111] outline-none transition",
           "focus:border-[#111111] disabled:cursor-not-allowed disabled:bg-[#eeeae2] disabled:text-[#777168]",
+          "[&>option]:bg-white [&>option]:text-[#111111]",
           compact ? "px-3.5 py-2.5" : "px-3.5 py-3",
           className,
         )}


### PR DESCRIPTION
## What changed

- Force shared native select controls to use the light color scheme.
- Give every option an explicit white background and dark text.

## Why

The native dropdown popup inherited the system dark theme, removing the intended light site background even though the closed control was styled correctly.

## Validation

- `pnpm --filter web test`
- `pnpm --filter web build`
- Full repository pre-push verification
