### PR TITLE
feat(hosted-sites): increase hosted-web task complexity

### DIFF
--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -28,6 +28,8 @@ jobs:
           - full-pool-1
           - full-pool-2
           - full-pool-4
+          - full-pool-5
+          - full-pool-9
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -28,8 +28,9 @@ jobs:
           - full-pool-1
           - full-pool-2
           - full-pool-4
-          - full-pool-5
+          - full-pool-7
           - full-pool-9
+          - full-pool-16
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -26,10 +26,11 @@ jobs:
         generation_seed:
           - full-pool-0
           - full-pool-1
+          - full-pool-4
+          - full-pool-6
           - full-pool-9
-          - full-pool-16
-          - full-pool-34
-          - full-pool-91
+          - full-pool-43
+          - full-pool-153
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -26,11 +26,11 @@ jobs:
         generation_seed:
           - full-pool-0
           - full-pool-1
-          - full-pool-3
-          - full-pool-23
-          - full-pool-34
-          - full-pool-107
-          - full-pool-188
+          - full-pool-2
+          - full-pool-18
+          - full-pool-59
+          - full-pool-152
+          - full-pool-197
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -26,11 +26,11 @@ jobs:
         generation_seed:
           - full-pool-0
           - full-pool-1
-          - full-pool-4
-          - full-pool-6
-          - full-pool-9
-          - full-pool-43
-          - full-pool-153
+          - full-pool-3
+          - full-pool-23
+          - full-pool-34
+          - full-pool-107
+          - full-pool-188
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -26,11 +26,10 @@ jobs:
         generation_seed:
           - full-pool-0
           - full-pool-1
-          - full-pool-2
-          - full-pool-4
-          - full-pool-7
           - full-pool-9
           - full-pool-16
+          - full-pool-34
+          - full-pool-91
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,15 +32,15 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.5");
+  assert.equal(suite.suiteVersion, "v3.0.6");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
-  assert.equal(wiki.taskVersion, "v2");
-  assert.equal(wiki.seedVersion, "wiki-lite-v2");
+  assert.equal(wiki.taskVersion, "v3");
+  assert.equal(wiki.seedVersion, "wiki-lite-v4");
   const metadata = wiki.metadata as Record<string, unknown>;
   const variants = metadata.questionVariants as Array<Record<string, unknown>>;
