### PR TITLE
ci(deploy): publish benchmark catalog after database migrations

### DIFF
--- a/.github/workflows/deploy-hosted-sites.yml
+++ b/.github/workflows/deploy-hosted-sites.yml
@@ -274,6 +274,24 @@ jobs:
           TEST_SUPABASE_DB_URL: ${{ secrets.TEST_SUPABASE_DB_URL }}
         run: bash scripts/db-migrate.sh test
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish benchmark catalog
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: pnpm catalog:publish
+
   migrate-production:
     if: github.ref == 'refs/heads/main'
     runs-on:
@@ -299,6 +317,24 @@ jobs:
         env:
           PROD_SUPABASE_DB_URL: ${{ secrets.PROD_SUPABASE_DB_URL }}
         run: bash scripts/db-migrate.sh production
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish benchmark catalog
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: pnpm catalog:publish
 
   deploy-development:
     if: |


### PR DESCRIPTION
## Summary

Production deployments currently apply database migrations but do not publish the benchmark catalog defined in `packages/test-cases/src/suites/hosted-web.ts`. As a result, `benchmark_case_revisions` does not receive the current suite revision and `benchmark_cases.current_revision_id` stays stale.

This change adds a `pnpm catalog:publish` step to both the development and production migration jobs in `.github/workflows/deploy-hosted-sites.yml`, immediately after migrations are applied. The publish step uses the existing `SUPABASE_URL` variable and `SUPABASE_SERVICE_ROLE_KEY` secret and is idempotent.

## Related Issue

No issue.

## Verification

- [x] `pnpm verify:ci` passes locally (pre-push hook ran successfully; local service smoke skipped due to no running services)
- [ ] Tests cover changed behavior
- [x] UI changes include screenshots or recordings, or this is not a UI change

## Operational Impact

- [x] No database migration
- [x] No new or changed environment variable or secret
- [ ] No deployment, Docker, runner, or Cloudflare change
- [x] No breaking API or data compatibility change

This change modifies the GitHub Actions deployment workflow. It adds Node/pnpm setup and a catalog publish step to the existing self-hosted migration jobs. Rollback is a workflow revert; the `publish_benchmark_case_catalog` RPC is idempotent, so re-running an older deployment will not corrupt revision data.

## Contributor Checks

- [x] This pull request targets `develop`, unless it is an approved release or hotfix
- [x] The title, branch, and commits follow `docs/work-item-naming.md`
- [x] No credentials, session tokens, production data, or private user data are included
- [x] Substantial AI-generated code is disclosed below, or none was used

AI assistance disclosure: none