### PR TITLE
[codex] replace native select menus

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -131,6 +131,14 @@ Not a traditional admin dashboard.
 
 For visual replay, hosted-sites can emit DOM/task telemetry, but real screenshots or videos must be uploaded by the user's agent/browser runtime. A hosted site cannot reliably capture the agent's browser pixels because of browser security boundaries.
 
+Before committing or opening a pull request with user-visible frontend changes:
+
+1. Run the affected page in an actual browser; tests and production builds alone are insufficient.
+2. Visually inspect every changed interactive state, including open menus, dialogs, loading/empty states, and selected/disabled states.
+3. Check the relevant desktop layout and at least one narrow/mobile viewport when the component is responsive.
+4. Confirm colors, backgrounds, stacking, clipping, spacing, and overflow against the surrounding design.
+5. Record the pages, viewport states, and interactions checked in the pull request verification notes. Do not commit or publish the frontend change if visual verification is blocked or incomplete.
+
 ### 8. Infrastructure
 
 Prefer:

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -142,15 +142,11 @@ export function ConnectAgentCard() {
           <span className="mb-2 block text-[13px] text-[#5d574d]">Benchmark</span>
           <SiteSelect
             value={benchmark}
-            onChange={(event) => setBenchmark(event.target.value as typeof benchmark)}
+            onValueChange={(value) => setBenchmark(value as typeof benchmark)}
+            ariaLabel="Benchmark"
+            options={benchmarkOptions.map((item) => ({ value: item.value, label: item.label }))}
             compact
-          >
-            {benchmarkOptions.map((item) => (
-              <option key={item.value} value={item.value}>
-                {item.label}
-              </option>
-            ))}
-          </SiteSelect>
+          />
         </label>
 
         <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -75,18 +75,16 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
           {otherBoards.length > 0 ? (
             <SiteSelect
               compact
-              aria-label="Other benchmark suites"
+              ariaLabel="Other benchmark suites"
               value={otherBoards.some((board) => board.version === activeVersion) ? activeVersion : ""}
-              onChange={(event) => selectVersion(event.target.value)}
-              className="min-w-[10rem] bg-white/55 py-2.5 text-xs text-[#625c52]"
-            >
-              <option value="" disabled>Other suites</option>
-              {otherBoards.map((board) => (
-                <option key={board.version} value={board.version}>
-                  Suite {board.version}
-                </option>
-              ))}
-            </SiteSelect>
+              onValueChange={selectVersion}
+              options={[
+                { value: "", label: "Other suites", disabled: true },
+                ...otherBoards.map((board) => ({ value: board.version, label: `Suite ${board.version}` })),
+              ]}
+              className="min-w-[10rem]"
+              triggerClassName="bg-white/55 py-2.5 text-xs text-[#625c52]"
+            />
           ) : null}
         </div>
         <div className="text-xs uppercase tracking-[0.16em] text-[#8a8378]">

--- a/apps/web/components/run/AgentIdentityFields.tsx
+++ b/apps/web/components/run/AgentIdentityFields.tsx
@@ -77,18 +77,17 @@ export function AgentIdentityFields({
       <label className="text-xs font-medium text-[#4f4a43]">
         Agent
         <SiteSelect
-          required
           value={value.agentSelection}
-          onChange={(event) => onChange({ ...value, agentSelection: event.target.value })}
+          onValueChange={(agentSelection) => onChange({ ...value, agentSelection })}
+          ariaLabel="Agent"
+          options={[
+            { value: "", label: "Select an agent", disabled: true },
+            ...catalog.agents.map((option) => ({ value: option.value, label: option.label })),
+            { value: OTHER_OPTION_VALUE, label: "Other" },
+          ]}
           disabled={disabled}
           className={selectClass}
-        >
-          <option value="" disabled>Select an agent</option>
-          {catalog.agents.map((option) => (
-            <option key={option.value} value={option.value}>{option.label}</option>
-          ))}
-          <option value={OTHER_OPTION_VALUE}>Other</option>
-        </SiteSelect>
+        />
         {value.agentSelection === OTHER_OPTION_VALUE ? (
           <input
             required
@@ -116,20 +115,20 @@ export function AgentIdentityFields({
       <label className="text-xs font-medium text-[#4f4a43]">
         Base model
         <SiteSelect
-          required
           value={value.modelSelection}
-          onChange={(event) => onChange({ ...value, modelSelection: event.target.value })}
+          onValueChange={(modelSelection) => onChange({ ...value, modelSelection })}
+          ariaLabel="Base model"
+          options={[
+            { value: "", label: "Select a model", disabled: true },
+            ...catalog.models.map((option) => ({
+              value: option.value,
+              label: `${option.label} · ${option.provider}`,
+            })),
+            { value: OTHER_OPTION_VALUE, label: "Other" },
+          ]}
           disabled={disabled}
           className={selectClass}
-        >
-          <option value="" disabled>Select a model</option>
-          {catalog.models.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label} · {option.provider}
-            </option>
-          ))}
-          <option value={OTHER_OPTION_VALUE}>Other</option>
-        </SiteSelect>
+        />
         {value.modelSelection === OTHER_OPTION_VALUE ? (
           <input
             required

--- a/apps/web/components/ui/SiteSelect.tsx
+++ b/apps/web/components/ui/SiteSelect.tsx
@@ -1,36 +1,151 @@
 "use client";
 
-import type { SelectHTMLAttributes } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
-type SiteSelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
-  compact?: boolean;
+export type SiteSelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
 };
 
-export function SiteSelect({ className, compact = false, children, style, ...props }: SiteSelectProps) {
+type SiteSelectProps = {
+  value: string;
+  options: SiteSelectOption[];
+  onValueChange: (value: string) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+  compact?: boolean;
+  className?: string;
+  triggerClassName?: string;
+};
+
+export function SiteSelect({
+  value,
+  options,
+  onValueChange,
+  ariaLabel,
+  disabled = false,
+  compact = false,
+  className,
+  triggerClassName,
+}: SiteSelectProps) {
+  const listboxId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(() => Math.max(0, options.findIndex((option) => option.value === value)));
+  const selectedOption = options.find((option) => option.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function closeOnOutsidePointer(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePointer);
+  }, [open]);
+
+  function selectOption(option: SiteSelectOption) {
+    if (option.disabled) return;
+    onValueChange(option.value);
+    setOpen(false);
+  }
+
+  function moveActive(direction: 1 | -1) {
+    let nextIndex = activeIndex;
+    for (let step = 0; step < options.length; step += 1) {
+      nextIndex = (nextIndex + direction + options.length) % options.length;
+      if (!options[nextIndex]?.disabled) {
+        setActiveIndex(nextIndex);
+        return;
+      }
+    }
+  }
+
   return (
-    <span className="relative block">
-      <select
-        {...props}
-        style={{ colorScheme: "light", ...style }}
+    <div ref={rootRef} className={cn("relative", className)}>
+      <button
+        type="button"
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-controls={listboxId}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        disabled={disabled}
+        onClick={() => {
+          if (!open) {
+            setActiveIndex(Math.max(0, options.findIndex((option) => option.value === value)));
+          }
+          setOpen((current) => !current);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            if (!open) setOpen(true);
+            moveActive(event.key === "ArrowDown" ? 1 : -1);
+          } else if (event.key === "Enter" && open) {
+            event.preventDefault();
+            const option = options[activeIndex];
+            if (option) selectOption(option);
+          } else if (event.key === "Escape") {
+            setOpen(false);
+          }
+        }}
         className={cn(
-          "w-full appearance-none rounded-[0.6rem] border border-[#d8d1c4] bg-white pr-10 text-sm text-[#111111] outline-none transition",
+          "flex w-full items-center justify-between gap-3 rounded-[0.6rem] border border-[#d8d1c4] bg-white text-left text-sm text-[#111111] outline-none transition",
           "focus:border-[#111111] disabled:cursor-not-allowed disabled:bg-[#eeeae2] disabled:text-[#777168]",
-          "[&>option]:bg-white [&>option]:text-[#111111]",
           compact ? "px-3.5 py-2.5" : "px-3.5 py-3",
-          className,
+          triggerClassName,
         )}
       >
-        {children}
-      </select>
-      <svg
-        aria-hidden="true"
-        viewBox="0 0 20 20"
-        fill="none"
-        className="pointer-events-none absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#665f54]"
-      >
-        <path d="m6 8 4 4 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    </span>
+        <span className={cn("truncate", !selectedOption && "text-[#777168]")}>
+          {selectedOption?.label ?? options.find((option) => option.disabled)?.label ?? "Select"}
+        </span>
+        <svg aria-hidden="true" viewBox="0 0 20 20" fill="none" className="h-4 w-4 shrink-0 text-[#665f54]">
+          <path d="m6 8 4 4 4-4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open ? (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
+          className="absolute left-0 top-[calc(100%+0.35rem)] z-[80] min-w-full overflow-hidden rounded-[0.6rem] border border-[#cfc7b9] bg-[#fffdf8] p-1.5 shadow-[0_18px_45px_rgba(35,28,17,0.18)]"
+        >
+          {options.map((option, index) => {
+            const selected = option.value === value;
+            const active = index === activeIndex;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                disabled={option.disabled}
+                onPointerMove={() => setActiveIndex(index)}
+                onClick={() => selectOption(option)}
+                className={cn(
+                  "flex w-full items-center rounded-[0.4rem] px-3 py-2 text-left text-xs transition-colors",
+                  option.disabled
+                    ? "cursor-default text-[#9a9388]"
+                    : selected
+                      ? "bg-[#111111] text-white"
+                      : active
+                        ? "bg-[#eee9df] text-[#111111]"
+                        : "text-[#4f4940] hover:bg-[#eee9df]",
+                )}
+              >
+                <span className="truncate">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## What changed

- Replace native system select popups with a site-rendered accessible combobox/listbox.
- Apply the shared control to benchmark, suite version, agent, and base-model selectors.
- Add a required pre-commit visual verification gate for user-visible frontend changes to `agent.md`.

## Why

macOS renders native select popups outside normal page styling, so the menu inherited a dark system background despite CSS overrides. Rendering the listbox in the page makes its background, selected state, spacing, radius, and stacking deterministic.

## Visual verification

- Desktop 1280x720: opened the suite selector over the leaderboard and verified warm-white background, dark text, selected state, stacking, and no clipping.
- Narrow 390x844: opened the suite selector over the compact leaderboard and verified width, overflow, stacking, and readability.
- Narrow playground: opened the benchmark selector and verified its menu against the run card.
- Connection page: opened agent and base-model selectors; selected Codex and selected GPT-5 using keyboard controls.
- Verified Escape, ArrowDown, and Enter behavior and confirmed no browser console errors.

## Automated verification

- `pnpm --filter web test` (28/28)
- `pnpm --filter web build`
- Full repository pre-push verification, including database integration, coverage gates, hosted smoke, and production builds

## Documentation

- Reviewed `docs/roadmap.md`; no milestone status or scope update is required.