-  assert.equal(variants.length, 3);
+  assert.equal(variants.length, 5);
   for (const variant of variants) {
     const config = variant.taskConfig as Record<string, unknown>;
     assert.equal("expectedAnswer" in config, false);
@@ -56,7 +56,7 @@ test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-9", "full-pool-16", "full-pool-34", "full-pool-91"]) {
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-4", "full-pool-6", "full-pool-9", "full-pool-43", "full-pool-153"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
       seed,

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.2");
+  assert.equal(suite.suiteVersion, "v3.0.3");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
@@ -56,7 +56,7 @@ test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4"]) {
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4", "full-pool-5", "full-pool-9"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
       seed,

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.3");
+  assert.equal(suite.suiteVersion, "v3.0.4");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
@@ -56,7 +56,7 @@ test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4", "full-pool-5", "full-pool-9"]) {
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4", "full-pool-7", "full-pool-9", "full-pool-16"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
       seed,

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.4");
+  assert.equal(suite.suiteVersion, "v3.0.5");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
@@ -56,7 +56,7 @@ test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-4", "full-pool-7", "full-pool-9", "full-pool-16"]) {
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-9", "full-pool-16", "full-pool-34", "full-pool-91"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
       seed,

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.7");
+  assert.equal(suite.suiteVersion, "v3.0.8");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
@@ -56,7 +56,7 @@ test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-3", "full-pool-23", "full-pool-34", "full-pool-107", "full-pool-188"]) {
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-18", "full-pool-59", "full-pool-152", "full-pool-197"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
       seed,

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.6");
+  assert.equal(suite.suiteVersion, "v3.0.7");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);
@@ -56,7 +56,7 @@ test("scheduled development seeds cover every declared variant", () => {
   const suite = readHostedSuiteSeed();
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-4", "full-pool-6", "full-pool-9", "full-pool-43", "full-pool-153"]) {
+  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-3", "full-pool-23", "full-pool-34", "full-pool-107", "full-pool-188"]) {
     const generated = generateAttemptQuestions(
       sessions as Parameters<typeof generateAttemptQuestions>[0],
       seed,

--- a/apps/hosted-sites/src/apps/calendar-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/actions.ts
@@ -8,12 +8,14 @@ export function createCalendarEvent(
     startTime: string;
     durationMinutes: number;
     attendeeEmail: string;
+    secondaryAttendeeEmail?: string;
     makeId: (prefix: string) => string;
     now: () => string;
   },
 ) {
   const title = input.title.trim();
   const attendeeEmail = input.attendeeEmail.trim().toLowerCase();
+  const secondaryAttendeeEmail = input.secondaryAttendeeEmail?.trim().toLowerCase();
   if (!title) return { success: false as const, error: "Title is required" };
   if (!/^\d{4}-\d{2}-\d{2}$/.test(input.date)) return { success: false as const, error: "Date is invalid" };
   if (!/^\d{2}:\d{2}$/.test(input.startTime)) return { success: false as const, error: "Start time is invalid" };
@@ -23,6 +25,9 @@ export function createCalendarEvent(
   if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(attendeeEmail)) {
     return { success: false as const, error: "Attendee email is invalid" };
   }
+  if (secondaryAttendeeEmail !== undefined && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(secondaryAttendeeEmail)) {
+    return { success: false as const, error: "Secondary attendee email is invalid" };
+  }
 
   const calendarEvent = {
     id: input.makeId("event"),
@@ -31,6 +36,7 @@ export function createCalendarEvent(
     startTime: input.startTime,
     durationMinutes: input.durationMinutes,
     attendeeEmail,
+    secondaryAttendeeEmail,
     createdAt: input.now(),
   };
   session.state.calendarEvents.push(calendarEvent);

--- a/apps/hosted-sites/src/apps/calendar-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/definition.ts
@@ -14,6 +14,7 @@ function isCalendarEvent(value: unknown): value is CalendarEvent {
     typeof value.startTime === "string" &&
     typeof value.durationMinutes === "number" &&
     typeof value.attendeeEmail === "string" &&
+    (value.secondaryAttendeeEmail === undefined || typeof value.secondaryAttendeeEmail === "string") &&
     typeof value.createdAt === "string"
   );
 }

--- a/apps/hosted-sites/src/apps/calendar-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/evaluate.ts
@@ -1,5 +1,5 @@
 import { aggregateStrictScore, failedEvaluator, passedEvaluator, type HostedWebScoreResult } from "@agentbench/scoring";
-import { configString, readTaskConfig } from "../../runtime/question-config.js";
+import { configString, configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
 
 export function evaluateCalendarLite(session: HostedSessionFor<"calendar-lite">): HostedWebScoreResult {
@@ -9,13 +9,16 @@ export function evaluateCalendarLite(session: HostedSessionFor<"calendar-lite">)
   const expectedStartTime = configString(config, "expectedStartTime");
   const expectedDurationMinutes = Number(config.expectedDurationMinutes);
   const expectedAttendeeEmail = configString(config, "expectedAttendeeEmail").toLowerCase();
+  const expectedSecondaryAttendeeEmail = configStringOrNull(config, "expectedSecondaryAttendeeEmail")?.toLowerCase();
   const match = session.state.calendarEvents.find(
     (calendarEvent) =>
       calendarEvent.title === expectedTitle &&
       calendarEvent.date === expectedDate &&
       calendarEvent.startTime === expectedStartTime &&
       calendarEvent.durationMinutes === expectedDurationMinutes &&
-      calendarEvent.attendeeEmail === expectedAttendeeEmail,
+      calendarEvent.attendeeEmail === expectedAttendeeEmail &&
+      (expectedSecondaryAttendeeEmail === null ||
+        calendarEvent.secondaryAttendeeEmail === expectedSecondaryAttendeeEmail),
   );
   return aggregateStrictScore({
     evaluators: [
@@ -24,7 +27,7 @@ export function evaluateCalendarLite(session: HostedSessionFor<"calendar-lite">)
         : failedEvaluator({
             type: "backend_state",
             name: "requested calendar event exists",
-            errorMessage: "No calendar event matches the requested title, schedule, duration, and attendee.",
+            errorMessage: "No calendar event matches the requested title, schedule, duration, and attendee(s).",
             evidence: { eventCount: session.state.calendarEvents.length },
           }),
     ],

--- a/apps/hosted-sites/src/apps/calendar-lite/render.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/render.ts
@@ -13,7 +13,7 @@ export function renderCalendarLite(
       <article class="card">
         <h2>${escapeHtml(calendarEvent.title)}</h2>
         <p>${escapeHtml(calendarEvent.date)} at ${escapeHtml(calendarEvent.startTime)} for ${calendarEvent.durationMinutes} minutes</p>
-        <p class="muted">${escapeHtml(calendarEvent.attendeeEmail)}</p>
+        <p class="muted">${escapeHtml(calendarEvent.attendeeEmail)}${calendarEvent.secondaryAttendeeEmail ? `, ${escapeHtml(calendarEvent.secondaryAttendeeEmail)}` : ""}</p>
       </article>`).join("")
     : '<article class="card"><p class="muted">No events scheduled.</p></article>';
 
@@ -38,6 +38,7 @@ export function renderCalendarLite(
           </label>
         </div>
         <label style="display:block;margin-top:12px;">Attendee email <input type="email" name="attendeeEmail" style="display:block;width:100%;margin-top:8px;padding:8px;" /></label>
+        <label style="display:block;margin-top:12px;">Secondary attendee email <input type="email" name="secondaryAttendeeEmail" placeholder="Optional" style="display:block;width:100%;margin-top:8px;padding:8px;" /></label>
         <button type="submit" style="margin-top:12px;">Create event</button>
       </form>
     </section>

--- a/apps/hosted-sites/src/apps/calendar-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/routes.ts
@@ -28,6 +28,7 @@ export function createCalendarLiteRoutes(deps: HostedAppRouteDeps) {
       const startTime = form.get("startTime");
       const durationMinutes = Number(form.get("durationMinutes"));
       const attendeeEmail = form.get("attendeeEmail");
+      const secondaryAttendeeEmail = form.get("secondaryAttendeeEmail");
       if (
         typeof title !== "string" ||
         typeof date !== "string" ||
@@ -43,6 +44,7 @@ export function createCalendarLiteRoutes(deps: HostedAppRouteDeps) {
         startTime,
         durationMinutes,
         attendeeEmail,
+        secondaryAttendeeEmail: typeof secondaryAttendeeEmail === "string" ? secondaryAttendeeEmail : undefined,
         makeId: deps.makeId,
         now: deps.now,
       });

--- a/apps/hosted-sites/src/apps/calendar-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/calendar-lite/test-driver.mjs
@@ -1,9 +1,13 @@
 export async function complete({ session, config, postForm, requireString }) {
-  await postForm("/calendar/events", session.token, {
+  const payload = {
     title: requireString(config.expectedTitle, "calendar-lite expectedTitle"),
     date: requireString(config.expectedDate, "calendar-lite expectedDate"),
     startTime: requireString(config.expectedStartTime, "calendar-lite expectedStartTime"),
     durationMinutes: String(config.expectedDurationMinutes),
     attendeeEmail: requireString(config.expectedAttendeeEmail, "calendar-lite expectedAttendeeEmail"),
-  });
+  };
+  if (config.expectedSecondaryAttendeeEmail) {
+    payload.secondaryAttendeeEmail = requireString(config.expectedSecondaryAttendeeEmail, "calendar-lite expectedSecondaryAttendeeEmail");
+  }
+  await postForm("/calendar/events", session.token, payload);
 }

--- a/apps/hosted-sites/src/apps/calendar-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/test-support.ts
@@ -1,4 +1,4 @@
-import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
+import { configString, configStringOrNull, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const calendarLiteTestSupport: HostedAppTestSupport<"calendar-lite"> = {
   exampleTaskConfig: {
@@ -16,10 +16,14 @@ export const calendarLiteTestSupport: HostedAppTestSupport<"calendar-lite"> = {
       startTime: configString(config, "expectedStartTime"),
       durationMinutes: Number(config.expectedDurationMinutes),
       attendeeEmail: configString(config, "expectedAttendeeEmail"),
+      secondaryAttendeeEmail: configStringOrNull(config, "expectedSecondaryAttendeeEmail") ?? undefined,
       createdAt: "2026-06-24T00:00:00.000Z",
     });
   },
   breakPassingState(session) {
-    session.state.calendarEvents[0]!.title = "Wrong event title";
+    const event = session.state.calendarEvents.at(-1);
+    if (event) {
+      event.title = "Wrong event title";
+    }
   },
 };

--- a/apps/hosted-sites/src/apps/calendar-lite/types.ts
+++ b/apps/hosted-sites/src/apps/calendar-lite/types.ts
@@ -5,6 +5,7 @@ export type CalendarEvent = {
   startTime: string;
   durationMinutes: number;
   attendeeEmail: string;
+  secondaryAttendeeEmail?: string;
   createdAt: string;
 };
 

--- a/apps/hosted-sites/src/apps/forum-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/actions.ts
@@ -52,3 +52,56 @@ export function lockThread(
   session.state.moderationActions.push(action);
   return { success: true, action } as const;
 }
+
+export function pinThread(
+  session: ForumSession,
+  params: {
+    threadId: string;
+    reason: string;
+    makeId: (prefix: string) => string;
+  },
+) {
+  const thread = session.state.threads.find((candidate) => candidate.id === params.threadId);
+  if (!thread) {
+    return { success: false, error: "Thread not found" } as const;
+  }
+  if (!thread.locked) {
+    return { success: false, error: "Thread must be locked before pinning" } as const;
+  }
+
+  thread.pinned = true;
+  const action: ModerationAction = {
+    id: params.makeId("mod"),
+    threadId: params.threadId,
+    action: "pin",
+    reason: params.reason,
+  };
+  session.state.moderationActions.push(action);
+  return { success: true, action } as const;
+}
+
+export function reportThread(
+  session: ForumSession,
+  params: {
+    threadId: string;
+    reason: string;
+    makeId: (prefix: string) => string;
+  },
+) {
+  const thread = session.state.threads.find((candidate) => candidate.id === params.threadId);
+  if (!thread) {
+    return { success: false, error: "Thread not found" } as const;
+  }
+  if (thread.locked) {
+    return { success: false, error: "Cannot report a locked thread" } as const;
+  }
+
+  const action: ModerationAction = {
+    id: params.makeId("mod"),
+    threadId: params.threadId,
+    action: "report",
+    reason: params.reason,
+  };
+  session.state.moderationActions.push(action);
+  return { success: true, action } as const;
+}

--- a/apps/hosted-sites/src/apps/forum-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/definition.ts
@@ -17,7 +17,8 @@ function isForumThread(value: unknown): value is ForumThread {
     typeof value.category === "string" &&
     Array.isArray(value.posts) &&
     value.posts.every(isForumPost) &&
-    (value.locked === undefined || typeof value.locked === "boolean")
+    (value.locked === undefined || typeof value.locked === "boolean") &&
+    (value.pinned === undefined || typeof value.pinned === "boolean")
   );
 }
 
@@ -26,7 +27,7 @@ function isModerationAction(value: unknown): value is ModerationAction {
     isStateRecord(value) &&
     typeof value.id === "string" &&
     typeof value.threadId === "string" &&
-    (value.action === "lock" || value.action === "pin" || value.action === "remove_post") &&
+    (value.action === "lock" || value.action === "pin" || value.action === "remove_post" || value.action === "report") &&
     typeof value.reason === "string"
   );
 }

--- a/apps/hosted-sites/src/apps/forum-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/evaluate.ts
@@ -6,7 +6,7 @@ import {
   type HostedWebScoreResult,
 } from "@agentbench/scoring";
 import type { ForumThread, ModerationAction } from "./types.js";
-import { configString, readTaskConfig } from "../../runtime/question-config.js";
+import { configBooleanOrFalse, configString, readTaskConfig } from "../../runtime/question-config.js";
 
 export type ForumEvaluationSession = {
   app: "forum-lite" | string;
@@ -23,9 +23,20 @@ export function evaluateForum(session: ForumEvaluationSession): HostedWebScoreRe
   const targetThreadId = configString(config, "targetThreadId");
   const expectedReplyValue = configString(config, "expectedReplyValue");
   const expectedLockReason = configString(config, "expectedLockReason");
+  const requiresPin = configBooleanOrFalse(config, "requiresPin");
+  const requiresReport = configBooleanOrFalse(config, "requiresReport");
+  const expectedReportReason = requiresReport ? configString(config, "expectedReportReason") : null;
   const targetThread = session.state.threads.find((candidate) => candidate.id === targetThreadId);
   const retrieve = evaluateRetrieveValue(targetThread, targetThreadId, expectedReplyValue);
-  const backend = evaluateForumBackendState(session, targetThread, targetThreadId, expectedLockReason);
+  const backend = evaluateForumBackendState(
+    session,
+    targetThread,
+    targetThreadId,
+    expectedLockReason,
+    requiresPin,
+    requiresReport,
+    expectedReportReason,
+  );
   const ui = targetThread?.locked
     ? passedEvaluator({
         type: "ui_state",
@@ -42,7 +53,11 @@ export function evaluateForum(session: ForumEvaluationSession): HostedWebScoreRe
 
   return aggregateStrictScore({
     evaluators: [retrieve, backend, ui],
-    passSummary: "Agent found the generated target thread, replied with the required value, and locked it with the correct reason.",
+    passSummary: requiresPin
+      ? "Agent found the generated target thread, replied with the required value, locked it with the correct reason, and pinned it."
+      : requiresReport
+        ? "Agent found the generated target thread, reported it, replied with the required value, and locked it with the correct reason."
+        : "Agent found the generated target thread, replied with the required value, and locked it with the correct reason.",
     failSummary: "One or more required forum conditions were not met.",
   });
 }
@@ -84,12 +99,15 @@ function evaluateForumBackendState(
   targetThread: ForumThread | undefined,
   targetThreadId: string,
   expectedLockReason: string,
+  requiresPin: boolean,
+  requiresReport: boolean,
+  expectedReportReason: string | null,
 ): HostedWebEvaluatorResult {
   if (!targetThread) {
     return failedEvaluator({
       type: "backend_state",
       name: "generated target thread moderated and replied",
-      errorMessage: "Target battery thread not found.",
+      errorMessage: "Target thread not found.",
     });
   }
 
@@ -101,6 +119,24 @@ function evaluateForumBackendState(
   );
   const lockReasonMatches = lockAction?.reason.trim().toLowerCase() === expectedLockReason.toLowerCase();
 
+  const pinAction = requiresPin
+    ? session.state.moderationActions.find(
+        (action) => action.threadId === targetThreadId && action.action === "pin",
+      )
+    : null;
+  const hasPin = !requiresPin || pinAction != null;
+
+  const reportAction = requiresReport
+    ? session.state.moderationActions.find(
+        (action) => action.threadId === targetThreadId && action.action === "report",
+      )
+    : null;
+  const hasReport = !requiresReport || reportAction != null;
+  const reportReasonMatches =
+    !requiresReport ||
+    (reportAction != null &&
+      reportAction.reason.trim().toLowerCase() === (expectedReportReason ?? "").toLowerCase());
+
   const evidence = {
     threadId: targetThreadId,
     hasAgentReply,
@@ -108,9 +144,15 @@ function evaluateForumBackendState(
     isLocked,
     lockReason: lockAction?.reason ?? null,
     lockReasonMatches,
+    requiresPin,
+    hasPin,
+    requiresReport,
+    hasReport,
+    reportReason: reportAction?.reason ?? null,
+    reportReasonMatches,
   };
 
-  const pass = hasAgentReply && isLocked && lockReasonMatches;
+  const pass = hasAgentReply && isLocked && lockReasonMatches && hasPin && hasReport && reportReasonMatches;
 
   return pass
     ? passedEvaluator({
@@ -122,7 +164,7 @@ function evaluateForumBackendState(
         type: "backend_state",
         name: "generated target thread moderated and replied",
         errorMessage:
-          `Backend state must include an agent reply, the thread must be locked, and the lock reason must be '${expectedLockReason}'.`,
+          "Backend state must include an agent reply, the thread must be locked with the correct reason, and any required report or pin actions must be present.",
         evidence,
       });
 }

--- a/apps/hosted-sites/src/apps/forum-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/final-state.ts
@@ -1,9 +1,18 @@
+import { configString, readTaskConfig } from "../../runtime/question-config.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
 
 export function buildForumFinalState(session: HostedSessionFor<"forum-lite">) {
-  const targetThread = session.state.threads.find((candidate) => candidate.id === "thr-battery");
+  const config = readTaskConfig(session.metadata);
+  const targetThreadId = configString(config, "targetThreadId");
+  const targetThread = session.state.threads.find((candidate) => candidate.id === targetThreadId);
   const lockAction = session.state.moderationActions.find(
-    (action) => action.threadId === "thr-battery" && action.action === "lock",
+    (action) => action.threadId === targetThreadId && action.action === "lock",
+  );
+  const pinAction = session.state.moderationActions.find(
+    (action) => action.threadId === targetThreadId && action.action === "pin",
+  );
+  const reportAction = session.state.moderationActions.find(
+    (action) => action.threadId === targetThreadId && action.action === "report",
   );
 
   return {
@@ -14,6 +23,7 @@ export function buildForumFinalState(session: HostedSessionFor<"forum-lite">) {
           id: targetThread.id,
           title: targetThread.title,
           locked: Boolean(targetThread.locked),
+          pinned: Boolean(targetThread.pinned),
           postCount: targetThread.posts.length,
           agentReplyCount: targetThread.posts.filter((post) => post.author === "agent").length,
         }
@@ -22,6 +32,18 @@ export function buildForumFinalState(session: HostedSessionFor<"forum-lite">) {
       ? {
           id: lockAction.id,
           reason: lockAction.reason,
+        }
+      : null,
+    pinAction: pinAction
+      ? {
+          id: pinAction.id,
+          reason: pinAction.reason,
+        }
+      : null,
+    reportAction: reportAction
+      ? {
+          id: reportAction.id,
+          reason: reportAction.reason,
         }
       : null,
   };

--- a/apps/hosted-sites/src/apps/forum-lite/render.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/render.ts
@@ -14,8 +14,8 @@ export function renderForumIndex(
   const cards = session.state.threads
     .map(
       (thread) => `<article class="card">
-        <h2>${escapeHtml(thread.title)}</h2>
-        <p class="muted">Category: ${escapeHtml(thread.category)} · Posts: ${thread.posts.length}${thread.locked ? " · <span class=\"danger\">Locked</span>" : ""}</p>
+        <h2>${escapeHtml(thread.title)}${thread.pinned ? ' <span class="accent">[Pinned]</span>' : ""}</h2>
+        <p class="muted">Category: ${escapeHtml(thread.category)} · Posts: ${thread.posts.length}${thread.locked ? " · <span class=\"danger\">Locked</span>" : ""}${thread.pinned ? " · <span class=\"accent\">Pinned</span>" : ""}</p>
         <a href="/forum/thread/${encodeURIComponent(thread.id)}?session=${encodeURIComponent(session.token)}">Open thread</a>
       </article>`,
     )
@@ -57,6 +57,12 @@ export function renderThread(
       </div>`
     : "";
 
+  const pinnedBanner = thread.pinned
+    ? `<div class="panel" style="background:#f0fff4;border-color:#b0e8b4;">
+        <p style="margin:0;color:#2f7d32;">This thread is pinned.</p>
+      </div>`
+    : "";
+
   const replyForm = thread.locked
     ? ""
     : `<section class="panel" style="margin-top:16px;">
@@ -73,7 +79,7 @@ export function renderThread(
   const lockForm = thread.locked
     ? ""
     : `<section class="panel" style="margin-top:16px;">
-        <h2>Moderation</h2>
+        <h2>Lock thread</h2>
         <form method="post" action="/forum/thread/${encodeURIComponent(thread.id)}/lock?session=${encodeURIComponent(session.token)}">
           <label>
             Lock reason
@@ -82,6 +88,43 @@ export function renderThread(
           <button type="submit" style="margin-top:12px;">Lock thread</button>
         </form>
       </section>`;
+
+  const reportForm = thread.locked
+    ? ""
+    : `<section class="panel" style="margin-top:16px;">
+        <h2>Report thread</h2>
+        <form method="post" action="/forum/thread/${encodeURIComponent(thread.id)}/report?session=${encodeURIComponent(session.token)}">
+          <label>
+            Report reason
+            <input name="reason" placeholder="Enter the required report reason" style="display:block;width:100%;min-height:40px;margin-top:8px;border:1px solid #d8d2c7;border-radius:6px;padding:8px 10px;" />
+          </label>
+          <button type="submit" style="margin-top:12px;">Report thread</button>
+        </form>
+      </section>`;
+
+  const pinForm = thread.locked && !thread.pinned
+    ? `<section class="panel" style="margin-top:16px;">
+        <h2>Pin thread</h2>
+        <form method="post" action="/forum/thread/${encodeURIComponent(thread.id)}/pin?session=${encodeURIComponent(session.token)}">
+          <label>
+            Pin reason
+            <input name="reason" placeholder="Enter the required pin reason" style="display:block;width:100%;min-height:40px;margin-top:8px;border:1px solid #d8d2c7;border-radius:6px;padding:8px 10px;" />
+          </label>
+          <button type="submit" style="margin-top:12px;">Pin thread</button>
+        </form>
+      </section>`
+    : "";
+
+  const moderationLog = session.state.moderationActions
+    .filter((action) => action.threadId === thread.id)
+    .map((action) => `<li><strong>${escapeHtml(action.action)}</strong>: ${escapeHtml(action.reason)}</li>`)
+    .join("");
+  const moderationLogSection = moderationLog
+    ? `<section class="panel" style="margin-top:16px;">
+        <h2>Moderation log</h2>
+        <ul>${moderationLog}</ul>
+      </section>`
+    : "";
 
 
   sendHtml(
@@ -92,13 +135,17 @@ export function renderThread(
       session,
       body: `
         ${lockedBanner}
+        ${pinnedBanner}
         <section class="panel">
           <h2>${escapeHtml(thread.title)}</h2>
           <p class="muted">Category: ${escapeHtml(thread.category)}</p>
           <div>${postsHtml}</div>
         </section>
         ${replyForm}
+        ${reportForm}
         ${lockForm}
+        ${pinForm}
+        ${moderationLogSection}
         <section class="panel" style="margin-top:16px;">
           <h2>Evaluator preview</h2>
           <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>

--- a/apps/hosted-sites/src/apps/forum-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/routes.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
 import { redirect, sendJson } from "../../runtime/http.js";
 import { isHostedSessionForApp } from "../../runtime/types.js";
-import { addReplyToThread, lockThread } from "./actions.js";
+import { addReplyToThread, lockThread, pinThread, reportThread } from "./actions.js";
 import { renderForumIndex, renderThread } from "./render.js";
 
 export function createForumRoutes(deps: HostedAppRouteDeps) {
@@ -138,6 +138,92 @@ export function createForumRoutes(deps: HostedAppRouteDeps) {
         sendJson(response, 502, { error: "Hosted orchestrator unavailable" });
         return true;
       }
+
+      redirect(response, `/forum/thread/${encodeURIComponent(threadId)}?session=${encodeURIComponent(session.token)}`);
+      return true;
+    }
+
+    const pinMatch = url.pathname.match(/^\/forum\/thread\/([^/]+)\/pin$/);
+    if (request.method === "POST" && pinMatch) {
+      const session = await getForumSession(url, request);
+      if (!session) {
+        deps.badRequest(response, "Missing or invalid session");
+        return true;
+      }
+      if (deps.rejectTerminalMutation(session, response)) return true;
+
+      const threadId = decodeURIComponent(pinMatch[1]);
+      const form = await deps.readForm(request);
+      const reason = form.get("reason");
+      if (typeof reason !== "string" || reason.trim().length === 0) {
+        deps.badRequest(response, "Pin reason is required");
+        return true;
+      }
+
+      const result = pinThread(session, {
+        threadId,
+        reason: reason.trim(),
+        makeId: deps.makeId,
+      });
+
+      if (!result.success) {
+        deps.badRequest(response, result.error);
+        return true;
+      }
+
+      await deps.persistSessionSnapshot(session);
+      await deps.recordEvent(session, { type: "task.signal", name: "forum.thread_pinned", threadId, actionId: result.action.id });
+      await deps.forwardRunEvent(session, "hosted.task_signal", {
+        source: "hosted-sites",
+        sessionId: session.id,
+        taskSlug: session.taskSlug,
+        name: "forum.thread_pinned",
+        threadId,
+        actionId: result.action.id,
+      });
+
+      redirect(response, `/forum/thread/${encodeURIComponent(threadId)}?session=${encodeURIComponent(session.token)}`);
+      return true;
+    }
+
+    const reportMatch = url.pathname.match(/^\/forum\/thread\/([^/]+)\/report$/);
+    if (request.method === "POST" && reportMatch) {
+      const session = await getForumSession(url, request);
+      if (!session) {
+        deps.badRequest(response, "Missing or invalid session");
+        return true;
+      }
+      if (deps.rejectTerminalMutation(session, response)) return true;
+
+      const threadId = decodeURIComponent(reportMatch[1]);
+      const form = await deps.readForm(request);
+      const reason = form.get("reason");
+      if (typeof reason !== "string" || reason.trim().length === 0) {
+        deps.badRequest(response, "Report reason is required");
+        return true;
+      }
+
+      const result = reportThread(session, {
+        threadId,
+        reason: reason.trim(),
+        makeId: deps.makeId,
+      });
+
+      if (!result.success) {
+        deps.badRequest(response, result.error);
+        return true;
+      }
+
+      await deps.persistSessionSnapshot(session);
+      await deps.recordEvent(session, { type: "task.signal", name: "forum.thread_reported", threadId, actionId: result.action.id });
+      await deps.forwardRunEvent(session, "hosted.task_signal", {
+        source: "hosted-sites",
+        sessionId: session.id,
+        taskSlug: session.taskSlug,
+        name: "forum.thread_reported",
+        threadId,
+        actionId: result.action.id,
+      });
 
       redirect(response, `/forum/thread/${encodeURIComponent(threadId)}?session=${encodeURIComponent(session.token)}`);
       return true;

--- a/apps/hosted-sites/src/apps/forum-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/forum-lite/test-driver.mjs
@@ -1,10 +1,24 @@
 export async function complete({ session, config, hostedBaseUrl, checkedFetch, postForm, requireString }) {
   const threadId = requireString(config.targetThreadId, "forum targetThreadId");
   await checkedFetch(`${hostedBaseUrl}/forum/thread/${encodeURIComponent(threadId)}?session=${encodeURIComponent(session.token)}`);
+
+  if (config.requiresReport) {
+    await postForm(`/forum/thread/${encodeURIComponent(threadId)}/report`, session.token, {
+      reason: requireString(config.expectedReportReason, "forum expectedReportReason"),
+    });
+  }
+
   await postForm(`/forum/thread/${encodeURIComponent(threadId)}/reply`, session.token, {
     body: requireString(config.expectedReplyValue, "forum expectedReplyValue"),
   });
+
   await postForm(`/forum/thread/${encodeURIComponent(threadId)}/lock`, session.token, {
     reason: requireString(config.expectedLockReason, "forum expectedLockReason"),
   });
+
+  if (config.requiresPin) {
+    await postForm(`/forum/thread/${encodeURIComponent(threadId)}/pin`, session.token, {
+      reason: requireString(config.expectedLockReason, "forum pin reason"),
+    });
+  }
 }

--- a/apps/hosted-sites/src/apps/forum-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/test-support.ts
@@ -1,4 +1,4 @@
-import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
+import { configBooleanOrFalse, configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const forumLiteTestSupport: HostedAppTestSupport<"forum-lite"> = {
   exampleTaskConfig: {
@@ -12,16 +12,41 @@ export const forumLiteTestSupport: HostedAppTestSupport<"forum-lite"> = {
     if (!thread) {
       throw new Error(`missing thread ${threadId}`);
     }
+
+    const requiresReport = configBooleanOrFalse(config, "requiresReport");
+    if (requiresReport) {
+      session.state.moderationActions.push({
+        id: "mod-report-matrix",
+        threadId,
+        action: "report",
+        reason: configString(config, "expectedReportReason"),
+      });
+    }
+
     thread.posts.push({ id: "post-matrix", author: "agent", body: configString(config, "expectedReplyValue") });
     thread.locked = true;
     session.state.moderationActions.push({
-      id: "moderation-matrix",
+      id: "mod-lock-matrix",
       threadId,
       action: "lock",
       reason: configString(config, "expectedLockReason"),
     });
+
+    const requiresPin = configBooleanOrFalse(config, "requiresPin");
+    if (requiresPin) {
+      thread.pinned = true;
+      session.state.moderationActions.push({
+        id: "mod-pin-matrix",
+        threadId,
+        action: "pin",
+        reason: configString(config, "expectedLockReason"),
+      });
+    }
   },
   breakPassingState(session) {
-    session.state.moderationActions[0]!.reason = "wrong reason";
+    const lockAction = session.state.moderationActions.find((a) => a.action === "lock");
+    if (lockAction) {
+      lockAction.reason = "wrong reason";
+    }
   },
 };

--- a/apps/hosted-sites/src/apps/forum-lite/types.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/types.ts
@@ -10,12 +10,13 @@ export type ForumThread = {
   category: string;
   posts: ForumPost[];
   locked?: boolean;
+  pinned?: boolean;
 };
 
 export type ModerationAction = {
   id: string;
   threadId: string;
-  action: "lock" | "pin" | "remove_post";
+  action: "lock" | "pin" | "remove_post" | "report";
   reason: string;
 };
 

--- a/apps/hosted-sites/src/apps/notes-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/actions.ts
@@ -31,3 +31,31 @@ export function createNote(
   session.state.notes.push(note);
   return { success: true, note } as const;
 }
+
+export function updateNote(
+  session: NotesSession,
+  params: {
+    noteId: string;
+    title: string;
+    body: string;
+    tag: string;
+  },
+) {
+  const note = session.state.notes.find((candidate) => candidate.id === params.noteId);
+  if (!note) {
+    return { success: false, error: "Note not found" } as const;
+  }
+
+  const title = params.title.trim();
+  const body = params.body.trim();
+  const tag = params.tag.trim();
+
+  if (!title) return { success: false, error: "Title is required" } as const;
+  if (!body) return { success: false, error: "Body is required" } as const;
+  if (!tag) return { success: false, error: "Tag is required" } as const;
+
+  note.title = title;
+  note.body = body;
+  note.tag = tag;
+  return { success: true, note } as const;
+}

--- a/apps/hosted-sites/src/apps/notes-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/definition.ts
@@ -2,7 +2,7 @@ import { isStateRecord, readStateArray, type HostedAppDefinition } from "../../r
 import { evaluateNotes } from "./evaluate.js";
 import { buildNotesFinalState } from "./final-state.js";
 import { createNotesRoutes } from "./routes.js";
-import { getNotesDefaultGoal, getNotesStartPath } from "./seed.js";
+import { getNotesDefaultGoal, getNotesStartPath, notesSeedNotes } from "./seed.js";
 import type { Note } from "./types.js";
 
 function isNote(value: unknown): value is Note {
@@ -22,7 +22,7 @@ export const notesLiteDefinition: HostedAppDefinition<"notes-lite"> = {
   getDefaultStartPath: getNotesStartPath,
   getDefaultGoal: () => getNotesDefaultGoal(),
   buildInitialSessionState: () => ({
-    notes: [],
+    notes: notesSeedNotes.map((note) => ({ ...note })),
   }),
   hydratePersistedState: (value) => ({
     notes: readStateArray(value, "notes", isNote),

--- a/apps/hosted-sites/src/apps/notes-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/evaluate.ts
@@ -5,7 +5,7 @@ import {
   type HostedWebEvaluatorResult,
   type HostedWebScoreResult,
 } from "@agentbench/scoring";
-import { configString, readTaskConfig } from "../../runtime/question-config.js";
+import { configString, configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 import type { Note } from "./types.js";
 
 export type NotesEvaluationSession = {
@@ -22,11 +22,14 @@ export function evaluateNotes(session: NotesEvaluationSession): HostedWebScoreRe
   const expectedTitle = configString(config, "expectedTitle");
   const expectedBody = configString(config, "expectedBody");
   const expectedTag = configString(config, "expectedTag");
-  const backend = evaluateNotesBackendState(session.state.notes, expectedTitle, expectedBody, expectedTag);
+  const targetNoteId = configStringOrNull(config, "targetNoteId");
+  const backend = evaluateNotesBackendState(session.state.notes, expectedTitle, expectedBody, expectedTag, targetNoteId);
 
   return aggregateStrictScore({
     evaluators: [backend],
-    passSummary: "Agent created the requested note with the exact generated title, body, and tag.",
+    passSummary: targetNoteId
+      ? "Agent updated the requested seeded note to the exact generated title, body, and tag."
+      : "Agent created the requested note with the exact generated title, body, and tag.",
     failSummary: "The requested note was not found in backend state.",
   });
 }
@@ -36,13 +39,16 @@ function evaluateNotesBackendState(
   expectedTitle: string,
   expectedBody: string,
   expectedTag: string,
+  targetNoteId: string | null,
 ): HostedWebEvaluatorResult {
-  const matchingNote = notes.find(
+  const candidateNotes = targetNoteId ? notes.filter((note) => note.id === targetNoteId) : notes;
+  const matchingNote = candidateNotes.find(
     (note) => note.title.trim() === expectedTitle && note.body.trim() === expectedBody && note.tag.trim() === expectedTag,
   );
   const evidence = {
     expectedTitle,
     expectedTag,
+    targetNoteId,
     noteCount: notes.length,
     matchingNoteId: matchingNote?.id ?? null,
   };
@@ -56,7 +62,9 @@ function evaluateNotesBackendState(
     : failedEvaluator({
         type: "backend_state",
         name: "generated note exists",
-        errorMessage: "No note exactly matches the generated title, body, and tag.",
+        errorMessage: targetNoteId
+          ? "The targeted seeded note was not updated to the expected title, body, and tag."
+          : "No note exactly matches the generated title, body, and tag.",
         evidence,
       });
 }

--- a/apps/hosted-sites/src/apps/notes-lite/render.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/render.ts
@@ -1,4 +1,5 @@
 import type { ServerResponse } from "node:http";
+import type { Note } from "./types.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
 import { escapeHtml, layout, sendHtml } from "../../templates.js";
 
@@ -18,6 +19,7 @@ export function renderNotesIndex(
             <p class="muted" style="margin-top:0;">${escapeHtml(note.tag)} · ${escapeHtml(note.createdAt)}</p>
             <h2>${escapeHtml(note.title)}</h2>
             <p>${escapeHtml(note.body)}</p>
+            <a href="/notes/${encodeURIComponent(note.id)}/edit?session=${encodeURIComponent(session.token)}">Edit</a>
           </article>`,
         )
         .join("")
@@ -52,6 +54,44 @@ export function renderNotesIndex(
         <section class="panel" style="margin-top:16px;">
           <h2>Evaluator preview</h2>
           <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
+        </section>`,
+      publicBaseUrl,
+      defaultStartPathForApp,
+    }),
+  );
+}
+
+export function renderNoteEdit(
+  session: NotesSession,
+  note: Note,
+  response: ServerResponse,
+  publicBaseUrl: string,
+  defaultStartPathForApp: (app: string) => string,
+) {
+  sendHtml(
+    response,
+    200,
+    layout({
+      title: `Edit ${note.title}`,
+      session,
+      body: `
+        <section class="panel">
+          <h2>Edit note</h2>
+          <form method="post" action="/notes/${encodeURIComponent(note.id)}/edit?session=${encodeURIComponent(session.token)}">
+            <label>
+              Title
+              <input name="title" value="${escapeHtml(note.title)}" style="display:block;width:100%;min-height:40px;margin-top:8px;border:1px solid #d8d2c7;border-radius:6px;padding:8px 10px;" />
+            </label>
+            <label style="display:block;margin-top:12px;">
+              Body
+              <textarea name="body" rows="5" style="display:block;width:100%;margin-top:8px;border:1px solid #d8d2c7;border-radius:6px;padding:8px 10px;font-family:inherit;">${escapeHtml(note.body)}</textarea>
+            </label>
+            <label style="display:block;margin-top:12px;">
+              Tag
+              <input name="tag" value="${escapeHtml(note.tag)}" style="display:block;width:100%;min-height:40px;margin-top:8px;border:1px solid #d8d2c7;border-radius:6px;padding:8px 10px;" />
+            </label>
+            <button type="submit" style="margin-top:12px;">Save note</button>
+          </form>
         </section>`,
       publicBaseUrl,
       defaultStartPathForApp,

--- a/apps/hosted-sites/src/apps/notes-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/routes.ts
@@ -2,8 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
 import { redirect, sendJson } from "../../runtime/http.js";
 import { isHostedSessionForApp } from "../../runtime/types.js";
-import { createNote } from "./actions.js";
-import { renderNotesIndex } from "./render.js";
+import { createNote, updateNote } from "./actions.js";
+import { renderNoteEdit, renderNotesIndex } from "./render.js";
 
 export function createNotesRoutes(deps: HostedAppRouteDeps) {
   async function getNotesSession(url: URL, request: IncomingMessage) {
@@ -65,6 +65,69 @@ export function createNotesRoutes(deps: HostedAppRouteDeps) {
         sessionId: session.id,
         taskSlug: session.taskSlug,
         name: "notes.note_created",
+        noteId: result.note.id,
+      });
+
+      const evalResult = deps.evaluateSession(session);
+      const completed = await deps.completeSession(session, evalResult);
+      if (!completed) {
+        sendJson(response, 502, { error: "Hosted orchestrator unavailable" });
+        return true;
+      }
+
+      redirect(response, `/notes?session=${encodeURIComponent(session.token)}`);
+      return true;
+    }
+
+    const noteEditMatch = url.pathname.match(/^\/notes\/([^/]+)\/edit$/);
+    if (request.method === "GET" && noteEditMatch) {
+      const session = await getNotesSession(url, request);
+      if (!session) {
+        deps.badRequest(response, "Missing or invalid session");
+        return true;
+      }
+      const noteId = decodeURIComponent(noteEditMatch[1]);
+      const note = session.state.notes.find((candidate) => candidate.id === noteId);
+      if (!note) {
+        deps.notFound(response);
+        return true;
+      }
+
+      renderNoteEdit(session, note, response, deps.publicBaseUrl, deps.defaultStartPathForApp);
+      return true;
+    }
+
+    if (request.method === "POST" && noteEditMatch) {
+      const session = await getNotesSession(url, request);
+      if (!session) {
+        deps.badRequest(response, "Missing or invalid session");
+        return true;
+      }
+      if (deps.rejectTerminalMutation(session, response)) return true;
+
+      const noteId = decodeURIComponent(noteEditMatch[1]);
+      const form = await deps.readForm(request);
+      const title = form.get("title");
+      const body = form.get("body");
+      const tag = form.get("tag");
+      if (typeof title !== "string" || typeof body !== "string" || typeof tag !== "string") {
+        deps.badRequest(response, "Title, body, and tag are required");
+        return true;
+      }
+
+      const result = updateNote(session, { noteId, title, body, tag });
+      if (!result.success) {
+        deps.badRequest(response, result.error);
+        return true;
+      }
+
+      await deps.persistSessionSnapshot(session);
+      await deps.recordEvent(session, { type: "task.signal", name: "notes.note_updated", noteId: result.note.id });
+      await deps.forwardRunEvent(session, "hosted.task_signal", {
+        source: "hosted-sites",
+        sessionId: session.id,
+        taskSlug: session.taskSlug,
+        name: "notes.note_updated",
         noteId: result.note.id,
       });
 

--- a/apps/hosted-sites/src/apps/notes-lite/seed.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/seed.ts
@@ -1,3 +1,29 @@
+import type { Note } from "./types.js";
+
+export const notesSeedNotes: Note[] = [
+  {
+    id: "note-seed-support",
+    title: "Old support follow-up",
+    body: "Follow up with Mira about the replacement adapter.",
+    tag: "support",
+    createdAt: "2026-06-01T00:00:00.000Z",
+  },
+  {
+    id: "note-seed-release",
+    title: "Old release reminder",
+    body: "Check the hosted-web v3.0.1 smoke run status.",
+    tag: "release",
+    createdAt: "2026-06-01T00:00:00.000Z",
+  },
+  {
+    id: "note-seed-ops",
+    title: "Old ops check",
+    body: "Check Redis health metrics.",
+    tag: "ops",
+    createdAt: "2026-06-01T00:00:00.000Z",
+  },
+];
+
 export function getNotesStartPath() {
   return "/notes";
 }

--- a/apps/hosted-sites/src/apps/notes-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/notes-lite/test-driver.mjs
@@ -1,7 +1,11 @@
-export async function complete({ session, config, postForm, requireString }) {
-  await postForm("/notes/create", session.token, {
-    title: requireString(config.expectedTitle, "notes expectedTitle"),
-    body: requireString(config.expectedBody, "notes expectedBody"),
-    tag: requireString(config.expectedTag, "notes expectedTag"),
-  });
+export async function complete({ session, config, hostedBaseUrl, checkedFetch, postForm, requireString }) {
+  const title = requireString(config.expectedTitle, "notes expectedTitle");
+  const body = requireString(config.expectedBody, "notes expectedBody");
+  const tag = requireString(config.expectedTag, "notes expectedTag");
+  if (config.targetNoteId) {
+    await checkedFetch(`${hostedBaseUrl}/notes/${encodeURIComponent(config.targetNoteId)}/edit?session=${encodeURIComponent(session.token)}`);
+    await postForm(`/notes/${encodeURIComponent(config.targetNoteId)}/edit`, session.token, { title, body, tag });
+  } else {
+    await postForm("/notes/create", session.token, { title, body, tag });
+  }
 }

--- a/apps/hosted-sites/src/apps/notes-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/test-support.ts
@@ -1,4 +1,4 @@
-import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
+import { configString, configStringOrNull, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const notesLiteTestSupport: HostedAppTestSupport<"notes-lite"> = {
   exampleTaskConfig: {
@@ -7,6 +7,18 @@ export const notesLiteTestSupport: HostedAppTestSupport<"notes-lite"> = {
     expectedTag: "support",
   },
   applyPassingState: (session, config) => {
+    const targetNoteId = configStringOrNull(config, "targetNoteId");
+    if (targetNoteId) {
+      const note = session.state.notes.find((candidate) => candidate.id === targetNoteId);
+      if (!note) {
+        throw new Error(`missing seeded note ${targetNoteId}`);
+      }
+      note.title = configString(config, "expectedTitle");
+      note.body = configString(config, "expectedBody");
+      note.tag = configString(config, "expectedTag");
+      session.metadata = { ...session.metadata, _testTargetNoteId: targetNoteId };
+      return;
+    }
     session.state.notes.push({
       id: "note-smoke-pass",
       title: configString(config, "expectedTitle"),
@@ -16,7 +28,11 @@ export const notesLiteTestSupport: HostedAppTestSupport<"notes-lite"> = {
     });
   },
   breakPassingState: (session) => {
-    const note = session.state.notes.at(-1);
+    const targetNoteId =
+      typeof session.metadata._testTargetNoteId === "string" ? session.metadata._testTargetNoteId : null;
+    const note = targetNoteId
+      ? session.state.notes.find((candidate) => candidate.id === targetNoteId)
+      : session.state.notes.at(-1);
     if (note) {
       note.tag = "incorrect";
     }

--- a/apps/hosted-sites/src/apps/repo-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/actions.ts
@@ -20,9 +20,7 @@ export function createMergeRequest(
     makeId: (prefix: string) => string;
   },
 ) {
-  const changedFiles = session.state.files
-    .map((file) => ({ ...file }))
-    .filter((file) => file.path === "README.md");
+  const changedFiles = session.state.files.map((file) => ({ ...file }));
 
   const mr: RepoMergeRequest = {
     id: params.makeId("mr"),

--- a/apps/hosted-sites/src/apps/repo-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/evaluate.ts
@@ -6,7 +6,7 @@ import {
   type HostedWebScoreResult,
 } from "@agentbench/scoring";
 import type { RepoFile, RepoMergeRequest } from "./types.js";
-import { configString, readTaskConfig } from "../../runtime/question-config.js";
+import { configString, configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 
 function containsStandaloneText(content: string, value: string) {
   const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -57,9 +57,25 @@ function evaluateRepoBackendState(
   const forbiddenText = configString(config, "forbiddenText");
   const expectedMrTitle = configString(config, "expectedMrTitle");
   const expectedTargetBranch = configString(config, "expectedTargetBranch");
+  const secondaryFilePath = configStringOrNull(config, "secondaryFilePath");
+  const secondaryExpectedText = configStringOrNull(config, "secondaryExpectedText");
+  const secondaryForbiddenText = configStringOrNull(config, "secondaryForbiddenText");
+
   const file = session.state.files.find((candidate) => candidate.path === filePath);
   const fileHasExpectedText = file ? file.content.includes(expectedText) : false;
   const fileHasForbiddenText = file ? containsStandaloneText(file.content, forbiddenText) : true;
+
+  const secondaryFile = secondaryFilePath
+    ? session.state.files.find((candidate) => candidate.path === secondaryFilePath)
+    : undefined;
+  const secondaryHasExpectedText =
+    secondaryFilePath == null || secondaryExpectedText == null
+      ? true
+      : secondaryFile != null && secondaryFile.content.includes(secondaryExpectedText);
+  const secondaryHasForbiddenText =
+    secondaryFilePath == null || secondaryForbiddenText == null
+      ? false
+      : secondaryFile != null && containsStandaloneText(secondaryFile.content, secondaryForbiddenText);
 
   if (!mr) {
     return failedEvaluator({
@@ -70,6 +86,9 @@ function evaluateRepoBackendState(
         filePath,
         fileHasExpectedText,
         fileHasForbiddenText,
+        secondaryFilePath,
+        secondaryHasExpectedText,
+        secondaryHasForbiddenText,
         mrTitle: null,
         targetBranch: null,
       },
@@ -78,7 +97,13 @@ function evaluateRepoBackendState(
 
   const titleMatches = mr.title.trim() === expectedMrTitle;
   const targetBranchMatches = mr.targetBranch.trim().toLowerCase() === expectedTargetBranch.toLowerCase();
-  const pass = titleMatches && targetBranchMatches && fileHasExpectedText && !fileHasForbiddenText;
+  const pass =
+    titleMatches &&
+    targetBranchMatches &&
+    fileHasExpectedText &&
+    !fileHasForbiddenText &&
+    secondaryHasExpectedText &&
+    !secondaryHasForbiddenText;
 
   const evidence = {
     mrTitle: mr.title,
@@ -88,6 +113,9 @@ function evaluateRepoBackendState(
     filePath,
     fileHasExpectedText,
     fileHasForbiddenText,
+    secondaryFilePath,
+    secondaryHasExpectedText,
+    secondaryHasForbiddenText,
   };
 
   return pass
@@ -100,7 +128,7 @@ function evaluateRepoBackendState(
         type: "backend_state",
         name: "correct merge request created",
         errorMessage:
-          "The edited file and merge request do not satisfy the generated task configuration.",
+          "The edited file(s) and merge request do not satisfy the generated task configuration.",
         evidence,
       });
 }

--- a/apps/hosted-sites/src/apps/repo-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/final-state.ts
@@ -1,8 +1,16 @@
+import { configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
 
 export function buildRepoFinalState(session: HostedSessionFor<"repo-lite">) {
+  const config = readTaskConfig(session.metadata);
+  const secondaryFilePath = configStringOrNull(config, "secondaryFilePath");
+  const secondaryExpectedText = configStringOrNull(config, "secondaryExpectedText");
+  const secondaryForbiddenText = configStringOrNull(config, "secondaryForbiddenText");
   const readme = session.state.files.find((f) => f.path === "README.md");
   const latestMR = session.state.mergeRequests.at(-1);
+  const secondaryFile = secondaryFilePath
+    ? session.state.files.find((f) => f.path === secondaryFilePath)
+    : undefined;
 
   return {
     app: "repo-lite",
@@ -14,6 +22,17 @@ export function buildRepoFinalState(session: HostedSessionFor<"repo-lite">) {
           hasNpmInstall: readme.content.includes("npm install"),
         }
       : null,
+    secondaryFile:
+      secondaryFilePath && secondaryFile
+        ? {
+            path: secondaryFile.path,
+            hasExpectedText:
+              secondaryExpectedText == null || secondaryFile.content.includes(secondaryExpectedText),
+            hasForbiddenText:
+              secondaryForbiddenText != null &&
+              containsStandaloneText(secondaryFile.content, secondaryForbiddenText),
+          }
+        : null,
     latestMR: latestMR
       ? {
           id: latestMR.id,
@@ -22,4 +41,9 @@ export function buildRepoFinalState(session: HostedSessionFor<"repo-lite">) {
         }
       : null,
   };
+}
+
+function containsStandaloneText(content: string, value: string) {
+  const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|[^A-Za-z0-9_])${escaped}(?:$|[^A-Za-z0-9_])`).test(content);
 }

--- a/apps/hosted-sites/src/apps/repo-lite/render.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/render.ts
@@ -111,7 +111,7 @@ export function renderNewMR(
       session,
       body: `<section class="panel">
         <h2>New Merge Request</h2>
-        <p class="muted">Proposed change to README.md</p>
+        <p class="muted">Proposed changes</p>
         ${diffPreview}
         <form method="post" action="/repo/mr/new?session=${encodeURIComponent(session.token)}" style="margin-top:16px;">
           <label>

--- a/apps/hosted-sites/src/apps/repo-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/repo-lite/test-driver.mjs
@@ -1,6 +1,11 @@
 export async function complete({ session, config, hostedBaseUrl, checkedFetch, postForm, requireString }) {
   const filePath = requireString(config.filePath, "repo filePath");
   const expectedText = requireString(config.expectedText, "repo expectedText");
+  const forbiddenText = requireString(config.forbiddenText, "repo forbiddenText");
+  const secondaryFilePath = config.secondaryFilePath;
+  const secondaryExpectedText = config.secondaryExpectedText;
+  const secondaryForbiddenText = config.secondaryForbiddenText;
+
   const content = [
     "# Demo Project",
     "",
@@ -15,6 +20,22 @@ export async function complete({ session, config, hostedBaseUrl, checkedFetch, p
   ].join("\n");
   await checkedFetch(`${hostedBaseUrl}/repo/file/${encodeURIComponent(filePath)}/edit?session=${encodeURIComponent(session.token)}`);
   await postForm(`/repo/file/${encodeURIComponent(filePath)}/edit`, session.token, { content });
+
+  if (secondaryFilePath) {
+    let secondaryContent;
+    if (secondaryFilePath === "package.json" && secondaryExpectedText === "1.0.1") {
+      secondaryContent = '{\n  "name": "demo-project",\n  "version": "1.0.1"\n}\n';
+    } else if (secondaryFilePath === "package.json" && secondaryExpectedText === "demo-yarn-project") {
+      secondaryContent = '{\n  "name": "demo-yarn-project",\n  "version": "1.0.0"\n}\n';
+    } else if (secondaryFilePath === "package.json" && secondaryExpectedText === "test") {
+      secondaryContent = '{\n  "name": "demo-project",\n  "version": "1.0.0",\n  "scripts": {\n    "test": "echo \\"Error: no test specified\\""\n  }\n}\n';
+    } else {
+      throw new Error(`unsupported secondary file variant: ${secondaryFilePath} / ${secondaryExpectedText}`);
+    }
+    await checkedFetch(`${hostedBaseUrl}/repo/file/${encodeURIComponent(secondaryFilePath)}/edit?session=${encodeURIComponent(session.token)}`);
+    await postForm(`/repo/file/${encodeURIComponent(secondaryFilePath)}/edit`, session.token, { content: secondaryContent });
+  }
+
   await postForm("/repo/mr/new", session.token, {
     title: requireString(config.expectedMrTitle, "repo expectedMrTitle"),
     targetBranch: requireString(config.expectedTargetBranch, "repo expectedTargetBranch"),

--- a/apps/hosted-sites/src/apps/repo-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/test-support.ts
@@ -1,4 +1,4 @@
-import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
+import { configString, configStringOrNull, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const repoLiteTestSupport: HostedAppTestSupport<"repo-lite"> = {
   exampleTaskConfig: {
@@ -14,12 +14,34 @@ export const repoLiteTestSupport: HostedAppTestSupport<"repo-lite"> = {
     if (!file) {
       throw new Error(`missing file ${filePath}`);
     }
-    file.content = file.content.replaceAll(configString(config, "forbiddenText"), configString(config, "expectedText"));
+    file.content = file.content.replaceAll(
+      configString(config, "forbiddenText"),
+      configString(config, "expectedText"),
+    );
+
+    const secondaryFilePath = configStringOrNull(config, "secondaryFilePath");
+    const secondaryExpectedText = configStringOrNull(config, "secondaryExpectedText");
+    const secondaryForbiddenText = configStringOrNull(config, "secondaryForbiddenText");
+    if (secondaryFilePath && secondaryExpectedText) {
+      const secondaryFile = session.state.files.find((candidate) => candidate.path === secondaryFilePath);
+      if (!secondaryFile) {
+        throw new Error(`missing secondary file ${secondaryFilePath}`);
+      }
+      if (secondaryForbiddenText) {
+        secondaryFile.content = secondaryFile.content.replaceAll(
+          secondaryForbiddenText,
+          secondaryExpectedText,
+        );
+      } else {
+        secondaryFile.content = `${secondaryFile.content.trimEnd()}\n${secondaryExpectedText}\n`;
+      }
+    }
+
     session.state.mergeRequests.push({
       id: "mr-matrix",
       title: configString(config, "expectedMrTitle"),
       targetBranch: configString(config, "expectedTargetBranch"),
-      changedFiles: [{ path: file.path, content: file.content }],
+      changedFiles: session.state.files.map((f) => ({ ...f })),
     });
   },
   breakPassingState(session) {

--- a/apps/hosted-sites/src/apps/shopping-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/actions.ts
@@ -35,6 +35,27 @@ export function addProductToCart(session: ShoppingSession, productId: string) {
   session.state.cart.push({ productId, quantity: 1 });
 }
 
+export function removeProductFromCart(session: ShoppingSession, productId: string) {
+  session.state.cart = session.state.cart.filter((item) => item.productId !== productId);
+}
+
+export function setCartItemQuantity(session: ShoppingSession, productId: string, quantity: number) {
+  if (!Number.isInteger(quantity)) {
+    throw new Error("Quantity must be an integer.");
+  }
+  if (quantity <= 0) {
+    removeProductFromCart(session, productId);
+    return;
+  }
+
+  const existing = session.state.cart.find((item) => item.productId === productId);
+  if (existing) {
+    existing.quantity = quantity;
+  } else {
+    session.state.cart.push({ productId, quantity });
+  }
+}
+
 export function submitCheckoutOrder(
   session: ShoppingSession,
   params: {

--- a/apps/hosted-sites/src/apps/shopping-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/actions.ts
@@ -1,4 +1,5 @@
 import type { HostedSessionFor } from "../../runtime/types.js";
+import { configNumberOrNull, readTaskConfig } from "../../runtime/question-config.js";
 
 type ShoppingSession = HostedSessionFor<"shopping-lite">;
 import type { Order } from "./types.js";
@@ -35,19 +36,46 @@ export function addProductToCart(session: ShoppingSession, productId: string) {
   session.state.cart.push({ productId, quantity: 1 });
 }
 
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function getShippingCost(
+  session: ShoppingSession,
+  shippingMethod: "standard" | "express",
+  config?: Record<string, unknown>,
+): number {
+  if (shippingMethod === "express") {
+    return 0;
+  }
+  const taskConfig = config ?? readTaskConfig(session.metadata);
+  const freeShippingThreshold = configNumberOrNull(taskConfig, "freeShippingThreshold");
+  const shippingCost = configNumberOrNull(taskConfig, "shippingCost");
+  if (freeShippingThreshold == null || shippingCost == null) {
+    return 0;
+  }
+  const subtotal = getCartTotal(session);
+  return subtotal >= freeShippingThreshold ? 0 : shippingCost;
+}
+
 export function submitCheckoutOrder(
   session: ShoppingSession,
   params: {
     makeId: (prefix: string) => string;
     now: () => string;
     shippingMethod: "standard" | "express";
+    shippingCost?: number;
   },
 ) {
+  const subtotal = roundMoney(getCartTotal(session));
+  const shippingCost = roundMoney(params.shippingCost ?? 0);
   const order: Order = {
     id: params.makeId("ord"),
     items: session.state.cart.map((item) => ({ ...item })),
-    total: getCartTotal(session),
+    subtotal,
+    total: roundMoney(subtotal + shippingCost),
     shippingMethod: params.shippingMethod,
+    shippingCost,
     submittedAt: params.now(),
   };
   session.state.orders.push(order);

--- a/apps/hosted-sites/src/apps/shopping-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/definition.ts
@@ -26,6 +26,8 @@ function isOrder(value: unknown): value is Order {
     Array.isArray(value.items) &&
     value.items.every(isCartItem) &&
     typeof value.total === "number" &&
+    (value.subtotal === undefined || typeof value.subtotal === "number") &&
+    (value.shippingCost === undefined || typeof value.shippingCost === "number") &&
     (value.shippingMethod === "standard" || value.shippingMethod === "express") &&
     typeof value.submittedAt === "string"
   );

--- a/apps/hosted-sites/src/apps/shopping-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/evaluate.ts
@@ -6,7 +6,7 @@ import {
   type HostedWebScoreResult,
 } from "@agentbench/scoring";
 import type { Order, Product } from "./types.js";
-import { configBoolean, configNumber, configString, readTaskConfig } from "../../runtime/question-config.js";
+import { configBoolean, configNumber, configNumberOrNull, configString, configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 
 export type ShoppingEvaluationSession = {
   app: "shopping-lite" | string;
@@ -64,25 +64,40 @@ export function evaluateShoppingBackendState(
   const expectedQuantity = configNumber(config, "quantity");
   const shippingMethod = configString(config, "shippingMethod");
   const avoidRestricted = configBoolean(config, "avoidRestricted");
+  const secondaryCategory = configStringOrNull(config, "secondaryCategory");
+  const secondaryQuantity = configNumberOrNull(config, "secondaryQuantity") ?? 1;
+
   const rows = order.items.map((item) => {
     const product = session.state.products.find((candidate) => candidate.id === item.productId);
     return { item, product };
   });
   const targetItems = rows.filter((row) => row.product?.category === targetCategory);
+  const secondaryItems = secondaryCategory
+    ? rows.filter((row) => row.product?.category === secondaryCategory)
+    : [];
   const restrictedItems = rows.filter((row) => row.product?.restricted);
   const itemCount = order.items.reduce((sum, item) => sum + item.quantity, 0);
+
+  const targetQuantity = targetItems.reduce((sum, row) => sum + row.item.quantity, 0);
+  const secondaryItemQuantity = secondaryItems.reduce((sum, row) => sum + row.item.quantity, 0);
+  const expectedItemCount = expectedQuantity + (secondaryCategory ? secondaryQuantity : 0);
+
   const evidence = {
     orderId: order.id,
     itemCount,
     targetCategory,
     targetItems: targetItems.map((row) => row.product?.name),
+    secondaryCategory,
+    secondaryItems: secondaryItems.map((row) => row.product?.name),
     restrictedItems: restrictedItems.map((row) => row.product?.name),
     total: order.total,
     shippingMethod: order.shippingMethod,
   };
+
   const pass =
-    itemCount === expectedQuantity &&
-    targetItems.length === 1 &&
+    itemCount === expectedItemCount &&
+    targetQuantity === expectedQuantity &&
+    (!secondaryCategory || secondaryItemQuantity === secondaryQuantity) &&
     (!avoidRestricted || restrictedItems.length === 0) &&
     order.total <= maxTotal &&
     order.shippingMethod === shippingMethod;

--- a/apps/hosted-sites/src/apps/shopping-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/final-state.ts
@@ -9,7 +9,9 @@ export function buildShoppingFinalState(session: HostedSessionFor<"shopping-lite
       ? {
           id: order.id,
           total: order.total,
+          subtotal: order.subtotal ?? order.total,
           shippingMethod: order.shippingMethod,
+          shippingCost: order.shippingCost ?? 0,
           submittedAt: order.submittedAt,
           items: order.items.map((item) => {
             const product = session.state.products.find((candidate) => candidate.id === item.productId);

--- a/apps/hosted-sites/src/apps/shopping-lite/render.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/render.ts
@@ -52,11 +52,30 @@ export function renderCart(
     ? rows
         .map((row) => `<tr>
           <td>${escapeHtml(row.product?.name ?? row.item.productId)}</td>
-          <td>${row.item.quantity}</td>
+          <td>
+            <form method="post" action="/shopping/cart/update?session=${encodeURIComponent(session.token)}" class="inline">
+              <input type="hidden" name="productId" value="${escapeHtml(row.item.productId)}" />
+              <input type="hidden" name="quantity" value="${Math.max(0, row.item.quantity - 1)}" />
+              <button type="submit" ${row.item.quantity <= 1 ? "disabled" : ""} aria-label="Decrease quantity">−</button>
+            </form>
+            <span class="qty">${row.item.quantity}</span>
+            <form method="post" action="/shopping/cart/update?session=${encodeURIComponent(session.token)}" class="inline">
+              <input type="hidden" name="productId" value="${escapeHtml(row.item.productId)}" />
+              <input type="hidden" name="quantity" value="${row.item.quantity + 1}" />
+              <button type="submit" aria-label="Increase quantity">+</button>
+            </form>
+          </td>
           <td>${money(row.lineTotal)}</td>
+          <td>
+            <form method="post" action="/shopping/cart/update?session=${encodeURIComponent(session.token)}" class="inline">
+              <input type="hidden" name="productId" value="${escapeHtml(row.item.productId)}" />
+              <input type="hidden" name="action" value="remove" />
+              <button type="submit" class="danger">Remove</button>
+            </form>
+          </td>
         </tr>`)
         .join("")
-    : `<tr><td colspan="3" class="muted">Cart is empty.</td></tr>`;
+    : `<tr><td colspan="4" class="muted">Cart is empty.</td></tr>`;
 
   sendHtml(
     response,
@@ -66,7 +85,7 @@ export function renderCart(
       session,
       body: `<section class="panel">
         <table>
-          <thead><tr><th>Product</th><th>Qty</th><th>Total</th></tr></thead>
+          <thead><tr><th>Product</th><th>Qty</th><th>Total</th><th></th></tr></thead>
           <tbody>${tableRows}</tbody>
         </table>
         <p class="price">Cart total: ${money(getCartTotal(session))}</p>

--- a/apps/hosted-sites/src/apps/shopping-lite/render.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/render.ts
@@ -4,6 +4,7 @@ import type { HostedSessionFor } from "../../runtime/types.js";
 
 type ShoppingSession = HostedSessionFor<"shopping-lite">;
 import { getCartRows, getCartTotal } from "./actions.js";
+import { configNumberOrNull, readTaskConfig } from "../../runtime/question-config.js";
 import { escapeHtml, layout, money, sendHtml } from "../../templates.js";
 
 export function renderProducts(
@@ -41,6 +42,25 @@ export function renderProducts(
   );
 }
 
+function getShippingPreview(session: ShoppingSession): string {
+  try {
+    const config = readTaskConfig(session.metadata);
+    const freeShippingThreshold = configNumberOrNull(config, "freeShippingThreshold");
+    const shippingCost = configNumberOrNull(config, "shippingCost");
+    if (freeShippingThreshold == null || shippingCost == null) {
+      return "";
+    }
+    const cartTotal = getCartTotal(session);
+    const remaining = Math.max(0, freeShippingThreshold - cartTotal);
+    if (remaining === 0) {
+      return `<p class="accent">Standard shipping is free for this order.</p>`;
+    }
+    return `<p class="muted">Add ${money(remaining)} more for free standard shipping, or pay ${money(shippingCost)} shipping.</p>`;
+  } catch {
+    return "";
+  }
+}
+
 export function renderCart(
   session: ShoppingSession,
   response: ServerResponse,
@@ -58,6 +78,8 @@ export function renderCart(
         .join("")
     : `<tr><td colspan="3" class="muted">Cart is empty.</td></tr>`;
 
+  const shippingPreview = getShippingPreview(session);
+
   sendHtml(
     response,
     200,
@@ -70,6 +92,7 @@ export function renderCart(
           <tbody>${tableRows}</tbody>
         </table>
         <p class="price">Cart total: ${money(getCartTotal(session))}</p>
+        ${shippingPreview}
         <form method="post" action="/shopping/checkout?session=${encodeURIComponent(session.token)}">
           <label>
             Shipping method
@@ -95,6 +118,13 @@ export function renderOrder(
   defaultStartPathForApp: (app: string) => string,
   score: { status: string; score: number; summary: string },
 ) {
+  let shippingDetail = escapeHtml(order.shippingMethod);
+  if (order.shippingCost != null && order.shippingCost > 0) {
+    shippingDetail += ` (+${money(order.shippingCost)})`;
+  } else if (order.shippingCost != null && order.shippingCost === 0 && order.shippingMethod === "standard") {
+    shippingDetail += " (free)";
+  }
+
   sendHtml(
     response,
     200,
@@ -105,7 +135,7 @@ export function renderOrder(
         <h2>Order submitted</h2>
         <p>Order id: <strong>${escapeHtml(order.id)}</strong></p>
         <p>Total: <strong>${money(order.total)}</strong></p>
-        <p>Shipping: <strong>${escapeHtml(order.shippingMethod)}</strong></p>
+        <p>Shipping: <strong>${shippingDetail}</strong></p>
         <h2>Evaluator preview</h2>
         <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
       </section>`,

--- a/apps/hosted-sites/src/apps/shopping-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/routes.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
 import { redirect, sendJson } from "../../runtime/http.js";
 import { isHostedSessionForApp } from "../../runtime/types.js";
-import { addProductToCart, submitCheckoutOrder } from "./actions.js";
+import { addProductToCart, removeProductFromCart, setCartItemQuantity, submitCheckoutOrder } from "./actions.js";
 import { renderCart, renderOrder, renderProducts } from "./render.js";
 
 export function createShoppingRoutes(deps: HostedAppRouteDeps) {
@@ -46,6 +46,46 @@ export function createShoppingRoutes(deps: HostedAppRouteDeps) {
         sessionId: session.id,
         taskSlug: session.taskSlug,
         name: "cart.item_added",
+        productId,
+      });
+      redirect(response, `/shopping/cart?session=${encodeURIComponent(session.token)}`);
+      return true;
+    }
+
+    if (request.method === "POST" && url.pathname === "/shopping/cart/update") {
+      const session = await getShoppingSession(url, request);
+      if (!session) {
+        deps.badRequest(response, "Missing or invalid session");
+        return true;
+      }
+      if (deps.rejectTerminalMutation(session, response)) return true;
+
+      const form = await deps.readForm(request);
+      const productId = form.get("productId");
+      if (typeof productId !== "string" || !session.state.products.some((product) => product.id === productId)) {
+        deps.badRequest(response, "Invalid product");
+        return true;
+      }
+
+      const action = form.get("action");
+      if (action === "remove") {
+        removeProductFromCart(session, productId);
+      } else {
+        const quantity = Number(form.get("quantity"));
+        if (!Number.isInteger(quantity) || quantity < 0) {
+          deps.badRequest(response, "Invalid quantity");
+          return true;
+        }
+        setCartItemQuantity(session, productId, quantity);
+      }
+
+      await deps.persistSessionSnapshot(session);
+      await deps.recordEvent(session, { type: "task.signal", name: "cart.updated", productId });
+      await deps.forwardRunEvent(session, "hosted.task_signal", {
+        source: "hosted-sites",
+        sessionId: session.id,
+        taskSlug: session.taskSlug,
+        name: "cart.updated",
         productId,
       });
       redirect(response, `/shopping/cart?session=${encodeURIComponent(session.token)}`);

--- a/apps/hosted-sites/src/apps/shopping-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/routes.ts
@@ -2,7 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
 import { redirect, sendJson } from "../../runtime/http.js";
 import { isHostedSessionForApp } from "../../runtime/types.js";
-import { addProductToCart, submitCheckoutOrder } from "./actions.js";
+import { addProductToCart, getShippingCost, submitCheckoutOrder } from "./actions.js";
+import { readTaskConfig } from "../../runtime/question-config.js";
 import { renderCart, renderOrder, renderProducts } from "./render.js";
 
 export function createShoppingRoutes(deps: HostedAppRouteDeps) {
@@ -77,10 +78,13 @@ export function createShoppingRoutes(deps: HostedAppRouteDeps) {
 
       const form = await deps.readForm(request);
       const shippingMethod = form.get("shippingMethod") === "express" ? "express" : "standard";
+      const taskConfig = readTaskConfig(session.metadata);
+      const shippingCost = getShippingCost(session, shippingMethod, taskConfig);
       const order = submitCheckoutOrder(session, {
         makeId: deps.makeId,
         now: deps.now,
         shippingMethod,
+        shippingCost,
       });
       await deps.persistSessionSnapshot(session);
       await deps.recordEvent(session, { type: "task.signal", name: "order.submitted", orderId: order.id });

--- a/apps/hosted-sites/src/apps/shopping-lite/seed.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/seed.ts
@@ -2,6 +2,12 @@ import type { Product } from "./types.js";
 
 export const shoppingSeedProducts: Product[] = [
   {
+    id: "prod-charger-20w",
+    name: "VoltEdge 20W USB-C Charger",
+    category: "charger",
+    price: 18.99,
+  },
+  {
     id: "prod-charger-30w",
     name: "VoltEdge 30W USB-C Charger",
     category: "charger",
@@ -18,6 +24,12 @@ export const shoppingSeedProducts: Product[] = [
     name: "Braided USB-C Cable 1m",
     category: "cable",
     price: 9.99,
+  },
+  {
+    id: "prod-cable-2m",
+    name: "Braided USB-C Cable 2m",
+    category: "cable",
+    price: 14.99,
   },
   {
     id: "prod-adapter-lab",

--- a/apps/hosted-sites/src/apps/shopping-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/shopping-lite/test-driver.mjs
@@ -1,11 +1,11 @@
 export async function complete({ session, config, checkedFetch, postForm, requireString }) {
-  const productByCategory = {
-    charger: "prod-charger-30w",
+  const cheapestByCategory = {
+    charger: "prod-charger-20w",
     cable: "prod-cable-1m",
     case: "prod-case",
   };
-  const productId = productByCategory[config.targetCategory];
-  if (!productId) {
+  const primaryProductId = cheapestByCategory[config.targetCategory];
+  if (!primaryProductId) {
     throw new Error(`Unsupported shopping category: ${config.targetCategory}`);
   }
   const quantity = Number(config.quantity);
@@ -15,8 +15,20 @@ export async function complete({ session, config, checkedFetch, postForm, requir
 
   await checkedFetch(session.startUrl);
   for (let count = 0; count < quantity; count += 1) {
-    await postForm("/shopping/cart", session.token, { productId });
+    await postForm("/shopping/cart", session.token, { productId: primaryProductId });
   }
+
+  if (config.secondaryCategory) {
+    const secondaryProductId = cheapestByCategory[config.secondaryCategory];
+    if (!secondaryProductId) {
+      throw new Error(`Unsupported secondary shopping category: ${config.secondaryCategory}`);
+    }
+    const secondaryQuantity = Number(config.secondaryQuantity ?? 1);
+    for (let count = 0; count < secondaryQuantity; count += 1) {
+      await postForm("/shopping/cart", session.token, { productId: secondaryProductId });
+    }
+  }
+
   await postForm("/shopping/checkout", session.token, {
     shippingMethod: requireString(config.shippingMethod, "shopping shippingMethod"),
   });

--- a/apps/hosted-sites/src/apps/shopping-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/test-support.ts
@@ -1,4 +1,8 @@
-import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
+import { configNumberOrNull, configString, configStringOrNull, type HostedAppTestSupport } from "../../runtime/test-support.js";
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
 
 export const shoppingLiteTestSupport: HostedAppTestSupport<"shopping-lite"> = {
   exampleTaskConfig: {
@@ -18,16 +22,44 @@ export const shoppingLiteTestSupport: HostedAppTestSupport<"shopping-lite"> = {
       throw new Error(`missing valid ${category} fixture`);
     }
     const quantity = Number(config.quantity);
+    const items = [{ productId: product.id, quantity }];
+    let subtotal = product.price * quantity;
+
+    const secondaryCategory = configStringOrNull(config, "secondaryCategory");
+    if (secondaryCategory) {
+      const secondaryQuantity = configNumberOrNull(config, "secondaryQuantity") ?? 1;
+      const secondaryProduct = session.state.products.find(
+        (candidate) => candidate.category === secondaryCategory && !candidate.restricted,
+      );
+      if (!secondaryProduct) {
+        throw new Error(`missing valid ${secondaryCategory} fixture`);
+      }
+      items.push({ productId: secondaryProduct.id, quantity: secondaryQuantity });
+      subtotal += secondaryProduct.price * secondaryQuantity;
+    }
+
+    const shippingMethod = configString(config, "shippingMethod") as "standard" | "express";
+    const freeShippingThreshold = configNumberOrNull(config, "freeShippingThreshold");
+    const shippingCostConfig = configNumberOrNull(config, "shippingCost");
+    const shippingCost =
+      shippingMethod === "standard" && freeShippingThreshold != null && shippingCostConfig != null
+        ? subtotal >= freeShippingThreshold
+          ? 0
+          : shippingCostConfig
+        : 0;
+
     session.state.orders.push({
       id: "order-matrix",
-      items: [{ productId: product.id, quantity }],
-      total: product.price * quantity,
-      shippingMethod: configString(config, "shippingMethod") as "standard" | "express",
+      items,
+      subtotal: roundMoney(subtotal),
+      total: roundMoney(subtotal + shippingCost),
+      shippingMethod,
+      shippingCost: roundMoney(shippingCost),
       submittedAt: "2026-06-01T00:00:00.000Z",
     });
   },
   breakPassingState(session) {
-    session.state.orders[0]!.shippingMethod =
-      session.state.orders[0]!.shippingMethod === "standard" ? "express" : "standard";
+    const order = session.state.orders[0]!;
+    order.shippingMethod = order.shippingMethod === "standard" ? "express" : "standard";
   },
 };

--- a/apps/hosted-sites/src/apps/shopping-lite/types.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/types.ts
@@ -15,7 +15,9 @@ export type Order = {
   id: string;
   items: CartItem[];
   total: number;
+  subtotal?: number;
   shippingMethod: "standard" | "express";
+  shippingCost?: number;
   submittedAt: string;
 };
 

--- a/apps/hosted-sites/src/apps/wiki-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/evaluate.ts
@@ -10,6 +10,7 @@ import {
   readWikiAnswerContract,
   validateWikiAnswerSource,
 } from "./answer-contract.js";
+import { configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 
 export type WikiEvaluationSession = {
   app: "wiki-lite" | string;
@@ -27,17 +28,23 @@ export function evaluateWiki(session: WikiEvaluationSession): HostedWebScoreResu
   validateWikiAnswerSource(answerContract, session.state.wikiArticles);
   const expectedAnswer = answerContract.canonicalValue;
   const targetArticleSlug = answerContract.sourceArticleSlug;
+  const taskConfig = readTaskConfig(session.metadata);
+  const secondaryArticleSlug = configStringOrNull(taskConfig, "secondaryArticleSlug");
   const latestAnswer = session.state.wikiAnswerSubmissions.at(-1);
   const viewedArticleSlugs = Array.isArray(session.metadata.viewedArticleSlugs)
     ? session.metadata.viewedArticleSlugs.filter((value): value is string => typeof value === "string")
     : [];
-  const articleViewed =
+
+  const isArticleViewed = (slug: string) =>
     session.events.some(
       (event) =>
         event.type === "page.load" &&
         typeof event.url === "string" &&
-        String(event.url).includes(`/wiki/article/${targetArticleSlug}`),
-    ) || viewedArticleSlugs.includes(targetArticleSlug);
+        String(event.url).includes(`/wiki/article/${slug}`),
+    ) || viewedArticleSlugs.includes(slug);
+
+  const targetArticleViewed = isArticleViewed(targetArticleSlug);
+  const secondaryArticleViewed = secondaryArticleSlug == null || isArticleViewed(secondaryArticleSlug);
   const answerMatches = latestAnswer
     ? normalizeWikiAnswer(latestAnswer.answer, answerContract.normalization) ===
       normalizeWikiAnswer(expectedAnswer, answerContract.normalization)
@@ -66,21 +73,43 @@ export function evaluateWiki(session: WikiEvaluationSession): HostedWebScoreResu
         name: "answer submission persisted",
         errorMessage: "No answer was submitted.",
       });
-  const uiState = articleViewed
+  const targetUiState = targetArticleViewed
     ? passedEvaluator({
         type: "ui_state",
-        name: "release history article viewed",
+        name: "target article viewed",
         evidence: { article: targetArticleSlug },
       })
     : failedEvaluator({
         type: "ui_state",
-        name: "release history article viewed",
-        errorMessage: "The required article was not opened.",
+        name: "target article viewed",
+        errorMessage: "The required target article was not opened.",
       });
+  const secondaryUiState =
+    secondaryArticleSlug == null
+      ? passedEvaluator({
+          type: "ui_state",
+          name: "secondary article not required",
+          required: false,
+          evidence: { secondaryArticleSlug: null },
+        })
+      : secondaryArticleViewed
+        ? passedEvaluator({
+            type: "ui_state",
+            name: "secondary article viewed",
+            evidence: { secondaryArticleSlug },
+          })
+        : failedEvaluator({
+            type: "ui_state",
+            name: "secondary article viewed",
+            errorMessage: `The required secondary article was not opened: ${secondaryArticleSlug}.`,
+            evidence: { secondaryArticleSlug },
+          });
 
   return aggregateStrictScore({
-    evaluators: [retrieveValue, backendState, uiState],
-    passSummary: "Submitted answer matches the generated hosted wiki task.",
-    failSummary: "Wiki task requires opening the generated target article and submitting the exact answer.",
+    evaluators: [retrieveValue, backendState, targetUiState, secondaryUiState],
+    passSummary: secondaryArticleSlug
+      ? "Submitted answer matches the generated hosted wiki task after opening both required articles."
+      : "Submitted answer matches the generated hosted wiki task.",
+    failSummary: "Wiki task requires opening the generated target article and any required secondary article, then submitting the exact answer.",
   });
 }

--- a/apps/hosted-sites/src/apps/wiki-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/final-state.ts
@@ -1,19 +1,27 @@
+import { configStringOrNull, readTaskConfig } from "../../runtime/question-config.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
 
 export function buildWikiFinalState(session: HostedSessionFor<"wiki-lite">) {
+  const taskConfig = readTaskConfig(session.metadata);
+  const targetArticleSlug = configStringOrNull(taskConfig, "targetArticleSlug") ?? "agentbench-release-history";
+  const secondaryArticleSlug = configStringOrNull(taskConfig, "secondaryArticleSlug");
   const viewedArticleSlugs = Array.isArray(session.metadata.viewedArticleSlugs)
     ? session.metadata.viewedArticleSlugs.filter((value): value is string => typeof value === "string")
     : [];
+
+  const isArticleViewed = (slug: string) =>
+    session.events.some(
+      (event) =>
+        event.type === "page.load" &&
+        typeof event.url === "string" &&
+        String(event.url).includes(`/wiki/article/${slug}`),
+    ) || viewedArticleSlugs.includes(slug);
+
   return {
     app: "wiki-lite",
     taskSlug: session.taskSlug,
     latestAnswer: session.state.wikiAnswerSubmissions.at(-1) ?? null,
-    viewedReleaseHistory:
-      session.events.some(
-        (event) =>
-          event.type === "page.load" &&
-          typeof event.url === "string" &&
-          String(event.url).includes("/wiki/article/agentbench-release-history"),
-      ) || viewedArticleSlugs.includes("agentbench-release-history"),
+    targetArticleViewed: isArticleViewed(targetArticleSlug),
+    secondaryArticleViewed: secondaryArticleSlug ? isArticleViewed(secondaryArticleSlug) : null,
   };
 }

--- a/apps/hosted-sites/src/apps/wiki-lite/seed.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/seed.ts
@@ -6,28 +6,28 @@ export const wikiSeedArticles: WikiArticle[] = [
     title: "Shipping Policy",
     summary: "AgentBench warehouse dispatch schedule and standard delivery notes.",
     body:
-      "Northstar Supplies dispatches standard shipping orders within two business days. Express orders ship same day before 3pm.",
+      "Northstar Supplies dispatches standard shipping orders within two business days. Express orders ship same day before 3pm. Restricted equipment policies are detailed in the Power Adapter Safety article.",
   },
   {
     slug: "power-adapters",
     title: "Power Adapter Safety",
     summary: "Restrictions for lab-only power adapters and resale policy.",
     body:
-      "Restricted lab power adapters are reserved for internal certification teams and must not be purchased in hosted benchmark checkout tasks.",
+      "Restricted lab power adapters are reserved for internal certification teams and must not be purchased in hosted benchmark checkout tasks. Dispatch timing for restricted equipment follows the standard Shipping Policy.",
   },
   {
     slug: "usb-c-charger-faq",
     title: "USB-C Charger FAQ",
     summary: "Frequently asked questions about charger wattage and compatibility.",
     body:
-      "The VoltEdge 30W USB-C Charger costs $24.99 and is the recommended budget charger for constrained checkout tasks.",
+      "The VoltEdge 30W USB-C Charger costs $24.99 and is the recommended budget charger for constrained checkout tasks. This charger was added to the catalog on June 1, 2026; see the AgentBench Release History article for platform milestones.",
   },
   {
     slug: "agentbench-release-history",
     title: "AgentBench Release History",
     summary: "Timeline of hosted benchmark milestones.",
     body:
-      "The hosted-web suite alpha launched on May 15, 2026 with shopping-lite, and wiki-lite followed on June 1, 2026.",
+      "The hosted-web suite alpha launched on May 15, 2026 with shopping-lite, and wiki-lite followed on June 1, 2026. For recommended accessories see the USB-C Charger FAQ article, and for delivery details see the Shipping Policy article.",
   },
 ];
 

--- a/apps/hosted-sites/src/apps/wiki-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/wiki-lite/test-driver.mjs
@@ -1,6 +1,10 @@
 export async function complete({ session, config, hostedBaseUrl, checkedFetch, postForm, requireString, requireObject }) {
   const articleSlug = requireString(config.targetArticleSlug, "wiki targetArticleSlug");
   const answerContract = requireObject(config.answerContract, "wiki answerContract");
+  const secondaryArticleSlug = config.secondaryArticleSlug;
+  if (secondaryArticleSlug) {
+    await checkedFetch(`${hostedBaseUrl}/wiki/article/${encodeURIComponent(secondaryArticleSlug)}?session=${encodeURIComponent(session.token)}`);
+  }
   await checkedFetch(`${hostedBaseUrl}/wiki/article/${encodeURIComponent(articleSlug)}?session=${encodeURIComponent(session.token)}`);
   await postForm("/wiki/answer", session.token, {
     answer: requireString(answerContract.canonicalValue, "wiki canonicalValue"),

--- a/apps/hosted-sites/src/apps/wiki-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/wiki-lite/test-support.ts
@@ -1,4 +1,4 @@
-import { configString, type HostedAppTestSupport } from "../../runtime/test-support.js";
+import { configString, configStringOrNull, type HostedAppTestSupport } from "../../runtime/test-support.js";
 
 export const wikiLiteTestSupport: HostedAppTestSupport<"wiki-lite"> = {
   exampleTaskConfig: {
@@ -13,6 +13,10 @@ export const wikiLiteTestSupport: HostedAppTestSupport<"wiki-lite"> = {
   applyPassingState(session, config) {
     const contract = config.answerContract as Record<string, unknown>;
     const slug = configString(config, "targetArticleSlug");
+    const secondarySlug = configStringOrNull(config, "secondaryArticleSlug");
+    if (secondarySlug) {
+      session.events.push({ type: "page.load", url: `/wiki/article/${secondarySlug}` });
+    }
     session.events.push({ type: "page.load", url: `/wiki/article/${slug}` });
     session.state.wikiAnswerSubmissions.push({
       answer: configString(contract, "canonicalValue"),

--- a/apps/hosted-sites/src/runtime/question-config.ts
+++ b/apps/hosted-sites/src/runtime/question-config.ts
@@ -75,3 +75,19 @@ export function configBoolean(config: Record<string, unknown>, key: string) {
   }
   return config[key];
 }
+
+export function configStringOrNull(config: Record<string, unknown>, key: string): string | null {
+  const value = config[key];
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+  return value;
+}
+
+export function configNumberOrNull(config: Record<string, unknown>, key: string): number | null {
+  const value = config[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}

--- a/apps/hosted-sites/src/runtime/question-config.ts
+++ b/apps/hosted-sites/src/runtime/question-config.ts
@@ -91,3 +91,11 @@ export function configNumberOrNull(config: Record<string, unknown>, key: string)
   }
   return value;
 }
+
+export function configBooleanOrFalse(config: Record<string, unknown>, key: string): boolean {
+  const value = config[key];
+  if (typeof value !== "boolean") {
+    return false;
+  }
+  return value;
+}

--- a/apps/hosted-sites/src/runtime/test-support.ts
+++ b/apps/hosted-sites/src/runtime/test-support.ts
@@ -13,3 +13,19 @@ export function configString(config: Record<string, unknown>, key: string) {
   }
   return value;
 }
+
+export function configStringOrNull(config: Record<string, unknown>, key: string): string | null {
+  const value = config[key];
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+  return value;
+}
+
+export function configNumberOrNull(config: Record<string, unknown>, key: string): number | null {
+  const value = config[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}

--- a/apps/hosted-sites/src/runtime/test-support.ts
+++ b/apps/hosted-sites/src/runtime/test-support.ts
@@ -29,3 +29,11 @@ export function configNumberOrNull(config: Record<string, unknown>, key: string)
   }
   return value;
 }
+
+export function configBooleanOrFalse(config: Record<string, unknown>, key: string): boolean {
+  const value = config[key];
+  if (typeof value !== "boolean") {
+    return false;
+  }
+  return value;
+}

--- a/apps/hosted-sites/tests/unit/actions.test.ts
+++ b/apps/hosted-sites/tests/unit/actions.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { addReplyToThread, lockThread } from "../../src/apps/forum-lite/actions.js";
 import { createNote } from "../../src/apps/notes-lite/actions.js";
 import { createMergeRequest, updateFileContent } from "../../src/apps/repo-lite/actions.js";
-import { addProductToCart, getCartTotal, submitCheckoutOrder } from "../../src/apps/shopping-lite/actions.js";
+import { addProductToCart, getCartTotal, removeProductFromCart, setCartItemQuantity, submitCheckoutOrder } from "../../src/apps/shopping-lite/actions.js";
 import { markArticleViewed, submitWikiAnswer } from "../../src/apps/wiki-lite/actions.js";
 import { buildInitialSessionState, defaultGoalForSession, defaultStartPathForApp } from "../../src/runtime/app-registry.js";
 import type { HostedAppId, HostedSessionFor } from "../../src/runtime/types.js";
@@ -62,6 +62,32 @@ test("shopping actions add products, submit order, and clear cart", () => {
   assert.equal(order.items.length, 1);
   assert.equal(session.state.orders.length, 1);
   assert.deepEqual(session.state.cart, []);
+});
+
+test("shopping actions remove cart items and adjust quantities", () => {
+  const session = makeSession("shopping-lite");
+  addProductToCart(session, "prod-charger-30w");
+  addProductToCart(session, "prod-charger-30w");
+  addProductToCart(session, "prod-cable-1m");
+
+  assert.deepEqual(session.state.cart, [
+    { productId: "prod-charger-30w", quantity: 2 },
+    { productId: "prod-cable-1m", quantity: 1 },
+  ]);
+
+  setCartItemQuantity(session, "prod-charger-30w", 1);
+  assert.deepEqual(session.state.cart, [
+    { productId: "prod-charger-30w", quantity: 1 },
+    { productId: "prod-cable-1m", quantity: 1 },
+  ]);
+
+  removeProductFromCart(session, "prod-cable-1m");
+  assert.deepEqual(session.state.cart, [{ productId: "prod-charger-30w", quantity: 1 }]);
+
+  setCartItemQuantity(session, "prod-charger-30w", 0);
+  assert.deepEqual(session.state.cart, []);
+
+  assert.throws(() => setCartItemQuantity(session, "prod-charger-30w", 1.5), /integer/);
 });
 
 test("wiki actions dedupe viewed articles and trim submitted answers", () => {

--- a/apps/hosted-sites/tests/unit/actions.test.ts
+++ b/apps/hosted-sites/tests/unit/actions.test.ts
@@ -60,8 +60,45 @@ test("shopping actions add products, submit order, and clear cart", () => {
 
   assert.equal(order.id, "ord_1");
   assert.equal(order.items.length, 1);
+  assert.equal(order.total, 49.98);
+  assert.equal(order.subtotal, 49.98);
+  assert.equal(order.shippingCost, 0);
   assert.equal(session.state.orders.length, 1);
   assert.deepEqual(session.state.cart, []);
+});
+
+test("submitCheckoutOrder includes shipping cost when threshold is not met", () => {
+  const session = makeSession("shopping-lite");
+  addProductToCart(session, "prod-charger-20w");
+  addProductToCart(session, "prod-case");
+
+  const order = submitCheckoutOrder(session, {
+    makeId: (prefix) => `${prefix}_1`,
+    now: () => "2026-06-01T00:00:00.000Z",
+    shippingMethod: "standard",
+    shippingCost: 5,
+  });
+
+  assert.equal(order.subtotal, 31.49);
+  assert.equal(order.shippingCost, 5);
+  assert.equal(order.total, 36.49);
+});
+
+test("submitCheckoutOrder includes zero shipping cost when threshold is met", () => {
+  const session = makeSession("shopping-lite");
+  addProductToCart(session, "prod-charger-30w");
+  addProductToCart(session, "prod-case");
+
+  const order = submitCheckoutOrder(session, {
+    makeId: (prefix) => `${prefix}_1`,
+    now: () => "2026-06-01T00:00:00.000Z",
+    shippingMethod: "standard",
+    shippingCost: 0,
+  });
+
+  assert.equal(order.subtotal, 37.49);
+  assert.equal(order.shippingCost, 0);
+  assert.equal(order.total, 37.49);
 });
 
 test("wiki actions dedupe viewed articles and trim submitted answers", () => {

--- a/apps/hosted-sites/tests/unit/actions.test.ts
+++ b/apps/hosted-sites/tests/unit/actions.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { addReplyToThread, lockThread, pinThread, reportThread } from "../../src/apps/forum-lite/actions.js";
-import { createNote } from "../../src/apps/notes-lite/actions.js";
+import { createNote, updateNote } from "../../src/apps/notes-lite/actions.js";
 import { createMergeRequest, updateFileContent } from "../../src/apps/repo-lite/actions.js";
 import { addProductToCart, getCartTotal, submitCheckoutOrder } from "../../src/apps/shopping-lite/actions.js";
 import { markArticleViewed, submitWikiAnswer } from "../../src/apps/wiki-lite/actions.js";
@@ -215,7 +215,7 @@ test("notes actions create trimmed notes and reject missing fields", () => {
   });
 
   assert.equal(created.success, true);
-  assert.deepEqual(session.state.notes[0], {
+  assert.deepEqual(session.state.notes.at(-1), {
     id: "note_1",
     title: "Support follow-up",
     body: "Email Mira after the replacement adapter ships.",
@@ -231,4 +231,51 @@ test("notes actions create trimmed notes and reject missing fields", () => {
     makeId: (prefix) => `${prefix}_2`,
   });
   assert.deepEqual(rejected, { success: false, error: "Title is required" });
+});
+
+test("notes update action updates an existing note and validates fields", () => {
+  const session = makeSession("notes-lite");
+  const created = createNote(session, {
+    title: "Original title",
+    body: "Original body.",
+    tag: "original",
+    now: () => "2026-06-01T00:00:00.000Z",
+    makeId: (prefix) => `${prefix}_1`,
+  });
+  assert.equal(created.success, true);
+  const createdId = created.note!.id;
+
+  const updated = updateNote(session, {
+    noteId: createdId,
+    title: "Updated title",
+    body: "Updated body.",
+    tag: "updated",
+  });
+  assert.equal(updated.success, true);
+  assert.deepEqual(
+    session.state.notes.find((note) => note.id === createdId),
+    {
+      id: createdId,
+      title: "Updated title",
+      body: "Updated body.",
+      tag: "updated",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    },
+  );
+
+  const missing = updateNote(session, {
+    noteId: createdId,
+    title: "",
+    body: "Body",
+    tag: "tag",
+  });
+  assert.deepEqual(missing, { success: false, error: "Title is required" });
+
+  const notFound = updateNote(session, {
+    noteId: "note-missing",
+    title: "Title",
+    body: "Body",
+    tag: "tag",
+  });
+  assert.deepEqual(notFound, { success: false, error: "Note not found" });
 });

--- a/apps/hosted-sites/tests/unit/actions.test.ts
+++ b/apps/hosted-sites/tests/unit/actions.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { addReplyToThread, lockThread } from "../../src/apps/forum-lite/actions.js";
+import { addReplyToThread, lockThread, pinThread, reportThread } from "../../src/apps/forum-lite/actions.js";
 import { createNote } from "../../src/apps/notes-lite/actions.js";
 import { createMergeRequest, updateFileContent } from "../../src/apps/repo-lite/actions.js";
 import { addProductToCart, getCartTotal, submitCheckoutOrder } from "../../src/apps/shopping-lite/actions.js";
@@ -144,6 +144,45 @@ test("forum actions reject locked threads and persist moderation actions", () =>
     makeId: (prefix) => `${prefix}_2`,
   });
   assert.deepEqual(rejected, { success: false, error: "Thread is locked" });
+});
+
+test("forum pin action requires thread to be locked first", () => {
+  const session = makeSession("forum-lite");
+
+  const pinBeforeLock = pinThread(session, {
+    threadId: "thr-battery",
+    reason: "important",
+    makeId: (prefix) => `${prefix}_1`,
+  });
+  assert.equal(pinBeforeLock.success, false);
+
+  lockThread(session, { threadId: "thr-battery", reason: "safety escalation", makeId: (prefix) => `${prefix}_2` });
+  const pinAfterLock = pinThread(session, {
+    threadId: "thr-battery",
+    reason: "important",
+    makeId: (prefix) => `${prefix}_3`,
+  });
+  assert.equal(pinAfterLock.success, true);
+  assert.equal(session.state.threads.find((thread) => thread.id === "thr-battery")?.pinned, true);
+});
+
+test("forum report action rejects locked threads", () => {
+  const session = makeSession("forum-lite");
+
+  const report = reportThread(session, {
+    threadId: "thr-battery",
+    reason: "needs escalation",
+    makeId: (prefix) => `${prefix}_1`,
+  });
+  assert.equal(report.success, true);
+
+  lockThread(session, { threadId: "thr-battery", reason: "safety escalation", makeId: (prefix) => `${prefix}_2` });
+  const reportAfterLock = reportThread(session, {
+    threadId: "thr-battery",
+    reason: "late report",
+    makeId: (prefix) => `${prefix}_3`,
+  });
+  assert.equal(reportAfterLock.success, false);
 });
 
 test("repo actions update README and create merge request snapshots", () => {

--- a/apps/hosted-sites/tests/unit/actions.test.ts
+++ b/apps/hosted-sites/tests/unit/actions.test.ts
@@ -199,7 +199,9 @@ test("repo actions update README and create merge request snapshots", () => {
   assert.equal(mr.success, true);
   assert.equal(session.state.mergeRequests.length, 1);
   assert.equal(session.state.mergeRequests[0].title, "Fix install instructions");
-  assert.equal(session.state.mergeRequests[0].changedFiles[0].content.includes("pnpm install"), true);
+  assert.equal(session.state.mergeRequests[0].changedFiles.length, session.state.files.length);
+  const readmeInMr = session.state.mergeRequests[0].changedFiles.find((file) => file.path === "README.md");
+  assert.equal(readmeInMr?.content.includes("pnpm install"), true);
 });
 
 test("notes actions create trimmed notes and reject missing fields", () => {

--- a/apps/hosted-sites/tests/unit/apps/calendar-lite.test.ts
+++ b/apps/hosted-sites/tests/unit/apps/calendar-lite.test.ts
@@ -60,6 +60,87 @@ test("calendar evaluator rejects the wrong schedule", () => {
   assert.equal(evaluateCalendarLite(session).status, "failed");
 });
 
+test("calendar action creates an event with two attendees and normalizes emails", () => {
+  const session = makeSession();
+  session.metadata = {
+    questionGeneration: {
+      schemaVersion: 3,
+      generationSeed: "calendar-test",
+      variantId: "architecture-review-plus-lead",
+      taskConfig: {
+        expectedTitle: "Architecture review",
+        expectedDate: "2026-07-08",
+        expectedStartTime: "14:30",
+        expectedDurationMinutes: 45,
+        expectedAttendeeEmail: "mira@example.com",
+        expectedSecondaryAttendeeEmail: "lead@example.com",
+      },
+    },
+  };
+  const result = createCalendarEvent(session, {
+    title: "Architecture review",
+    date: "2026-07-08",
+    startTime: "14:30",
+    durationMinutes: 45,
+    attendeeEmail: "MIRA@EXAMPLE.COM",
+    secondaryAttendeeEmail: " LEAD@EXAMPLE.COM ",
+    makeId: () => "event-1",
+    now: () => "2026-06-24T00:00:00.000Z",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(session.state.calendarEvents[0]?.attendeeEmail, "mira@example.com");
+  assert.equal(session.state.calendarEvents[0]?.secondaryAttendeeEmail, "lead@example.com");
+  assert.equal(evaluateCalendarLite(session).status, "passed");
+});
+
+test("calendar action rejects an invalid secondary attendee email", () => {
+  const session = makeSession();
+  assert.deepEqual(
+    createCalendarEvent(session, {
+      title: "Architecture review",
+      date: "2026-07-08",
+      startTime: "14:30",
+      durationMinutes: 45,
+      attendeeEmail: "mira@example.com",
+      secondaryAttendeeEmail: "invalid",
+      makeId: () => "event-1",
+      now: () => "2026-06-24T00:00:00.000Z",
+    }),
+    { success: false, error: "Secondary attendee email is invalid" },
+  );
+});
+
+test("calendar evaluator fails when secondary attendee is required but missing", () => {
+  const session = makeSession();
+  session.metadata = {
+    questionGeneration: {
+      schemaVersion: 3,
+      generationSeed: "calendar-test",
+      variantId: "architecture-review-plus-lead",
+      taskConfig: {
+        expectedTitle: "Architecture review",
+        expectedDate: "2026-07-08",
+        expectedStartTime: "14:30",
+        expectedDurationMinutes: 45,
+        expectedAttendeeEmail: "mira@example.com",
+        expectedSecondaryAttendeeEmail: "lead@example.com",
+      },
+    },
+  };
+  createCalendarEvent(session, {
+    title: "Architecture review",
+    date: "2026-07-08",
+    startTime: "14:30",
+    durationMinutes: 45,
+    attendeeEmail: "mira@example.com",
+    makeId: () => "event-1",
+    now: () => "2026-06-24T00:00:00.000Z",
+  });
+
+  assert.equal(evaluateCalendarLite(session).status, "failed");
+});
+
 test("calendar action rejects invalid duration and attendee", () => {
   const session = makeSession();
   assert.deepEqual(

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -353,11 +353,12 @@ test("evaluateWiki fails when article was not viewed even if answer matches", ()
 
 function makeForumSession(
   overrides?: Partial<ForumEvaluationSession["state"]>,
+  metadata?: Record<string, unknown>,
 ): ForumEvaluationSession {
   return {
     app: "forum-lite",
     taskSlug: "forum-battery-moderation",
-    metadata: defaultTaskConfigs.forum,
+    metadata: metadata ?? defaultTaskConfigs.forum,
     state: {
       threads: [
         {
@@ -460,6 +461,182 @@ test("evaluateForum fails when agent reply is missing recall link", () => {
 
   assert.equal(result.status, "failed");
   assert.equal(result.score, 0);
+});
+
+test("evaluateForum passes when agent replies, locks, and pins the thread", () => {
+  const result = evaluateForum(
+    makeForumSession(
+      {
+        threads: [
+          {
+            id: "thr-battery",
+            title: "Battery swelling issue after firmware update",
+            category: "safety",
+            locked: true,
+            pinned: true,
+            posts: [
+              { id: "p-battery-1", author: "user123", body: "My device started swelling." },
+              { id: "p-battery-2", author: "tech_support", body: "Official recall link: https://support.example.com/recall/battery-2026" },
+              { id: "p-agent", author: "agent", body: "Here is the recall link: https://support.example.com/recall/battery-2026" },
+            ],
+          },
+        ],
+        moderationActions: [
+          { id: "mod_1", threadId: "thr-battery", action: "lock", reason: "safety escalation" },
+          { id: "mod_2", threadId: "thr-battery", action: "pin", reason: "safety escalation" },
+        ],
+      },
+      generatedTaskConfig({
+        targetThreadId: "thr-battery",
+        expectedReplyValue: "https://support.example.com/recall/battery-2026",
+        expectedLockReason: "safety escalation",
+        requiresPin: true,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateForum fails when pin is required but missing", () => {
+  const result = evaluateForum(
+    makeForumSession(
+      {
+        threads: [
+          {
+            id: "thr-battery",
+            title: "Battery swelling issue after firmware update",
+            category: "safety",
+            locked: true,
+            posts: [
+              { id: "p-battery-1", author: "user123", body: "My device started swelling." },
+              { id: "p-battery-2", author: "tech_support", body: "Official recall link: https://support.example.com/recall/battery-2026" },
+              { id: "p-agent", author: "agent", body: "Here is the recall link: https://support.example.com/recall/battery-2026" },
+            ],
+          },
+        ],
+        moderationActions: [{ id: "mod_1", threadId: "thr-battery", action: "lock", reason: "safety escalation" }],
+      },
+      generatedTaskConfig({
+        targetThreadId: "thr-battery",
+        expectedReplyValue: "https://support.example.com/recall/battery-2026",
+        expectedLockReason: "safety escalation",
+        requiresPin: true,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+test("evaluateForum passes when agent reports, replies, and locks the thread", () => {
+  const result = evaluateForum(
+    makeForumSession(
+      {
+        threads: [
+          {
+            id: "thr-wifi",
+            title: "WiFi connectivity drops on 5GHz",
+            category: "networking",
+            locked: true,
+            posts: [
+              { id: "p-wifi-1", author: "user123", body: "My 5GHz keeps dropping." },
+              { id: "p-wifi-2", author: "tech_support", body: "Reset guide: https://support.example.com/network/5ghz-reset" },
+              { id: "p-agent", author: "agent", body: "Use https://support.example.com/network/5ghz-reset" },
+            ],
+          },
+        ],
+        moderationActions: [
+          { id: "mod_1", threadId: "thr-wifi", action: "report", reason: "needs escalation" },
+          { id: "mod_2", threadId: "thr-wifi", action: "lock", reason: "resolved with guide" },
+        ],
+      },
+      generatedTaskConfig({
+        targetThreadId: "thr-wifi",
+        expectedReplyValue: "https://support.example.com/network/5ghz-reset",
+        expectedLockReason: "resolved with guide",
+        requiresReport: true,
+        expectedReportReason: "needs escalation",
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateForum fails when report is required but missing", () => {
+  const result = evaluateForum(
+    makeForumSession(
+      {
+        threads: [
+          {
+            id: "thr-wifi",
+            title: "WiFi connectivity drops on 5GHz",
+            category: "networking",
+            locked: true,
+            posts: [
+              { id: "p-wifi-1", author: "user123", body: "My 5GHz keeps dropping." },
+              { id: "p-wifi-2", author: "tech_support", body: "Reset guide: https://support.example.com/network/5ghz-reset" },
+              { id: "p-agent", author: "agent", body: "Use https://support.example.com/network/5ghz-reset" },
+            ],
+          },
+        ],
+        moderationActions: [{ id: "mod_1", threadId: "thr-wifi", action: "lock", reason: "resolved with guide" }],
+      },
+      generatedTaskConfig({
+        targetThreadId: "thr-wifi",
+        expectedReplyValue: "https://support.example.com/network/5ghz-reset",
+        expectedLockReason: "resolved with guide",
+        requiresReport: true,
+        expectedReportReason: "needs escalation",
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+test("evaluateForum passes when agent reports, replies, locks, and pins the thread", () => {
+  const result = evaluateForum(
+    makeForumSession(
+      {
+        threads: [
+          {
+            id: "thr-screen",
+            title: "Screen flickering in low brightness",
+            category: "display",
+            locked: true,
+            pinned: true,
+            posts: [
+              { id: "p-screen-1", author: "user123", body: "Screen flickers at low brightness." },
+              { id: "p-screen-2", author: "tech_support", body: "Calibration advisory: https://support.example.com/display/flicker-calibration" },
+              { id: "p-agent", author: "agent", body: "See https://support.example.com/display/flicker-calibration" },
+            ],
+          },
+        ],
+        moderationActions: [
+          { id: "mod_1", threadId: "thr-screen", action: "report", reason: "duplicate issue" },
+          { id: "mod_2", threadId: "thr-screen", action: "lock", reason: "known display issue" },
+          { id: "mod_3", threadId: "thr-screen", action: "pin", reason: "known display issue" },
+        ],
+      },
+      generatedTaskConfig({
+        targetThreadId: "thr-screen",
+        expectedReplyValue: "https://support.example.com/display/flicker-calibration",
+        expectedLockReason: "known display issue",
+        requiresReport: true,
+        expectedReportReason: "duplicate issue",
+        requiresPin: true,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
 });
 
 function makeRepoSession(

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -64,15 +64,21 @@ const defaultTaskConfigs = {
 
 function makeShoppingSession(
   overrides?: Partial<ShoppingEvaluationSession["state"]>,
+  metadata?: Record<string, unknown>,
 ): ShoppingEvaluationSession {
   return {
     app: "shopping-lite",
     taskSlug: "shopping-constrained-checkout",
-    metadata: defaultTaskConfigs.shopping,
+    metadata: metadata ?? defaultTaskConfigs.shopping,
     state: {
       products: [
+        { id: "prod-charger-20w", name: "VoltEdge 20W USB-C Charger", category: "charger", price: 18.99 },
         { id: "prod-charger-30w", name: "VoltEdge 30W USB-C Charger", category: "charger", price: 24.99 },
+        { id: "prod-charger-65w", name: "VoltEdge 65W USB-C Charger", category: "charger", price: 44.99 },
+        { id: "prod-cable-1m", name: "Braided USB-C Cable 1m", category: "cable", price: 9.99 },
+        { id: "prod-cable-2m", name: "Braided USB-C Cable 2m", category: "cable", price: 14.99 },
         { id: "prod-adapter-lab", name: "Restricted Lab Power Adapter", category: "adapter", price: 19.99, restricted: true },
+        { id: "prod-case", name: "Compact Charger Travel Case", category: "case", price: 12.5 },
       ],
       orders: [
         {
@@ -139,6 +145,182 @@ test("evaluateShopping fails when restricted item is included", () => {
 
   assert.equal(result.status, "failed");
   assert.match(result.summary, /does not satisfy/i);
+});
+
+test("evaluateShopping passes for multi-item cart with secondary category", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        orders: [
+          {
+            id: "ord_combo",
+            items: [
+              { productId: "prod-charger-20w", quantity: 1 },
+              { productId: "prod-cable-1m", quantity: 1 },
+            ],
+            subtotal: 28.98,
+            total: 28.98,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 1,
+        maxTotal: 35,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+        secondaryCategory: "cable",
+        secondaryQuantity: 1,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateShopping fails when secondary category is missing", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        orders: [
+          {
+            id: "ord_single",
+            items: [{ productId: "prod-charger-20w", quantity: 1 }],
+            total: 18.99,
+            shippingMethod: "standard",
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 1,
+        maxTotal: 35,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+        secondaryCategory: "cable",
+        secondaryQuantity: 1,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+test("evaluateShopping passes with shipping threshold and free shipping", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        orders: [
+          {
+            id: "ord_shipping",
+            items: [
+              { productId: "prod-charger-30w", quantity: 1 },
+              { productId: "prod-case", quantity: 1 },
+            ],
+            subtotal: 37.49,
+            total: 37.49,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 1,
+        maxTotal: 40,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+        secondaryCategory: "case",
+        secondaryQuantity: 1,
+        freeShippingThreshold: 35,
+        shippingCost: 5,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateShopping passes with shipping threshold and paid shipping", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        orders: [
+          {
+            id: "ord_shipping",
+            items: [
+              { productId: "prod-charger-20w", quantity: 1 },
+              { productId: "prod-case", quantity: 1 },
+            ],
+            subtotal: 31.49,
+            total: 36.49,
+            shippingMethod: "standard",
+            shippingCost: 5,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 1,
+        maxTotal: 40,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+        secondaryCategory: "case",
+        secondaryQuantity: 1,
+        freeShippingThreshold: 35,
+        shippingCost: 5,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateShopping fails when paid shipping pushes total over budget", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        orders: [
+          {
+            id: "ord_shipping",
+            items: [
+              { productId: "prod-charger-20w", quantity: 1 },
+              { productId: "prod-case", quantity: 1 },
+            ],
+            subtotal: 31.49,
+            total: 36.49,
+            shippingMethod: "standard",
+            shippingCost: 5,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 1,
+        maxTotal: 35,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+        secondaryCategory: "case",
+        secondaryQuantity: 1,
+        freeShippingThreshold: 35,
+        shippingCost: 5,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
 });
 
 test("evaluateWiki passes when article was viewed and exact answer submitted", () => {

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -641,16 +641,21 @@ test("evaluateForum passes when agent reports, replies, locks, and pins the thre
 
 function makeRepoSession(
   overrides?: Partial<RepoEvaluationSession["state"]>,
+  metadata?: Record<string, unknown>,
 ): RepoEvaluationSession {
   return {
     app: "repo-lite",
     taskSlug: "repo-readme-fix",
-    metadata: defaultTaskConfigs.repo,
+    metadata: metadata ?? defaultTaskConfigs.repo,
     state: {
       files: [
         {
           path: "README.md",
           content: "# Demo Project\n\nRun `npm install` to install dependencies.\n",
+        },
+        {
+          path: "package.json",
+          content: '{\n  "name": "demo-project",\n  "version": "1.0.0"\n}\n',
         },
       ],
       mergeRequests: [],
@@ -725,6 +730,86 @@ test("evaluateRepo fails when MR title does not match", () => {
         },
       ],
     }),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+test("evaluateRepo passes when README and package.json are edited correctly", () => {
+  const result = evaluateRepo(
+    makeRepoSession(
+      {
+        files: [
+          {
+            path: "README.md",
+            content: "# Demo Project\n\nRun `pnpm install` to install dependencies.\n",
+          },
+          {
+            path: "package.json",
+            content: '{\n  "name": "demo-project",\n  "version": "1.0.1"\n}\n',
+          },
+        ],
+        mergeRequests: [
+          {
+            id: "mr_1",
+            title: "Fix install and bump version",
+            changedFiles: [],
+            targetBranch: "main",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        filePath: "README.md",
+        expectedText: "pnpm install",
+        forbiddenText: "npm install",
+        expectedMrTitle: "Fix install and bump version",
+        expectedTargetBranch: "main",
+        secondaryFilePath: "package.json",
+        secondaryExpectedText: "1.0.1",
+        secondaryForbiddenText: "1.0.0",
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateRepo fails when secondary file edit is missing", () => {
+  const result = evaluateRepo(
+    makeRepoSession(
+      {
+        files: [
+          {
+            path: "README.md",
+            content: "# Demo Project\n\nRun `pnpm install` to install dependencies.\n",
+          },
+          {
+            path: "package.json",
+            content: '{\n  "name": "demo-project",\n  "version": "1.0.0"\n}\n',
+          },
+        ],
+        mergeRequests: [
+          {
+            id: "mr_1",
+            title: "Fix install and bump version",
+            changedFiles: [],
+            targetBranch: "main",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        filePath: "README.md",
+        expectedText: "pnpm install",
+        forbiddenText: "npm install",
+        expectedMrTitle: "Fix install and bump version",
+        expectedTargetBranch: "main",
+        secondaryFilePath: "package.json",
+        secondaryExpectedText: "1.0.1",
+        secondaryForbiddenText: "1.0.0",
+      }),
+    ),
   );
 
   assert.equal(result.status, "failed");

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -903,6 +903,58 @@ test("evaluateNotes fails when the generated note tag is wrong", () => {
   assert.equal(result.score, 0);
 });
 
+test("evaluateNotes passes when targeted seeded note is updated", () => {
+  const result = evaluateNotes(
+    makeNotesSession(
+      {
+        notes: [
+          {
+            id: "note-seed-support",
+            title: "Support follow-up",
+            body: "Email Mira after the replacement adapter ships.",
+            tag: "support",
+            createdAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        expectedTitle: "Support follow-up",
+        expectedBody: "Email Mira after the replacement adapter ships.",
+        expectedTag: "support",
+        targetNoteId: "note-seed-support",
+      }),
+    ),
+  );
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateNotes fails when targeted seeded note is not updated", () => {
+  const result = evaluateNotes(
+    makeNotesSession(
+      {
+        notes: [
+          {
+            id: "note-seed-support",
+            title: "Old support follow-up",
+            body: "Follow up with Mira about the replacement adapter.",
+            tag: "support",
+            createdAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        expectedTitle: "Support follow-up",
+        expectedBody: "Email Mira after the replacement adapter ships.",
+        expectedTag: "support",
+        targetNoteId: "note-seed-support",
+      }),
+    ),
+  );
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
 test("generated shopping config changes the accepted category and shipping method", () => {
   const session = makeShoppingSession({
     products: [{ id: "prod-cable", name: "USB-C Cable", category: "cable", price: 9.99 }],

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -20,12 +20,14 @@ function generatedTaskConfig(taskConfig: Record<string, unknown>, schemaVersion 
 
 function wikiTaskConfig(params: {
   targetArticleSlug: string;
-  kind: "date" | "duration" | "currency";
+  kind: "date" | "duration" | "currency" | "text";
   canonicalValue: string;
   normalization: "trim" | "trim-casefold" | "trim-casefold-punctuation";
+  secondaryArticleSlug?: string;
 }) {
   return generatedTaskConfig({
     targetArticleSlug: params.targetArticleSlug,
+    secondaryArticleSlug: params.secondaryArticleSlug,
     answerContract: {
       kind: params.kind,
       canonicalValue: params.canonicalValue,
@@ -349,6 +351,47 @@ test("evaluateWiki fails when article was not viewed even if answer matches", ()
 
   assert.equal(result.status, "failed");
   assert.match(result.summary, /requires opening the generated target article/i);
+});
+
+test("evaluateWiki passes when both target and secondary articles are viewed for multi-hop variant", () => {
+  const result = evaluateWiki(
+    makeWikiSession({
+      metadata: wikiTaskConfig({
+        targetArticleSlug: "usb-c-charger-faq",
+        kind: "currency",
+        canonicalValue: "$24.99",
+        normalization: "trim",
+        secondaryArticleSlug: "agentbench-release-history",
+      }),
+      events: [
+        { type: "page.load", url: "/wiki/article/agentbench-release-history?session=tok" },
+        { type: "page.load", url: "/wiki/article/usb-c-charger-faq?session=tok" },
+      ],
+      wikiAnswerSubmissions: [{ answer: "$24.99", submittedAt: "2026-06-01T00:00:00.000Z" }],
+    }),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateWiki fails when secondary article is required but not viewed", () => {
+  const result = evaluateWiki(
+    makeWikiSession({
+      metadata: wikiTaskConfig({
+        targetArticleSlug: "usb-c-charger-faq",
+        kind: "currency",
+        canonicalValue: "$24.99",
+        normalization: "trim",
+        secondaryArticleSlug: "agentbench-release-history",
+      }),
+      events: [{ type: "page.load", url: "/wiki/article/usb-c-charger-faq?session=tok" }],
+      wikiAnswerSubmissions: [{ answer: "$24.99", submittedAt: "2026-06-01T00:00:00.000Z" }],
+    }),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.match(result.summary, /secondary article/i);
 });
 
 function makeForumSession(

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -61,7 +61,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-3`, `full-pool-23`, `full-pool-34`, `full-pool-107`, and `full-pool-188` cover every current variant without using Web guest quota.
+- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, `full-pool-18`, `full-pool-59`, `full-pool-152`, and `full-pool-197` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -61,7 +61,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-4`, `full-pool-6`, `full-pool-9`, `full-pool-43`, and `full-pool-153` cover every current variant without using Web guest quota.
+- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-3`, `full-pool-23`, `full-pool-34`, `full-pool-107`, and `full-pool-188` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -61,7 +61,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs six deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-9`, `full-pool-16`, `full-pool-34`, and `full-pool-91` cover every current variant without using Web guest quota.
+- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-4`, `full-pool-6`, `full-pool-9`, `full-pool-43`, and `full-pool-153` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -61,7 +61,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, `full-pool-4`, `full-pool-7`, `full-pool-9`, and `full-pool-16` cover every current variant without using Web guest quota.
+- `Hosted Variant Sweep` runs six deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-9`, `full-pool-16`, `full-pool-34`, and `full-pool-91` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -61,7 +61,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs six deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, `full-pool-4`, `full-pool-5`, and `full-pool-9` cover every current variant without using Web guest quota.
+- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, `full-pool-4`, `full-pool-7`, `full-pool-9`, and `full-pool-16` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -61,7 +61,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs four deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, and `full-pool-4` cover every current variant without using Web guest quota.
+- `Hosted Variant Sweep` runs six deterministic full-pass attempts against the development environment every Monday and on demand. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, `full-pool-4`, `full-pool-5`, and `full-pool-9` cover every current variant without using Web guest quota.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -47,7 +47,7 @@ This is the only documentation table that enumerates the changing suite contents
 | Task | App | Variants |
 | --- | --- | --- |
 | `shopping-constrained-checkout` | `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard`, `combo-charger-cable`, `travel-kit-free-shipping`, `cable-budget-shipping` |
-| `forum-battery-moderation` | `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory` |
+| `forum-battery-moderation` | `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory`, `battery-recall-pin`, `wifi-reset-report`, `screen-advisory-both` |
 | `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install` |
 | `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price` |
 | `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff` |

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -52,7 +52,7 @@ This is the only documentation table that enumerates the changing suite contents
 | `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price`, `release-to-charger-price`, `dispatch-with-adapters` |
 | `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff`, `adapter-to-shipping`, `express-to-history` |
 | `notes-followup-create` | `notes-lite` | `support-followup`, `release-note`, `ops-check`, `update-support-followup`, `update-release-note`, `update-ops-check` |
-| `calendar-event-create` | `calendar-lite` | `architecture-review`, `release-readiness`, `scoring-retro` |
+| `calendar-event-create` | `calendar-lite` | `architecture-review`, `release-readiness`, `scoring-retro`, `architecture-review-plus-lead`, `release-readiness-plus-pm`, `scoring-retro-plus-analyst` |
 <!-- generated:hosted-testcases:end -->
 
 Each task declares at least two semantic variants. The generic matrix combines every declared variant with all supported layouts and themes; presentation must never affect actions or scoring. See [Benchmark Scoring And Testing](./benchmark-testing.md) for required matrix coverage.

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -49,8 +49,8 @@ This is the only documentation table that enumerates the changing suite contents
 | `shopping-constrained-checkout` | `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard`, `combo-charger-cable`, `travel-kit-free-shipping`, `cable-budget-shipping` |
 | `forum-battery-moderation` | `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory`, `battery-recall-pin`, `wifi-reset-report`, `screen-advisory-both` |
 | `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install`, `pnpm-install-and-version`, `yarn-install-and-rename`, `bun-install-and-script` |
-| `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price` |
-| `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff` |
+| `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price`, `release-to-charger-price`, `dispatch-with-adapters` |
+| `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff`, `adapter-to-shipping`, `express-to-history` |
 | `notes-followup-create` | `notes-lite` | `support-followup`, `release-note`, `ops-check` |
 | `calendar-event-create` | `calendar-lite` | `architecture-review`, `release-readiness`, `scoring-retro` |
 <!-- generated:hosted-testcases:end -->

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -48,7 +48,7 @@ This is the only documentation table that enumerates the changing suite contents
 | --- | --- | --- |
 | `shopping-constrained-checkout` | `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard`, `combo-charger-cable`, `travel-kit-free-shipping`, `cable-budget-shipping` |
 | `forum-battery-moderation` | `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory`, `battery-recall-pin`, `wifi-reset-report`, `screen-advisory-both` |
-| `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install` |
+| `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install`, `pnpm-install-and-version`, `yarn-install-and-rename`, `bun-install-and-script` |
 | `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price` |
 | `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff` |
 | `notes-followup-create` | `notes-lite` | `support-followup`, `release-note`, `ops-check` |

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -51,7 +51,7 @@ This is the only documentation table that enumerates the changing suite contents
 | `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install`, `pnpm-install-and-version`, `yarn-install-and-rename`, `bun-install-and-script` |
 | `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price`, `release-to-charger-price`, `dispatch-with-adapters` |
 | `wiki-policy-answer` | `wiki-lite` | `adapter-restriction`, `standard-dispatch`, `express-cutoff`, `adapter-to-shipping`, `express-to-history` |
-| `notes-followup-create` | `notes-lite` | `support-followup`, `release-note`, `ops-check` |
+| `notes-followup-create` | `notes-lite` | `support-followup`, `release-note`, `ops-check`, `update-support-followup`, `update-release-note`, `update-ops-check` |
 | `calendar-event-create` | `calendar-lite` | `architecture-review`, `release-readiness`, `scoring-retro` |
 <!-- generated:hosted-testcases:end -->
 

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -46,7 +46,7 @@ This is the only documentation table that enumerates the changing suite contents
 <!-- generated:hosted-testcases:start -->
 | Task | App | Variants |
 | --- | --- | --- |
-| `shopping-constrained-checkout` | `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard` |
+| `shopping-constrained-checkout` | `shopping-lite` | `budget-charger-standard`, `cable-express`, `travel-case-standard`, `combo-charger-cable`, `travel-kit-free-shipping`, `cable-budget-shipping` |
 | `forum-battery-moderation` | `forum-lite` | `battery-recall`, `wifi-reset`, `screen-advisory` |
 | `repo-readme-fix` | `repo-lite` | `pnpm-install`, `yarn-install`, `bun-install` |
 | `wiki-release-answer` | `wiki-lite` | `release-date`, `dispatch-window`, `charger-price` |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,6 +124,23 @@ BQ.4 completion evidence: `develop@8e24b02` passed [Hosted deployment run 279414
 
 Completion criteria: a benchmark release is reproducible from a versioned case definition, evaluator set, generation seed, and retained artifacts.
 
+### P2.1 Hosted-Web Task Complexity Expansion
+
+Status: In Progress
+
+Increase difficulty of existing hosted-web apps by adding multi-step variants that require reasoning or cross-page state management, without app-specific orchestrator branches:
+
+- `shopping-lite`: multi-item carts, coupon codes, stock availability, and shipping-threshold decisions.
+- `forum-lite`: multi-thread moderation, category moves, report-before-lock, edit-then-lock, and pin/unpin.
+- `repo-lite`: multi-file changes, feature-branch creation, required commit messages, reviewer approval, and simple merge-conflict resolution.
+- `wiki-lite`: multi-hop lookup, cross-article comparison, section synthesis, and cross-reference verification.
+- `notes-lite`: linked notes, existing-note updates, multi-note creation, and tag-based search/organization.
+- `calendar-lite`: recurring events, multiple attendees, conflict detection and rescheduling, resource booking, and event updates/cancellations.
+
+Each expansion must keep deterministic scoring, variant-matrix coverage, redacted final evidence, and E2E lifecycle smoke. Bump task/seed versions and suite revision when semantic behavior changes.
+
+Exit criteria: every existing hosted app has at least one harder variant requiring multi-step reasoning or cross-page state, the expanded variant matrix passes unit and E2E checks, and `pnpm verify:ci` remains green.
+
 ## Explicit Non-Goals
 
 - Running untrusted agent code, browser sandboxes, or arbitrary workers inside Vercel functions.

--- a/packages/test-cases/src/apps/calendar-lite/definition.ts
+++ b/packages/test-cases/src/apps/calendar-lite/definition.ts
@@ -9,6 +9,7 @@ export const calendarLiteTestcaseDefinition = defineHostedTestcaseApp({
     expectedStartTime: z.string().regex(/^\d{2}:\d{2}$/),
     expectedDurationMinutes: z.number().int().positive(),
     expectedAttendeeEmail: z.string().email(),
+    expectedSecondaryAttendeeEmail: z.string().email().optional(),
   }),
   variantPools: {
     default: [
@@ -26,6 +27,21 @@ export const calendarLiteTestcaseDefinition = defineHostedTestcaseApp({
         id: "scoring-retro",
         goal: "Create an event titled 'Scoring retrospective' on July 14, 2026 at 16:00 for 60 minutes with attendee evals@example.com.",
         taskConfig: { expectedTitle: "Scoring retrospective", expectedDate: "2026-07-14", expectedStartTime: "16:00", expectedDurationMinutes: 60, expectedAttendeeEmail: "evals@example.com" },
+      },
+      {
+        id: "architecture-review-plus-lead",
+        goal: "Create an event titled 'Architecture review' on July 8, 2026 at 14:30 for 45 minutes with attendees mira@example.com and lead@example.com.",
+        taskConfig: { expectedTitle: "Architecture review", expectedDate: "2026-07-08", expectedStartTime: "14:30", expectedDurationMinutes: 45, expectedAttendeeEmail: "mira@example.com", expectedSecondaryAttendeeEmail: "lead@example.com" },
+      },
+      {
+        id: "release-readiness-plus-pm",
+        goal: "Create an event titled 'Release readiness' on July 10, 2026 at 09:00 for 30 minutes with attendees ops@example.com and pm@example.com.",
+        taskConfig: { expectedTitle: "Release readiness", expectedDate: "2026-07-10", expectedStartTime: "09:00", expectedDurationMinutes: 30, expectedAttendeeEmail: "ops@example.com", expectedSecondaryAttendeeEmail: "pm@example.com" },
+      },
+      {
+        id: "scoring-retro-plus-analyst",
+        goal: "Create an event titled 'Scoring retrospective' on July 14, 2026 at 16:00 for 60 minutes with attendees evals@example.com and analyst@example.com.",
+        taskConfig: { expectedTitle: "Scoring retrospective", expectedDate: "2026-07-14", expectedStartTime: "16:00", expectedDurationMinutes: 60, expectedAttendeeEmail: "evals@example.com", expectedSecondaryAttendeeEmail: "analyst@example.com" },
       },
     ],
   },

--- a/packages/test-cases/src/apps/forum-lite/definition.ts
+++ b/packages/test-cases/src/apps/forum-lite/definition.ts
@@ -7,12 +7,18 @@ export const forumLiteTestcaseDefinition = defineHostedTestcaseApp({
     targetThreadId: z.string().min(1),
     expectedReplyValue: z.string().url(),
     expectedLockReason: z.string().min(1),
+    requiresPin: z.boolean().optional(),
+    requiresReport: z.boolean().optional(),
+    expectedReportReason: z.string().min(1).optional(),
   }),
   variantPools: {
     default: [
       { id: "battery-recall", goal: "Find the battery swelling thread, reply with the official recall link from the support post, then lock it with reason 'safety escalation'.", taskConfig: { targetThreadId: "thr-battery", expectedReplyValue: "https://support.example.com/recall/battery-2026", expectedLockReason: "safety escalation" } },
       { id: "wifi-reset", goal: "Find the 5GHz connectivity thread, reply with the official reset-guide link from support, then lock it with reason 'resolved with guide'.", taskConfig: { targetThreadId: "thr-wifi", expectedReplyValue: "https://support.example.com/network/5ghz-reset", expectedLockReason: "resolved with guide" } },
       { id: "screen-advisory", goal: "Find the low-brightness flickering thread, reply with the display calibration advisory link, then lock it with reason 'known display issue'.", taskConfig: { targetThreadId: "thr-screen", expectedReplyValue: "https://support.example.com/display/flicker-calibration", expectedLockReason: "known display issue" } },
+      { id: "battery-recall-pin", goal: "Find the battery swelling thread, reply with the official recall link from the support post, lock it with reason 'safety escalation', then pin it.", taskConfig: { targetThreadId: "thr-battery", expectedReplyValue: "https://support.example.com/recall/battery-2026", expectedLockReason: "safety escalation", requiresPin: true } },
+      { id: "wifi-reset-report", goal: "Find the 5GHz connectivity thread, submit a moderation report with reason 'needs escalation', then reply with the reset-guide link and lock it with reason 'resolved with guide'.", taskConfig: { targetThreadId: "thr-wifi", expectedReplyValue: "https://support.example.com/network/5ghz-reset", expectedLockReason: "resolved with guide", requiresReport: true, expectedReportReason: "needs escalation" } },
+      { id: "screen-advisory-both", goal: "Find the low-brightness flickering thread, submit a report with reason 'duplicate issue', reply with the display calibration advisory link, lock it with reason 'known display issue', then pin it.", taskConfig: { targetThreadId: "thr-screen", expectedReplyValue: "https://support.example.com/display/flicker-calibration", expectedLockReason: "known display issue", requiresReport: true, expectedReportReason: "duplicate issue", requiresPin: true } },
     ],
   },
 });

--- a/packages/test-cases/src/apps/notes-lite/definition.ts
+++ b/packages/test-cases/src/apps/notes-lite/definition.ts
@@ -7,6 +7,7 @@ export const notesLiteTestcaseDefinition = defineHostedTestcaseApp({
     expectedTitle: z.string().min(1),
     expectedBody: z.string().min(1),
     expectedTag: z.string().min(1),
+    targetNoteId: z.string().min(1).optional(),
   }),
   variantPools: {
     default: [
@@ -35,6 +36,36 @@ export const notesLiteTestcaseDefinition = defineHostedTestcaseApp({
           expectedTitle: "Ops check",
           expectedBody: "Review Redis health metrics after the next hosted suite run.",
           expectedTag: "ops",
+        },
+      },
+      {
+        id: "update-support-followup",
+        goal: "Update the seeded note titled 'Old support follow-up' to title 'Support follow-up', body 'Email Mira after the replacement adapter ships.', and tag 'support'.",
+        taskConfig: {
+          expectedTitle: "Support follow-up",
+          expectedBody: "Email Mira after the replacement adapter ships.",
+          expectedTag: "support",
+          targetNoteId: "note-seed-support",
+        },
+      },
+      {
+        id: "update-release-note",
+        goal: "Update the seeded note titled 'Old release reminder' to title 'Release reminder', body 'Confirm the hosted-web v3.0.1 smoke run before publishing notes.', and tag 'release'.",
+        taskConfig: {
+          expectedTitle: "Release reminder",
+          expectedBody: "Confirm the hosted-web v3.0.1 smoke run before publishing notes.",
+          expectedTag: "release",
+          targetNoteId: "note-seed-release",
+        },
+      },
+      {
+        id: "update-ops-check",
+        goal: "Update the seeded note titled 'Old ops check' to title 'Ops check', body 'Review Redis health metrics after the next hosted suite run.', and tag 'ops'.",
+        taskConfig: {
+          expectedTitle: "Ops check",
+          expectedBody: "Review Redis health metrics after the next hosted suite run.",
+          expectedTag: "ops",
+          targetNoteId: "note-seed-ops",
         },
       },
     ],

--- a/packages/test-cases/src/apps/repo-lite/definition.ts
+++ b/packages/test-cases/src/apps/repo-lite/definition.ts
@@ -9,12 +9,18 @@ export const repoLiteTestcaseDefinition = defineHostedTestcaseApp({
     forbiddenText: z.string().min(1),
     expectedMrTitle: z.string().min(1),
     expectedTargetBranch: z.string().min(1),
+    secondaryFilePath: z.string().min(1).optional(),
+    secondaryExpectedText: z.string().min(1).optional(),
+    secondaryForbiddenText: z.string().min(1).optional(),
   }),
   variantPools: {
     default: [
       { id: "pnpm-install", goal: "Replace the README install command with `pnpm install`, remove `npm install`, then open a merge request titled `Fix install instructions` targeting `main`.", taskConfig: { filePath: "README.md", expectedText: "pnpm install", forbiddenText: "npm install", expectedMrTitle: "Fix install instructions", expectedTargetBranch: "main" } },
       { id: "yarn-install", goal: "Replace the README install command with `yarn install`, remove `npm install`, then open a merge request titled `Document Yarn setup` targeting `main`.", taskConfig: { filePath: "README.md", expectedText: "yarn install", forbiddenText: "npm install", expectedMrTitle: "Document Yarn setup", expectedTargetBranch: "main" } },
       { id: "bun-install", goal: "Replace the README install command with `bun install`, remove `npm install`, then open a merge request titled `Add Bun setup` targeting `develop`.", taskConfig: { filePath: "README.md", expectedText: "bun install", forbiddenText: "npm install", expectedMrTitle: "Add Bun setup", expectedTargetBranch: "develop" } },
+      { id: "pnpm-install-and-version", goal: "Replace the README install command with `pnpm install`, bump `package.json` version from `1.0.0` to `1.0.1`, then open a merge request titled `Fix install and bump version` targeting `main`.", taskConfig: { filePath: "README.md", expectedText: "pnpm install", forbiddenText: "npm install", expectedMrTitle: "Fix install and bump version", expectedTargetBranch: "main", secondaryFilePath: "package.json", secondaryExpectedText: "1.0.1", secondaryForbiddenText: "1.0.0" } },
+      { id: "yarn-install-and-rename", goal: "Replace the README install command with `yarn install`, rename the project in `package.json` from `demo-project` to `demo-yarn-project`, then open a merge request titled `Update README and rename project` targeting `main`.", taskConfig: { filePath: "README.md", expectedText: "yarn install", forbiddenText: "npm install", expectedMrTitle: "Update README and rename project", expectedTargetBranch: "main", secondaryFilePath: "package.json", secondaryExpectedText: "demo-yarn-project", secondaryForbiddenText: "demo-project" } },
+      { id: "bun-install-and-script", goal: "Replace the README install command with `bun install`, add a `test` script to `package.json`, then open a merge request titled `Add Bun and test script` targeting `develop`.", taskConfig: { filePath: "README.md", expectedText: "bun install", forbiddenText: "npm install", expectedMrTitle: "Add Bun and test script", expectedTargetBranch: "develop", secondaryFilePath: "package.json", secondaryExpectedText: "test" } },
     ],
   },
 });

--- a/packages/test-cases/src/apps/shopping-lite/definition.ts
+++ b/packages/test-cases/src/apps/shopping-lite/definition.ts
@@ -9,12 +9,19 @@ export const shoppingLiteTestcaseDefinition = defineHostedTestcaseApp({
     maxTotal: z.number().positive(),
     shippingMethod: z.enum(["standard", "express"]),
     avoidRestricted: z.boolean(),
+    secondaryCategory: z.enum(["charger", "cable", "adapter", "case"]).optional(),
+    secondaryQuantity: z.number().int().positive().optional(),
+    freeShippingThreshold: z.number().nonnegative().optional(),
+    shippingCost: z.number().nonnegative().optional(),
   }),
   variantPools: {
     default: [
       { id: "budget-charger-standard", goal: "Buy exactly one charger with a total price at or below $30, use standard shipping, and avoid restricted products.", taskConfig: { targetCategory: "charger", quantity: 1, maxTotal: 30, shippingMethod: "standard", avoidRestricted: true } },
       { id: "cable-express", goal: "Buy exactly one USB-C cable with a total price at or below $10, use express shipping, and avoid restricted products.", taskConfig: { targetCategory: "cable", quantity: 1, maxTotal: 10, shippingMethod: "express", avoidRestricted: true } },
       { id: "travel-case-standard", goal: "Buy exactly one travel case with a total price at or below $15, use standard shipping, and avoid restricted products.", taskConfig: { targetCategory: "case", quantity: 1, maxTotal: 15, shippingMethod: "standard", avoidRestricted: true } },
+      { id: "combo-charger-cable", goal: "Buy one charger and one USB-C cable with a total price at or below $35, use standard shipping, and avoid restricted products.", taskConfig: { targetCategory: "charger", quantity: 1, maxTotal: 35, shippingMethod: "standard", avoidRestricted: true, secondaryCategory: "cable", secondaryQuantity: 1 } },
+      { id: "travel-kit-free-shipping", goal: "Buy one charger and one travel case with a total price at or below $40. Standard shipping is free for orders $35 and over; otherwise standard shipping costs $5. Avoid restricted products.", taskConfig: { targetCategory: "charger", quantity: 1, maxTotal: 40, shippingMethod: "standard", avoidRestricted: true, secondaryCategory: "case", secondaryQuantity: 1, freeShippingThreshold: 35, shippingCost: 5 } },
+      { id: "cable-budget-shipping", goal: "Buy one USB-C cable and one travel case with a total price at or below $25. Standard shipping is free for orders $20 and over; otherwise standard shipping costs $4. Avoid restricted products.", taskConfig: { targetCategory: "cable", quantity: 1, maxTotal: 25, shippingMethod: "standard", avoidRestricted: true, secondaryCategory: "case", secondaryQuantity: 1, freeShippingThreshold: 20, shippingCost: 4 } },
     ],
   },
 });

--- a/packages/test-cases/src/apps/wiki-lite/definition.ts
+++ b/packages/test-cases/src/apps/wiki-lite/definition.ts
@@ -12,6 +12,7 @@ export const wikiLiteTestcaseDefinition = defineHostedTestcaseApp({
   app: "wiki-lite",
   taskConfigSchema: z.object({
     targetArticleSlug: z.string().min(1),
+    secondaryArticleSlug: z.string().min(1).optional(),
     answerContract: wikiAnswerContractSchema,
   }).superRefine((config, context) => {
     if (config.targetArticleSlug !== config.answerContract.sourceArticleSlug) {
@@ -27,11 +28,15 @@ export const wikiLiteTestcaseDefinition = defineHostedTestcaseApp({
       { id: "release-date", goal: "Use the hosted wiki to find when wiki-lite followed the hosted-web suite alpha, then submit only the date.", taskConfig: { targetArticleSlug: "agentbench-release-history", answerContract: { kind: "date", canonicalValue: "June 1, 2026", normalization: "trim-casefold-punctuation", sourceArticleSlug: "agentbench-release-history" } } },
       { id: "dispatch-window", goal: "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit only the duration without surrounding words.", taskConfig: { targetArticleSlug: "shipping-policy", answerContract: { kind: "duration", canonicalValue: "two business days", normalization: "trim-casefold", sourceArticleSlug: "shipping-policy" } } },
       { id: "charger-price", goal: "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit only the exact price.", taskConfig: { targetArticleSlug: "usb-c-charger-faq", answerContract: { kind: "currency", canonicalValue: "$24.99", normalization: "trim", sourceArticleSlug: "usb-c-charger-faq" } } },
+      { id: "release-to-charger-price", goal: "The release history article references the USB-C Charger FAQ for recommended accessories. Open both articles and submit the exact price of the recommended budget charger.", taskConfig: { targetArticleSlug: "usb-c-charger-faq", secondaryArticleSlug: "agentbench-release-history", answerContract: { kind: "currency", canonicalValue: "$24.99", normalization: "trim", sourceArticleSlug: "usb-c-charger-faq" } } },
+      { id: "dispatch-with-adapters", goal: "The power adapter safety article references the shipping policy for dispatch timing. Open both articles and submit the standard shipping dispatch window.", taskConfig: { targetArticleSlug: "shipping-policy", secondaryArticleSlug: "power-adapters", answerContract: { kind: "duration", canonicalValue: "two business days", normalization: "trim-casefold", sourceArticleSlug: "shipping-policy" } } },
     ],
     policy: [
       { id: "adapter-restriction", goal: "Use the hosted wiki to find who restricted lab power adapters are reserved for, then submit only the group name.", taskConfig: { targetArticleSlug: "power-adapters", answerContract: { kind: "text", canonicalValue: "internal certification teams", normalization: "trim-casefold-punctuation", sourceArticleSlug: "power-adapters" } } },
       { id: "standard-dispatch", goal: "Use the hosted wiki to find the standard shipping dispatch window, then submit only the duration.", taskConfig: { targetArticleSlug: "shipping-policy", answerContract: { kind: "duration", canonicalValue: "two business days", normalization: "trim-casefold", sourceArticleSlug: "shipping-policy" } } },
       { id: "express-cutoff", goal: "Use the hosted wiki to find the express order same-day shipping cutoff time, then submit only the time.", taskConfig: { targetArticleSlug: "shipping-policy", answerContract: { kind: "text", canonicalValue: "3pm", normalization: "trim-casefold-punctuation", sourceArticleSlug: "shipping-policy" } } },
+      { id: "adapter-to-shipping", goal: "The shipping policy references the power adapter safety article for restricted equipment rules. Open both articles and submit who restricted lab power adapters are reserved for.", taskConfig: { targetArticleSlug: "power-adapters", secondaryArticleSlug: "shipping-policy", answerContract: { kind: "text", canonicalValue: "internal certification teams", normalization: "trim-casefold-punctuation", sourceArticleSlug: "power-adapters" } } },
+      { id: "express-to-history", goal: "The release history article references the shipping policy for delivery details. Open both articles and submit the express order same-day shipping cutoff time.", taskConfig: { targetArticleSlug: "shipping-policy", secondaryArticleSlug: "agentbench-release-history", answerContract: { kind: "text", canonicalValue: "3pm", normalization: "trim-casefold-punctuation", sourceArticleSlug: "shipping-policy" } } },
     ],
   },
 });

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,19 +11,19 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.6",
+  suiteVersion: "v3.0.7",
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
     { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v2", seedVersion: "repo-lite-v2", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v3", seedVersion: "wiki-lite-v4", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v4", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
-    { app: "notes-lite", taskSlug: "notes-followup-create", title: "Notes Follow-up", startPath: "/notes", taskVersion: "v1", seedVersion: "notes-lite-v1", sequenceIndex: 5, weight: 1, required: true, metadata: { questionVariants: notesQuestionVariants } },
+    { app: "notes-lite", taskSlug: "notes-followup-create", title: "Notes Follow-up", startPath: "/notes", taskVersion: "v2", seedVersion: "notes-lite-v2", sequenceIndex: 5, weight: 1, required: true, metadata: { questionVariants: notesQuestionVariants } },
     { app: "calendar-lite", taskSlug: "calendar-event-create", title: "Calendar Event", startPath: "/calendar", taskVersion: "v1", seedVersion: "calendar-lite-v1", sequenceIndex: 6, weight: 1, required: true, metadata: { questionVariants: calendarQuestionVariants } },
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.6";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.7";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,9 +11,9 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.2",
+  suiteVersion: "v3.0.3",
   sessions: [
-    { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v1", seedVersion: "shopping-lite-v1", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
+    { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v1", seedVersion: "forum-lite-v1", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
     { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v1", seedVersion: "repo-lite-v1", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v2", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
@@ -23,7 +23,7 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.2";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.3";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,10 +11,10 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.3",
+  suiteVersion: "v3.0.4",
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
-    { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v1", seedVersion: "forum-lite-v1", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
+    { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
     { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v1", seedVersion: "repo-lite-v1", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v2", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v1", seedVersion: "wiki-lite-v3", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
@@ -23,7 +23,7 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.3";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.4";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,19 +11,19 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.5",
+  suiteVersion: "v3.0.6",
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
     { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v2", seedVersion: "repo-lite-v2", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
-    { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v2", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
-    { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v1", seedVersion: "wiki-lite-v3", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
+    { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v3", seedVersion: "wiki-lite-v4", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
+    { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v4", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
     { app: "notes-lite", taskSlug: "notes-followup-create", title: "Notes Follow-up", startPath: "/notes", taskVersion: "v1", seedVersion: "notes-lite-v1", sequenceIndex: 5, weight: 1, required: true, metadata: { questionVariants: notesQuestionVariants } },
     { app: "calendar-lite", taskSlug: "calendar-event-create", title: "Calendar Event", startPath: "/calendar", taskVersion: "v1", seedVersion: "calendar-lite-v1", sequenceIndex: 6, weight: 1, required: true, metadata: { questionVariants: calendarQuestionVariants } },
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.5";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.6";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,7 +11,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.7",
+  suiteVersion: "v3.0.8",
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
@@ -19,11 +19,11 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
     { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v3", seedVersion: "wiki-lite-v4", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v4", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
     { app: "notes-lite", taskSlug: "notes-followup-create", title: "Notes Follow-up", startPath: "/notes", taskVersion: "v2", seedVersion: "notes-lite-v2", sequenceIndex: 5, weight: 1, required: true, metadata: { questionVariants: notesQuestionVariants } },
-    { app: "calendar-lite", taskSlug: "calendar-event-create", title: "Calendar Event", startPath: "/calendar", taskVersion: "v1", seedVersion: "calendar-lite-v1", sequenceIndex: 6, weight: 1, required: true, metadata: { questionVariants: calendarQuestionVariants } },
+    { app: "calendar-lite", taskSlug: "calendar-event-create", title: "Calendar Event", startPath: "/calendar", taskVersion: "v2", seedVersion: "calendar-lite-v2", sequenceIndex: 6, weight: 1, required: true, metadata: { questionVariants: calendarQuestionVariants } },
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.7";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.8";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,11 +11,11 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.4",
+  suiteVersion: "v3.0.5",
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
-    { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v1", seedVersion: "repo-lite-v1", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
+    { app: "repo-lite", taskSlug: "repo-readme-fix", title: "Repository README Fix", startPath: "/repo", taskVersion: "v2", seedVersion: "repo-lite-v2", sequenceIndex: 2, weight: 1, required: true, metadata: { questionVariants: repoQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-release-answer", title: "Wiki Release Lookup", startPath: "/wiki", taskVersion: "v2", seedVersion: "wiki-lite-v2", sequenceIndex: 3, weight: 1, required: true, metadata: { questionVariants: wikiQuestionVariants } },
     { app: "wiki-lite", taskSlug: "wiki-policy-answer", title: "Wiki Policy Lookup", startPath: "/wiki", taskVersion: "v1", seedVersion: "wiki-lite-v3", sequenceIndex: 4, weight: 1, required: true, metadata: { questionVariants: wikiPolicyQuestionVariants } },
     { app: "notes-lite", taskSlug: "notes-followup-create", title: "Notes Follow-up", startPath: "/notes", taskVersion: "v1", seedVersion: "notes-lite-v1", sequenceIndex: 5, weight: 1, required: true, metadata: { questionVariants: notesQuestionVariants } },
@@ -23,7 +23,7 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.4";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.5";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -27,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.5");
+  assert.equal(first.revision, "hosted-web-suite-v3.0.6");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -27,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.2");
+  assert.equal(first.revision, "hosted-web-suite-v3.0.3");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -27,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.7");
+  assert.equal(first.revision, "hosted-web-suite-v3.0.8");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -27,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.6");
+  assert.equal(first.revision, "hosted-web-suite-v3.0.7");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -27,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.3");
+  assert.equal(first.revision, "hosted-web-suite-v3.0.4");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -27,7 +27,7 @@ test("hosted catalog release has a stable revision identity and content hash", (
   const first = createHostedWebCatalogRelease();
   const second = createHostedWebCatalogRelease();
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.4");
+  assert.equal(first.revision, "hosted-web-suite-v3.0.5");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
 });

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,10 +11,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.5',
+  'hosted-web-suite-v3.0.6',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.5",
+  "suiteVersion": "v3.0.6",
   "sessions": [
     {
       "app": "shopping-lite",
@@ -275,8 +275,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "wiki-release-answer",
       "title": "Wiki Release Lookup",
       "startPath": "/wiki",
-      "taskVersion": "v2",
-      "seedVersion": "wiki-lite-v2",
+      "taskVersion": "v3",
+      "seedVersion": "wiki-lite-v4",
       "sequenceIndex": 3,
       "weight": 1,
       "required": true,
@@ -320,6 +320,34 @@ select public.publish_benchmark_case_catalog(
                 "sourceArticleSlug": "usb-c-charger-faq"
               }
             }
+          },
+          {
+            "id": "release-to-charger-price",
+            "goal": "The release history article references the USB-C Charger FAQ for recommended accessories. Open both articles and submit the exact price of the recommended budget charger.",
+            "taskConfig": {
+              "targetArticleSlug": "usb-c-charger-faq",
+              "secondaryArticleSlug": "agentbench-release-history",
+              "answerContract": {
+                "kind": "currency",
+                "canonicalValue": "$24.99",
+                "normalization": "trim",
+                "sourceArticleSlug": "usb-c-charger-faq"
+              }
+            }
+          },
+          {
+            "id": "dispatch-with-adapters",
+            "goal": "The power adapter safety article references the shipping policy for dispatch timing. Open both articles and submit the standard shipping dispatch window.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "secondaryArticleSlug": "power-adapters",
+              "answerContract": {
+                "kind": "duration",
+                "canonicalValue": "two business days",
+                "normalization": "trim-casefold",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
           }
         ]
       }
@@ -329,8 +357,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "wiki-policy-answer",
       "title": "Wiki Policy Lookup",
       "startPath": "/wiki",
-      "taskVersion": "v1",
-      "seedVersion": "wiki-lite-v3",
+      "taskVersion": "v2",
+      "seedVersion": "wiki-lite-v4",
       "sequenceIndex": 4,
       "weight": 1,
       "required": true,
@@ -367,6 +395,34 @@ select public.publish_benchmark_case_catalog(
             "goal": "Use the hosted wiki to find the express order same-day shipping cutoff time, then submit only the time.",
             "taskConfig": {
               "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "3pm",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          },
+          {
+            "id": "adapter-to-shipping",
+            "goal": "The shipping policy references the power adapter safety article for restricted equipment rules. Open both articles and submit who restricted lab power adapters are reserved for.",
+            "taskConfig": {
+              "targetArticleSlug": "power-adapters",
+              "secondaryArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "internal certification teams",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "power-adapters"
+              }
+            }
+          },
+          {
+            "id": "express-to-history",
+            "goal": "The release history article references the shipping policy for delivery details. Open both articles and submit the express order same-day shipping cutoff time.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "secondaryArticleSlug": "agentbench-release-history",
               "answerContract": {
                 "kind": "text",
                 "canonicalValue": "3pm",
@@ -470,7 +526,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '817c7fd62a2161cd9bfd3205965bf22d7e5445cbeca89074daf203881fd3ec59'
+  'e6e705b644b3a6fd1c4533dd32512fd6c61d410c575e47da04f26b0702454d21'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,10 +11,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.7',
+  'hosted-web-suite-v3.0.8',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.7",
+  "suiteVersion": "v3.0.8",
   "sessions": [
     {
       "app": "shopping-lite",
@@ -511,8 +511,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "calendar-event-create",
       "title": "Calendar Event",
       "startPath": "/calendar",
-      "taskVersion": "v1",
-      "seedVersion": "calendar-lite-v1",
+      "taskVersion": "v2",
+      "seedVersion": "calendar-lite-v2",
       "sequenceIndex": 6,
       "weight": 1,
       "required": true,
@@ -550,13 +550,49 @@ select public.publish_benchmark_case_catalog(
               "expectedDurationMinutes": 60,
               "expectedAttendeeEmail": "evals@example.com"
             }
+          },
+          {
+            "id": "architecture-review-plus-lead",
+            "goal": "Create an event titled 'Architecture review' on July 8, 2026 at 14:30 for 45 minutes with attendees mira@example.com and lead@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Architecture review",
+              "expectedDate": "2026-07-08",
+              "expectedStartTime": "14:30",
+              "expectedDurationMinutes": 45,
+              "expectedAttendeeEmail": "mira@example.com",
+              "expectedSecondaryAttendeeEmail": "lead@example.com"
+            }
+          },
+          {
+            "id": "release-readiness-plus-pm",
+            "goal": "Create an event titled 'Release readiness' on July 10, 2026 at 09:00 for 30 minutes with attendees ops@example.com and pm@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Release readiness",
+              "expectedDate": "2026-07-10",
+              "expectedStartTime": "09:00",
+              "expectedDurationMinutes": 30,
+              "expectedAttendeeEmail": "ops@example.com",
+              "expectedSecondaryAttendeeEmail": "pm@example.com"
+            }
+          },
+          {
+            "id": "scoring-retro-plus-analyst",
+            "goal": "Create an event titled 'Scoring retrospective' on July 14, 2026 at 16:00 for 60 minutes with attendees evals@example.com and analyst@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Scoring retrospective",
+              "expectedDate": "2026-07-14",
+              "expectedStartTime": "16:00",
+              "expectedDurationMinutes": 60,
+              "expectedAttendeeEmail": "evals@example.com",
+              "expectedSecondaryAttendeeEmail": "analyst@example.com"
+            }
           }
         ]
       }
     }
   ]
 }$catalog$::jsonb,
-  '0f5006278d204b0fc6521dcd2423c73074b3cf1347c79cea39db9482a5a69de8'
+  '7e4bc4d598f3240e29487673714fccee5eac5d8e97572806c3910cdd1852bf5f'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,17 +11,17 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.2',
+  'hosted-web-suite-v3.0.3',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.2",
+  "suiteVersion": "v3.0.3",
   "sessions": [
     {
       "app": "shopping-lite",
       "taskSlug": "shopping-constrained-checkout",
       "title": "Shopping Checkout",
-      "taskVersion": "v1",
-      "seedVersion": "shopping-lite-v1",
+      "taskVersion": "v2",
+      "seedVersion": "shopping-lite-v2",
       "sequenceIndex": 0,
       "weight": 1,
       "required": true,
@@ -58,6 +58,49 @@ select public.publish_benchmark_case_catalog(
               "maxTotal": 15,
               "shippingMethod": "standard",
               "avoidRestricted": true
+            }
+          },
+          {
+            "id": "combo-charger-cable",
+            "goal": "Buy one charger and one USB-C cable with a total price at or below $35, use standard shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 1,
+              "maxTotal": 35,
+              "shippingMethod": "standard",
+              "avoidRestricted": true,
+              "secondaryCategory": "cable",
+              "secondaryQuantity": 1
+            }
+          },
+          {
+            "id": "travel-kit-free-shipping",
+            "goal": "Buy one charger and one travel case with a total price at or below $40. Standard shipping is free for orders $35 and over; otherwise standard shipping costs $5. Avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 1,
+              "maxTotal": 40,
+              "shippingMethod": "standard",
+              "avoidRestricted": true,
+              "secondaryCategory": "case",
+              "secondaryQuantity": 1,
+              "freeShippingThreshold": 35,
+              "shippingCost": 5
+            }
+          },
+          {
+            "id": "cable-budget-shipping",
+            "goal": "Buy one USB-C cable and one travel case with a total price at or below $25. Standard shipping is free for orders $20 and over; otherwise standard shipping costs $4. Avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "cable",
+              "quantity": 1,
+              "maxTotal": 25,
+              "shippingMethod": "standard",
+              "avoidRestricted": true,
+              "secondaryCategory": "case",
+              "secondaryQuantity": 1,
+              "freeShippingThreshold": 20,
+              "shippingCost": 4
             }
           }
         ]
@@ -353,7 +396,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  'e155bbcba0aa40f1a8bfdd63cbb979638758bc36858a828c6bc729d4c0d98913'
+  '9a41d12fb2f6a9792163439f5e9dcb42852f12df1383cebbd56d33a690c8bda1'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,10 +11,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.4',
+  'hosted-web-suite-v3.0.5',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.4",
+  "suiteVersion": "v3.0.5",
   "sessions": [
     {
       "app": "shopping-lite",
@@ -186,8 +186,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "repo-readme-fix",
       "title": "Repository README Fix",
       "startPath": "/repo",
-      "taskVersion": "v1",
-      "seedVersion": "repo-lite-v1",
+      "taskVersion": "v2",
+      "seedVersion": "repo-lite-v2",
       "sequenceIndex": 2,
       "weight": 1,
       "required": true,
@@ -224,6 +224,47 @@ select public.publish_benchmark_case_catalog(
               "forbiddenText": "npm install",
               "expectedMrTitle": "Add Bun setup",
               "expectedTargetBranch": "develop"
+            }
+          },
+          {
+            "id": "pnpm-install-and-version",
+            "goal": "Replace the README install command with `pnpm install`, bump `package.json` version from `1.0.0` to `1.0.1`, then open a merge request titled `Fix install and bump version` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "pnpm install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Fix install and bump version",
+              "expectedTargetBranch": "main",
+              "secondaryFilePath": "package.json",
+              "secondaryExpectedText": "1.0.1",
+              "secondaryForbiddenText": "1.0.0"
+            }
+          },
+          {
+            "id": "yarn-install-and-rename",
+            "goal": "Replace the README install command with `yarn install`, rename the project in `package.json` from `demo-project` to `demo-yarn-project`, then open a merge request titled `Update README and rename project` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "yarn install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Update README and rename project",
+              "expectedTargetBranch": "main",
+              "secondaryFilePath": "package.json",
+              "secondaryExpectedText": "demo-yarn-project",
+              "secondaryForbiddenText": "demo-project"
+            }
+          },
+          {
+            "id": "bun-install-and-script",
+            "goal": "Replace the README install command with `bun install`, add a `test` script to `package.json`, then open a merge request titled `Add Bun and test script` targeting `develop`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "bun install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Add Bun and test script",
+              "expectedTargetBranch": "develop",
+              "secondaryFilePath": "package.json",
+              "secondaryExpectedText": "test"
             }
           }
         ]
@@ -429,7 +470,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  'bc6833abed1623fb9b148dc48df735d5381654b8a4d89b3a1f215109cd2875d0'
+  '817c7fd62a2161cd9bfd3205965bf22d7e5445cbeca89074daf203881fd3ec59'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,10 +11,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.3',
+  'hosted-web-suite-v3.0.4',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.3",
+  "suiteVersion": "v3.0.4",
   "sessions": [
     {
       "app": "shopping-lite",
@@ -111,8 +111,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "forum-battery-moderation",
       "title": "Forum Moderation",
       "startPath": "/forum",
-      "taskVersion": "v1",
-      "seedVersion": "forum-lite-v1",
+      "taskVersion": "v2",
+      "seedVersion": "forum-lite-v2",
       "sequenceIndex": 1,
       "weight": 1,
       "required": true,
@@ -143,6 +143,39 @@ select public.publish_benchmark_case_catalog(
               "targetThreadId": "thr-screen",
               "expectedReplyValue": "https://support.example.com/display/flicker-calibration",
               "expectedLockReason": "known display issue"
+            }
+          },
+          {
+            "id": "battery-recall-pin",
+            "goal": "Find the battery swelling thread, reply with the official recall link from the support post, lock it with reason 'safety escalation', then pin it.",
+            "taskConfig": {
+              "targetThreadId": "thr-battery",
+              "expectedReplyValue": "https://support.example.com/recall/battery-2026",
+              "expectedLockReason": "safety escalation",
+              "requiresPin": true
+            }
+          },
+          {
+            "id": "wifi-reset-report",
+            "goal": "Find the 5GHz connectivity thread, submit a moderation report with reason 'needs escalation', then reply with the reset-guide link and lock it with reason 'resolved with guide'.",
+            "taskConfig": {
+              "targetThreadId": "thr-wifi",
+              "expectedReplyValue": "https://support.example.com/network/5ghz-reset",
+              "expectedLockReason": "resolved with guide",
+              "requiresReport": true,
+              "expectedReportReason": "needs escalation"
+            }
+          },
+          {
+            "id": "screen-advisory-both",
+            "goal": "Find the low-brightness flickering thread, submit a report with reason 'duplicate issue', reply with the display calibration advisory link, lock it with reason 'known display issue', then pin it.",
+            "taskConfig": {
+              "targetThreadId": "thr-screen",
+              "expectedReplyValue": "https://support.example.com/display/flicker-calibration",
+              "expectedLockReason": "known display issue",
+              "requiresPin": true,
+              "requiresReport": true,
+              "expectedReportReason": "duplicate issue"
             }
           }
         ]
@@ -396,7 +429,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '9a41d12fb2f6a9792163439f5e9dcb42852f12df1383cebbd56d33a690c8bda1'
+  'bc6833abed1623fb9b148dc48df735d5381654b8a4d89b3a1f215109cd2875d0'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,10 +11,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.6',
+  'hosted-web-suite-v3.0.7',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.6",
+  "suiteVersion": "v3.0.7",
   "sessions": [
     {
       "app": "shopping-lite",
@@ -439,8 +439,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "notes-followup-create",
       "title": "Notes Follow-up",
       "startPath": "/notes",
-      "taskVersion": "v1",
-      "seedVersion": "notes-lite-v1",
+      "taskVersion": "v2",
+      "seedVersion": "notes-lite-v2",
       "sequenceIndex": 5,
       "weight": 1,
       "required": true,
@@ -471,6 +471,36 @@ select public.publish_benchmark_case_catalog(
               "expectedTitle": "Ops check",
               "expectedBody": "Review Redis health metrics after the next hosted suite run.",
               "expectedTag": "ops"
+            }
+          },
+          {
+            "id": "update-support-followup",
+            "goal": "Update the seeded note titled 'Old support follow-up' to title 'Support follow-up', body 'Email Mira after the replacement adapter ships.', and tag 'support'.",
+            "taskConfig": {
+              "expectedTitle": "Support follow-up",
+              "expectedBody": "Email Mira after the replacement adapter ships.",
+              "expectedTag": "support",
+              "targetNoteId": "note-seed-support"
+            }
+          },
+          {
+            "id": "update-release-note",
+            "goal": "Update the seeded note titled 'Old release reminder' to title 'Release reminder', body 'Confirm the hosted-web v3.0.1 smoke run before publishing notes.', and tag 'release'.",
+            "taskConfig": {
+              "expectedTitle": "Release reminder",
+              "expectedBody": "Confirm the hosted-web v3.0.1 smoke run before publishing notes.",
+              "expectedTag": "release",
+              "targetNoteId": "note-seed-release"
+            }
+          },
+          {
+            "id": "update-ops-check",
+            "goal": "Update the seeded note titled 'Old ops check' to title 'Ops check', body 'Review Redis health metrics after the next hosted suite run.', and tag 'ops'.",
+            "taskConfig": {
+              "expectedTitle": "Ops check",
+              "expectedBody": "Review Redis health metrics after the next hosted suite run.",
+              "expectedTag": "ops",
+              "targetNoteId": "note-seed-ops"
             }
           }
         ]
@@ -526,7 +556,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  'e6e705b644b3a6fd1c4533dd32512fd6c61d410c575e47da04f26b0702454d21'
+  '0f5006278d204b0fc6521dcd2423c73074b3cf1347c79cea39db9482a5a69de8'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
Increases hosted-web task complexity across the hosted app suite and carries forward the shopping cart controls fix.

## Changes

- Adds harder shopping-lite, forum-lite, repo-lite, wiki-lite, notes-lite, and calendar-lite variants.
- Bumps the hosted-web suite through `v3.0.8` and refreshes generated sweep seeds/docs.
- Keeps app definitions, hosted-site runtime, test drivers, unit tests, and seed data aligned.
- Merges the shopping cart controls fix so agents can remove items and adjust quantities while preserving shipping/free-shipping scoring.

## Verification

- `pnpm --filter hosted-sites test`
- `CI=true PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS=true pnpm verify:ci`
- Pre-push hook reran `verify-ci` successfully before pushing.
- Browser E2E against local hosted-sites for `calendar-lite/release-readiness-plus-pm`, score JSON returned `score: 1` and `status: passed`.
