### PR TITLE
fix(web): scroll anchor links to the currently visible target section

### DIFF
--- a/apps/web/components/landing/ScrollSnapController.tsx
+++ b/apps/web/components/landing/ScrollSnapController.tsx
@@ -119,7 +119,9 @@ export function ScrollSnapController() {
       if (!anchor) return;
       const hash = anchor.getAttribute("href");
       if (!hash || hash === "#") return;
-      const target = document.querySelector<HTMLElement>(hash);
+      const target = Array.from(document.querySelectorAll<HTMLElement>(hash)).find(
+        (element) => element.offsetParent !== null,
+      );
       if (!target) return;
       e.preventDefault();
       clearSnapTimeout();


### PR DESCRIPTION
## Summary

On the landing page, the **Run Your Agent** and **Start Run** buttons link to `#playground`. On desktop viewports, the scroll jumped to the top of the page instead of the playground section.

## Root Cause

`ImmersiveStage` renders two `PlaygroundSection` elements with `id="playground"`: one for mobile viewports and one for desktop viewports. Only one is visible at a time, but both exist in the DOM.

`ScrollSnapController` used `document.querySelector<HTMLElement>(hash)` to resolve anchor clicks, which always returned the first `#playground` element (the mobile variant). Because that element is hidden on desktop, scrolling to its `offsetTop` behaved inconsistently and effectively reset scroll to the top.

## Fix

Changed the anchor-click handler to select the first matching element that is currently visible (`offsetParent !== null`). This ensures `#playground`, `#leaderboard`, `#docs`, and `#hero` links scroll to the viewport-appropriate section.

## Related Issue

No issue.

## Verification

- [x] `pnpm --filter web test` passes
- [ ] `pnpm verify:ci` passes locally
- [ ] Tests cover changed behavior
- [x] UI changes include screenshots or recordings, or this is not a UI change

## Operational Impact

- [x] No database migration
- [x] No new or changed environment variable or secret
- [x] No deployment, Docker, runner, or Cloudflare change
- [x] No breaking API or data compatibility change

## Contributor Checks

- [x] This pull request targets `develop`, unless it is an approved release or hotfix
- [x] The title, branch, and commits follow `docs/work-item-naming.md`
- [x] No credentials, session tokens, production data, or private user data are included
- [x] Substantial AI-generated code is disclosed below, or none was used

AI assistance disclosure: none
