### PR TITLE
feat(benchmark): add hosted-web hard suite catalog (#108)

### DIFF
--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -10,6 +10,11 @@ export const benchmarkOptions: Array<{
     label: "Hosted Web Suite",
     description: "Versioned multi-session benchmark with deterministic tasks and server-side scoring.",
   },
+  {
+    value: "hosted-web-hard-suite",
+    label: "Hosted Web Hard Suite",
+    description: "Harder deterministic hosted-web benchmark with multi-step reasoning and cross-page state tasks.",
+  },
 ];
 
 export const docsBlocks = {

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -14,7 +14,7 @@ import {
   type HostedSessionBreakdown,
 } from "./hosted-scoring";
 
-export type PlaygroundBenchmark = "hosted-web-suite";
+export type PlaygroundBenchmark = "hosted-web-suite" | "hosted-web-hard-suite";
 
 export type RunPhase = "idle" | "booting" | "running" | "completed" | "failed";
 export type PanelTab = "events" | "files" | "screenshots" | "score";
@@ -76,6 +76,7 @@ type RunSnapshot = {
 
 const BENCHMARK_CASE_IDS: Record<PlaygroundBenchmark, string> = {
   "hosted-web-suite": "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",
+  "hosted-web-hard-suite": "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",
 };
 
 const initialState = {

--- a/packages/test-cases/src/index.ts
+++ b/packages/test-cases/src/index.ts
@@ -2,3 +2,4 @@ export * from "./app-definition.js";
 export * from "./generated-app-registry.js";
 export * from "./schemas.js";
 export * from "./suites/hosted-web.js";
+export * from "./suites/hosted-web-hard.js";

--- a/packages/test-cases/src/release.ts
+++ b/packages/test-cases/src/release.ts
@@ -1,5 +1,12 @@
 import { createHash } from "node:crypto";
-import { hostedWebSuiteCase, hostedWebSuiteMetadata, hostedWebSuiteRevision } from "./index.js";
+import {
+  hostedWebHardSuiteCase,
+  hostedWebHardSuiteMetadata,
+  hostedWebHardSuiteRevision,
+  hostedWebSuiteCase,
+  hostedWebSuiteMetadata,
+  hostedWebSuiteRevision,
+} from "./index.js";
 
 export function createHostedWebCatalogRelease() {
   const manifest = hostedWebSuiteMetadata;
@@ -7,6 +14,17 @@ export function createHostedWebCatalogRelease() {
     caseId: hostedWebSuiteCase.id,
     benchmarkCase: hostedWebSuiteCase,
     revision: hostedWebSuiteRevision,
+    manifest,
+    contentHash: createHash("sha256").update(JSON.stringify(manifest)).digest("hex"),
+  };
+}
+
+export function createHostedWebHardCatalogRelease() {
+  const manifest = hostedWebHardSuiteMetadata;
+  return {
+    caseId: hostedWebHardSuiteCase.id,
+    benchmarkCase: hostedWebHardSuiteCase,
+    revision: hostedWebHardSuiteRevision,
     manifest,
     contentHash: createHash("sha256").update(JSON.stringify(manifest)).digest("hex"),
   };

--- a/packages/test-cases/src/seed-sql.ts
+++ b/packages/test-cases/src/seed-sql.ts
@@ -1,16 +1,25 @@
-import { hostedWebSuiteCase } from "./index.js";
-import { createHostedWebCatalogRelease } from "./release.js";
+import { hostedWebHardSuiteCase, hostedWebSuiteCase } from "./index.js";
+import { createHostedWebCatalogRelease, createHostedWebHardCatalogRelease } from "./release.js";
 
 export function generateSupabaseSeedSql() {
-  const release = createHostedWebCatalogRelease();
-  const manifest = JSON.stringify(release.manifest, null, 2);
+  const easyRelease = createHostedWebCatalogRelease();
+  const easyManifest = JSON.stringify(easyRelease.manifest, null, 2);
+  const hardRelease = createHostedWebHardCatalogRelease();
+  const hardManifest = JSON.stringify(hardRelease.manifest, null, 2);
 
   return `-- Generated from packages/test-cases. Run \`pnpm catalog:generate\`; do not edit by hand.
 select public.publish_benchmark_case_catalog(
   $case$${JSON.stringify(hostedWebSuiteCase, null, 2)}$case$::jsonb,
-  '${release.revision}',
-  $catalog$${manifest}$catalog$::jsonb,
-  '${release.contentHash}'
+  '${easyRelease.revision}',
+  $catalog$${easyManifest}$catalog$::jsonb,
+  '${easyRelease.contentHash}'
+);
+
+select public.publish_benchmark_case_catalog(
+  $case$${JSON.stringify(hostedWebHardSuiteCase, null, 2)}$case$::jsonb,
+  '${hardRelease.revision}',
+  $catalog$${hardManifest}$catalog$::jsonb,
+  '${hardRelease.contentHash}'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -1,0 +1,117 @@
+import { hostedTestcaseApps } from "../generated-app-registry.js";
+import { hostedSuiteMetadataSchema } from "../schemas.js";
+
+// TODO(#110-#114): replace default/release/policy pools with hard-specific variant pools.
+// The hard suite currently reuses easy-suite pools as a placeholder while app hard variants are built.
+const shoppingQuestionVariants = hostedTestcaseApps["shopping-lite"].variantPools.default;
+const forumQuestionVariants = hostedTestcaseApps["forum-lite"].variantPools.default;
+const repoQuestionVariants = hostedTestcaseApps["repo-lite"].variantPools.default;
+const wikiReleaseQuestionVariants = hostedTestcaseApps["wiki-lite"].variantPools.release;
+const wikiPolicyQuestionVariants = hostedTestcaseApps["wiki-lite"].variantPools.policy;
+const notesQuestionVariants = hostedTestcaseApps["notes-lite"].variantPools.default;
+const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPools.default;
+
+export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
+  suiteSlug: "hosted-web-hard-suite-v1",
+  suiteVersion: "v1.0.0",
+  sessions: [
+    {
+      app: "shopping-lite",
+      taskSlug: "shopping-constrained-checkout-hard",
+      title: "Shopping Checkout (Hard)",
+      startPath: "/shopping",
+      taskVersion: "v2",
+      seedVersion: "shopping-lite-hard-v1",
+      sequenceIndex: 0,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: shoppingQuestionVariants },
+    },
+    {
+      app: "forum-lite",
+      taskSlug: "forum-battery-moderation-hard",
+      title: "Forum Moderation (Hard)",
+      startPath: "/forum",
+      taskVersion: "v2",
+      seedVersion: "forum-lite-hard-v1",
+      sequenceIndex: 1,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: forumQuestionVariants },
+    },
+    {
+      app: "repo-lite",
+      taskSlug: "repo-readme-fix-hard",
+      title: "Repository README Fix (Hard)",
+      startPath: "/repo",
+      taskVersion: "v2",
+      seedVersion: "repo-lite-hard-v1",
+      sequenceIndex: 2,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: repoQuestionVariants },
+    },
+    {
+      app: "wiki-lite",
+      taskSlug: "wiki-release-answer-hard",
+      title: "Wiki Release Lookup (Hard)",
+      startPath: "/wiki",
+      taskVersion: "v3",
+      seedVersion: "wiki-lite-hard-v1",
+      sequenceIndex: 3,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: wikiReleaseQuestionVariants },
+    },
+    {
+      app: "wiki-lite",
+      taskSlug: "wiki-policy-answer-hard",
+      title: "Wiki Policy Lookup (Hard)",
+      startPath: "/wiki",
+      taskVersion: "v2",
+      seedVersion: "wiki-lite-hard-v1",
+      sequenceIndex: 4,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: wikiPolicyQuestionVariants },
+    },
+    {
+      app: "notes-lite",
+      taskSlug: "notes-followup-create-hard",
+      title: "Notes Follow-up (Hard)",
+      startPath: "/notes",
+      taskVersion: "v2",
+      seedVersion: "notes-lite-hard-v1",
+      sequenceIndex: 5,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: notesQuestionVariants },
+    },
+    {
+      app: "calendar-lite",
+      taskSlug: "calendar-event-create-hard",
+      title: "Calendar Event (Hard)",
+      startPath: "/calendar",
+      taskVersion: "v2",
+      seedVersion: "calendar-lite-hard-v1",
+      sequenceIndex: 6,
+      weight: 1,
+      required: true,
+      metadata: { questionVariants: calendarQuestionVariants },
+    },
+  ],
+});
+
+export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.0";
+
+export const hostedWebHardSuiteCase = {
+  id: "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",
+  slug: "hosted-web-hard-suite",
+  title: "Hosted Web Hard Suite",
+  description: "Run the published deterministic hosted-web hard benchmark suite.",
+  category: "browser",
+  difficulty: "hard",
+  provider: "hosted-web" as const,
+  metadata: {},
+  isPublic: true,
+};

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { hostedSuiteMetadataSchema, hostedWebSuiteCase, hostedWebSuiteMetadata } from "../../src/index.js";
-import { createHostedWebCatalogRelease } from "../../src/release.js";
+import {
+  hostedSuiteMetadataSchema,
+  hostedWebHardSuiteCase,
+  hostedWebHardSuiteMetadata,
+  hostedWebSuiteCase,
+  hostedWebSuiteMetadata,
+} from "../../src/index.js";
+import { createHostedWebCatalogRelease, createHostedWebHardCatalogRelease } from "../../src/release.js";
 
 test("hosted catalog is valid and has unique app/task definitions", () => {
   assert.equal(hostedWebSuiteCase.slug, "hosted-web-suite");
@@ -30,4 +36,40 @@ test("hosted catalog release has a stable revision identity and content hash", (
   assert.equal(first.revision, "hosted-web-suite-v3.0.8");
   assert.match(first.contentHash, /^[0-9a-f]{64}$/);
   assert.deepEqual(second, first);
+});
+
+test("hosted hard catalog is valid and has unique app/task definitions", () => {
+  assert.equal(hostedWebHardSuiteCase.slug, "hosted-web-hard-suite");
+  assert.equal(hostedWebHardSuiteCase.difficulty, "hard");
+  assert.deepEqual(hostedWebHardSuiteCase.metadata, {});
+  const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
+  assert.ok(suite.sessions.length > 0);
+  assert.equal(new Set(suite.sessions.map((session) => session.taskSlug)).size, suite.sessions.length);
+  assert.ok(suite.sessions.every((session, index) => session.sequenceIndex === index));
+  assert.ok(suite.sessions.every((session) => session.metadata.questionVariants.length >= 2));
+});
+
+test("hosted hard catalog rejects cross-app task config", () => {
+  const invalid = structuredClone(hostedWebHardSuiteMetadata);
+  invalid.sessions[0]!.metadata.questionVariants[0]!.taskConfig = {
+    targetThreadId: "thr-battery",
+    expectedReplyValue: "https://example.com",
+    expectedLockReason: "wrong app",
+  } as never;
+  assert.throws(() => hostedSuiteMetadataSchema.parse(invalid));
+});
+
+test("hosted hard catalog release has a stable revision identity and content hash", () => {
+  const first = createHostedWebHardCatalogRelease();
+  const second = createHostedWebHardCatalogRelease();
+
+  assert.equal(first.revision, "hosted-web-hard-suite-v1.0.0");
+  assert.match(first.contentHash, /^[0-9a-f]{64}$/);
+  assert.deepEqual(second, first);
+});
+
+test("hosted easy and hard suite cases are distinct", () => {
+  assert.notEqual(hostedWebSuiteCase.id, hostedWebHardSuiteCase.id);
+  assert.notEqual(hostedWebSuiteCase.slug, hostedWebHardSuiteCase.slug);
+  assert.notEqual(hostedWebSuiteMetadata.suiteSlug, hostedWebHardSuiteMetadata.suiteSlug);
 });

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -595,6 +595,603 @@ select public.publish_benchmark_case_catalog(
   '7e4bc4d598f3240e29487673714fccee5eac5d8e97572806c3910cdd1852bf5f'
 );
 
+select public.publish_benchmark_case_catalog(
+  $case${
+  "id": "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",
+  "slug": "hosted-web-hard-suite",
+  "title": "Hosted Web Hard Suite",
+  "description": "Run the published deterministic hosted-web hard benchmark suite.",
+  "category": "browser",
+  "difficulty": "hard",
+  "provider": "hosted-web",
+  "metadata": {},
+  "isPublic": true
+}$case$::jsonb,
+  'hosted-web-hard-suite-v1.0.0',
+  $catalog${
+  "suiteSlug": "hosted-web-hard-suite-v1",
+  "suiteVersion": "v1.0.0",
+  "sessions": [
+    {
+      "app": "shopping-lite",
+      "taskSlug": "shopping-constrained-checkout-hard",
+      "title": "Shopping Checkout (Hard)",
+      "startPath": "/shopping",
+      "taskVersion": "v2",
+      "seedVersion": "shopping-lite-hard-v1",
+      "sequenceIndex": 0,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "budget-charger-standard",
+            "goal": "Buy exactly one charger with a total price at or below $30, use standard shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 1,
+              "maxTotal": 30,
+              "shippingMethod": "standard",
+              "avoidRestricted": true
+            }
+          },
+          {
+            "id": "cable-express",
+            "goal": "Buy exactly one USB-C cable with a total price at or below $10, use express shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "cable",
+              "quantity": 1,
+              "maxTotal": 10,
+              "shippingMethod": "express",
+              "avoidRestricted": true
+            }
+          },
+          {
+            "id": "travel-case-standard",
+            "goal": "Buy exactly one travel case with a total price at or below $15, use standard shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "case",
+              "quantity": 1,
+              "maxTotal": 15,
+              "shippingMethod": "standard",
+              "avoidRestricted": true
+            }
+          },
+          {
+            "id": "combo-charger-cable",
+            "goal": "Buy one charger and one USB-C cable with a total price at or below $35, use standard shipping, and avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 1,
+              "maxTotal": 35,
+              "shippingMethod": "standard",
+              "avoidRestricted": true,
+              "secondaryCategory": "cable",
+              "secondaryQuantity": 1
+            }
+          },
+          {
+            "id": "travel-kit-free-shipping",
+            "goal": "Buy one charger and one travel case with a total price at or below $40. Standard shipping is free for orders $35 and over; otherwise standard shipping costs $5. Avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 1,
+              "maxTotal": 40,
+              "shippingMethod": "standard",
+              "avoidRestricted": true,
+              "secondaryCategory": "case",
+              "secondaryQuantity": 1,
+              "freeShippingThreshold": 35,
+              "shippingCost": 5
+            }
+          },
+          {
+            "id": "cable-budget-shipping",
+            "goal": "Buy one USB-C cable and one travel case with a total price at or below $25. Standard shipping is free for orders $20 and over; otherwise standard shipping costs $4. Avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "cable",
+              "quantity": 1,
+              "maxTotal": 25,
+              "shippingMethod": "standard",
+              "avoidRestricted": true,
+              "secondaryCategory": "case",
+              "secondaryQuantity": 1,
+              "freeShippingThreshold": 20,
+              "shippingCost": 4
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "forum-lite",
+      "taskSlug": "forum-battery-moderation-hard",
+      "title": "Forum Moderation (Hard)",
+      "startPath": "/forum",
+      "taskVersion": "v2",
+      "seedVersion": "forum-lite-hard-v1",
+      "sequenceIndex": 1,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "battery-recall",
+            "goal": "Find the battery swelling thread, reply with the official recall link from the support post, then lock it with reason 'safety escalation'.",
+            "taskConfig": {
+              "targetThreadId": "thr-battery",
+              "expectedReplyValue": "https://support.example.com/recall/battery-2026",
+              "expectedLockReason": "safety escalation"
+            }
+          },
+          {
+            "id": "wifi-reset",
+            "goal": "Find the 5GHz connectivity thread, reply with the official reset-guide link from support, then lock it with reason 'resolved with guide'.",
+            "taskConfig": {
+              "targetThreadId": "thr-wifi",
+              "expectedReplyValue": "https://support.example.com/network/5ghz-reset",
+              "expectedLockReason": "resolved with guide"
+            }
+          },
+          {
+            "id": "screen-advisory",
+            "goal": "Find the low-brightness flickering thread, reply with the display calibration advisory link, then lock it with reason 'known display issue'.",
+            "taskConfig": {
+              "targetThreadId": "thr-screen",
+              "expectedReplyValue": "https://support.example.com/display/flicker-calibration",
+              "expectedLockReason": "known display issue"
+            }
+          },
+          {
+            "id": "battery-recall-pin",
+            "goal": "Find the battery swelling thread, reply with the official recall link from the support post, lock it with reason 'safety escalation', then pin it.",
+            "taskConfig": {
+              "targetThreadId": "thr-battery",
+              "expectedReplyValue": "https://support.example.com/recall/battery-2026",
+              "expectedLockReason": "safety escalation",
+              "requiresPin": true
+            }
+          },
+          {
+            "id": "wifi-reset-report",
+            "goal": "Find the 5GHz connectivity thread, submit a moderation report with reason 'needs escalation', then reply with the reset-guide link and lock it with reason 'resolved with guide'.",
+            "taskConfig": {
+              "targetThreadId": "thr-wifi",
+              "expectedReplyValue": "https://support.example.com/network/5ghz-reset",
+              "expectedLockReason": "resolved with guide",
+              "requiresReport": true,
+              "expectedReportReason": "needs escalation"
+            }
+          },
+          {
+            "id": "screen-advisory-both",
+            "goal": "Find the low-brightness flickering thread, submit a report with reason 'duplicate issue', reply with the display calibration advisory link, lock it with reason 'known display issue', then pin it.",
+            "taskConfig": {
+              "targetThreadId": "thr-screen",
+              "expectedReplyValue": "https://support.example.com/display/flicker-calibration",
+              "expectedLockReason": "known display issue",
+              "requiresPin": true,
+              "requiresReport": true,
+              "expectedReportReason": "duplicate issue"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "repo-lite",
+      "taskSlug": "repo-readme-fix-hard",
+      "title": "Repository README Fix (Hard)",
+      "startPath": "/repo",
+      "taskVersion": "v2",
+      "seedVersion": "repo-lite-hard-v1",
+      "sequenceIndex": 2,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "pnpm-install",
+            "goal": "Replace the README install command with `pnpm install`, remove `npm install`, then open a merge request titled `Fix install instructions` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "pnpm install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Fix install instructions",
+              "expectedTargetBranch": "main"
+            }
+          },
+          {
+            "id": "yarn-install",
+            "goal": "Replace the README install command with `yarn install`, remove `npm install`, then open a merge request titled `Document Yarn setup` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "yarn install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Document Yarn setup",
+              "expectedTargetBranch": "main"
+            }
+          },
+          {
+            "id": "bun-install",
+            "goal": "Replace the README install command with `bun install`, remove `npm install`, then open a merge request titled `Add Bun setup` targeting `develop`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "bun install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Add Bun setup",
+              "expectedTargetBranch": "develop"
+            }
+          },
+          {
+            "id": "pnpm-install-and-version",
+            "goal": "Replace the README install command with `pnpm install`, bump `package.json` version from `1.0.0` to `1.0.1`, then open a merge request titled `Fix install and bump version` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "pnpm install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Fix install and bump version",
+              "expectedTargetBranch": "main",
+              "secondaryFilePath": "package.json",
+              "secondaryExpectedText": "1.0.1",
+              "secondaryForbiddenText": "1.0.0"
+            }
+          },
+          {
+            "id": "yarn-install-and-rename",
+            "goal": "Replace the README install command with `yarn install`, rename the project in `package.json` from `demo-project` to `demo-yarn-project`, then open a merge request titled `Update README and rename project` targeting `main`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "yarn install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Update README and rename project",
+              "expectedTargetBranch": "main",
+              "secondaryFilePath": "package.json",
+              "secondaryExpectedText": "demo-yarn-project",
+              "secondaryForbiddenText": "demo-project"
+            }
+          },
+          {
+            "id": "bun-install-and-script",
+            "goal": "Replace the README install command with `bun install`, add a `test` script to `package.json`, then open a merge request titled `Add Bun and test script` targeting `develop`.",
+            "taskConfig": {
+              "filePath": "README.md",
+              "expectedText": "bun install",
+              "forbiddenText": "npm install",
+              "expectedMrTitle": "Add Bun and test script",
+              "expectedTargetBranch": "develop",
+              "secondaryFilePath": "package.json",
+              "secondaryExpectedText": "test"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "wiki-lite",
+      "taskSlug": "wiki-release-answer-hard",
+      "title": "Wiki Release Lookup (Hard)",
+      "startPath": "/wiki",
+      "taskVersion": "v3",
+      "seedVersion": "wiki-lite-hard-v1",
+      "sequenceIndex": 3,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "release-date",
+            "goal": "Use the hosted wiki to find when wiki-lite followed the hosted-web suite alpha, then submit only the date.",
+            "taskConfig": {
+              "targetArticleSlug": "agentbench-release-history",
+              "answerContract": {
+                "kind": "date",
+                "canonicalValue": "June 1, 2026",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "agentbench-release-history"
+              }
+            }
+          },
+          {
+            "id": "dispatch-window",
+            "goal": "Use the hosted wiki to find how quickly standard shipping orders are dispatched, then submit only the duration without surrounding words.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "duration",
+                "canonicalValue": "two business days",
+                "normalization": "trim-casefold",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          },
+          {
+            "id": "charger-price",
+            "goal": "Use the hosted wiki to find the listed price of the recommended budget USB-C charger, then submit only the exact price.",
+            "taskConfig": {
+              "targetArticleSlug": "usb-c-charger-faq",
+              "answerContract": {
+                "kind": "currency",
+                "canonicalValue": "$24.99",
+                "normalization": "trim",
+                "sourceArticleSlug": "usb-c-charger-faq"
+              }
+            }
+          },
+          {
+            "id": "release-to-charger-price",
+            "goal": "The release history article references the USB-C Charger FAQ for recommended accessories. Open both articles and submit the exact price of the recommended budget charger.",
+            "taskConfig": {
+              "targetArticleSlug": "usb-c-charger-faq",
+              "secondaryArticleSlug": "agentbench-release-history",
+              "answerContract": {
+                "kind": "currency",
+                "canonicalValue": "$24.99",
+                "normalization": "trim",
+                "sourceArticleSlug": "usb-c-charger-faq"
+              }
+            }
+          },
+          {
+            "id": "dispatch-with-adapters",
+            "goal": "The power adapter safety article references the shipping policy for dispatch timing. Open both articles and submit the standard shipping dispatch window.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "secondaryArticleSlug": "power-adapters",
+              "answerContract": {
+                "kind": "duration",
+                "canonicalValue": "two business days",
+                "normalization": "trim-casefold",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "wiki-lite",
+      "taskSlug": "wiki-policy-answer-hard",
+      "title": "Wiki Policy Lookup (Hard)",
+      "startPath": "/wiki",
+      "taskVersion": "v2",
+      "seedVersion": "wiki-lite-hard-v1",
+      "sequenceIndex": 4,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "adapter-restriction",
+            "goal": "Use the hosted wiki to find who restricted lab power adapters are reserved for, then submit only the group name.",
+            "taskConfig": {
+              "targetArticleSlug": "power-adapters",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "internal certification teams",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "power-adapters"
+              }
+            }
+          },
+          {
+            "id": "standard-dispatch",
+            "goal": "Use the hosted wiki to find the standard shipping dispatch window, then submit only the duration.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "duration",
+                "canonicalValue": "two business days",
+                "normalization": "trim-casefold",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          },
+          {
+            "id": "express-cutoff",
+            "goal": "Use the hosted wiki to find the express order same-day shipping cutoff time, then submit only the time.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "3pm",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          },
+          {
+            "id": "adapter-to-shipping",
+            "goal": "The shipping policy references the power adapter safety article for restricted equipment rules. Open both articles and submit who restricted lab power adapters are reserved for.",
+            "taskConfig": {
+              "targetArticleSlug": "power-adapters",
+              "secondaryArticleSlug": "shipping-policy",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "internal certification teams",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "power-adapters"
+              }
+            }
+          },
+          {
+            "id": "express-to-history",
+            "goal": "The release history article references the shipping policy for delivery details. Open both articles and submit the express order same-day shipping cutoff time.",
+            "taskConfig": {
+              "targetArticleSlug": "shipping-policy",
+              "secondaryArticleSlug": "agentbench-release-history",
+              "answerContract": {
+                "kind": "text",
+                "canonicalValue": "3pm",
+                "normalization": "trim-casefold-punctuation",
+                "sourceArticleSlug": "shipping-policy"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "notes-lite",
+      "taskSlug": "notes-followup-create-hard",
+      "title": "Notes Follow-up (Hard)",
+      "startPath": "/notes",
+      "taskVersion": "v2",
+      "seedVersion": "notes-lite-hard-v1",
+      "sequenceIndex": 5,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "support-followup",
+            "goal": "Create a follow-up note titled 'Support follow-up' with body 'Email Mira after the replacement adapter ships.' and tag 'support'.",
+            "taskConfig": {
+              "expectedTitle": "Support follow-up",
+              "expectedBody": "Email Mira after the replacement adapter ships.",
+              "expectedTag": "support"
+            }
+          },
+          {
+            "id": "release-note",
+            "goal": "Create a follow-up note titled 'Release reminder' with body 'Confirm the hosted-web v3.0.1 smoke run before publishing notes.' and tag 'release'.",
+            "taskConfig": {
+              "expectedTitle": "Release reminder",
+              "expectedBody": "Confirm the hosted-web v3.0.1 smoke run before publishing notes.",
+              "expectedTag": "release"
+            }
+          },
+          {
+            "id": "ops-check",
+            "goal": "Create a follow-up note titled 'Ops check' with body 'Review Redis health metrics after the next hosted suite run.' and tag 'ops'.",
+            "taskConfig": {
+              "expectedTitle": "Ops check",
+              "expectedBody": "Review Redis health metrics after the next hosted suite run.",
+              "expectedTag": "ops"
+            }
+          },
+          {
+            "id": "update-support-followup",
+            "goal": "Update the seeded note titled 'Old support follow-up' to title 'Support follow-up', body 'Email Mira after the replacement adapter ships.', and tag 'support'.",
+            "taskConfig": {
+              "expectedTitle": "Support follow-up",
+              "expectedBody": "Email Mira after the replacement adapter ships.",
+              "expectedTag": "support",
+              "targetNoteId": "note-seed-support"
+            }
+          },
+          {
+            "id": "update-release-note",
+            "goal": "Update the seeded note titled 'Old release reminder' to title 'Release reminder', body 'Confirm the hosted-web v3.0.1 smoke run before publishing notes.', and tag 'release'.",
+            "taskConfig": {
+              "expectedTitle": "Release reminder",
+              "expectedBody": "Confirm the hosted-web v3.0.1 smoke run before publishing notes.",
+              "expectedTag": "release",
+              "targetNoteId": "note-seed-release"
+            }
+          },
+          {
+            "id": "update-ops-check",
+            "goal": "Update the seeded note titled 'Old ops check' to title 'Ops check', body 'Review Redis health metrics after the next hosted suite run.', and tag 'ops'.",
+            "taskConfig": {
+              "expectedTitle": "Ops check",
+              "expectedBody": "Review Redis health metrics after the next hosted suite run.",
+              "expectedTag": "ops",
+              "targetNoteId": "note-seed-ops"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "app": "calendar-lite",
+      "taskSlug": "calendar-event-create-hard",
+      "title": "Calendar Event (Hard)",
+      "startPath": "/calendar",
+      "taskVersion": "v2",
+      "seedVersion": "calendar-lite-hard-v1",
+      "sequenceIndex": 6,
+      "weight": 1,
+      "required": true,
+      "metadata": {
+        "questionVariants": [
+          {
+            "id": "architecture-review",
+            "goal": "Create an event titled 'Architecture review' on July 8, 2026 at 14:30 for 45 minutes with attendee mira@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Architecture review",
+              "expectedDate": "2026-07-08",
+              "expectedStartTime": "14:30",
+              "expectedDurationMinutes": 45,
+              "expectedAttendeeEmail": "mira@example.com"
+            }
+          },
+          {
+            "id": "release-readiness",
+            "goal": "Create an event titled 'Release readiness' on July 10, 2026 at 09:00 for 30 minutes with attendee ops@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Release readiness",
+              "expectedDate": "2026-07-10",
+              "expectedStartTime": "09:00",
+              "expectedDurationMinutes": 30,
+              "expectedAttendeeEmail": "ops@example.com"
+            }
+          },
+          {
+            "id": "scoring-retro",
+            "goal": "Create an event titled 'Scoring retrospective' on July 14, 2026 at 16:00 for 60 minutes with attendee evals@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Scoring retrospective",
+              "expectedDate": "2026-07-14",
+              "expectedStartTime": "16:00",
+              "expectedDurationMinutes": 60,
+              "expectedAttendeeEmail": "evals@example.com"
+            }
+          },
+          {
+            "id": "architecture-review-plus-lead",
+            "goal": "Create an event titled 'Architecture review' on July 8, 2026 at 14:30 for 45 minutes with attendees mira@example.com and lead@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Architecture review",
+              "expectedDate": "2026-07-08",
+              "expectedStartTime": "14:30",
+              "expectedDurationMinutes": 45,
+              "expectedAttendeeEmail": "mira@example.com",
+              "expectedSecondaryAttendeeEmail": "lead@example.com"
+            }
+          },
+          {
+            "id": "release-readiness-plus-pm",
+            "goal": "Create an event titled 'Release readiness' on July 10, 2026 at 09:00 for 30 minutes with attendees ops@example.com and pm@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Release readiness",
+              "expectedDate": "2026-07-10",
+              "expectedStartTime": "09:00",
+              "expectedDurationMinutes": 30,
+              "expectedAttendeeEmail": "ops@example.com",
+              "expectedSecondaryAttendeeEmail": "pm@example.com"
+            }
+          },
+          {
+            "id": "scoring-retro-plus-analyst",
+            "goal": "Create an event titled 'Scoring retrospective' on July 14, 2026 at 16:00 for 60 minutes with attendees evals@example.com and analyst@example.com.",
+            "taskConfig": {
+              "expectedTitle": "Scoring retrospective",
+              "expectedDate": "2026-07-14",
+              "expectedStartTime": "16:00",
+              "expectedDurationMinutes": 60,
+              "expectedAttendeeEmail": "evals@example.com",
+              "expectedSecondaryAttendeeEmail": "analyst@example.com"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}$catalog$::jsonb,
+  '0cc0241a41f0dc4355f1e7de9ed96b1e8264278105d0bf5a1f76188940c4c9b2'
+);
+
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)
 values (
   '7e8a6df3-17c3-4ddb-9877-d0bd8a0f1001',


### PR DESCRIPTION
Closes #108.

## Summary

Adds a separate hard hosted-web benchmark suite catalog while preserving the existing easy `hosted-web-suite` as the baseline.

## Changes

- New `packages/test-cases/src/suites/hosted-web-hard.ts` with:
  - Case UUID `bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb`
  - Slug `hosted-web-hard-suite`
  - Suite version `v1.0.0` / revision `hosted-web-hard-suite-v1.0.0`
  - Hard-identifying `taskSlug` and `seedVersion` values for every app session
  - Existing app variant pools reused temporarily behind `TODO(#110-#114)` comments
- Exported from `packages/test-cases/src/index.ts`.
- Added `createHostedWebHardCatalogRelease()` in `packages/test-cases/src/release.ts`.
- Updated `packages/test-cases/src/seed-sql.ts` to publish both easy and hard benchmark cases.
- Updated Web playground selector (`apps/web/lib/playground-store.ts` and `apps/web/components/landing/data.ts`) with a distinct "Hosted Web Hard Suite" option.
- Added unit tests validating the hard suite schema, release stability, and distinct identity from the easy suite.
- Regenerated `supabase/seed.sql`.

## Verification

- `pnpm catalog:check` — passed
- `pnpm --filter @agentbench/test-cases test` — 8/8 passed
- `pnpm --filter web test` — 28/28 passed
- `pnpm --filter hosted-sites test` — 143/143 passed
- `pnpm --filter hosted-orchestrator test` — 42/42 passed
- `pnpm --filter @agentbench/scoring test` — 5/5 passed
- `pnpm verify:ci` — passed

## Related

- Parent roadmap: #107
- Next: #109 scorer-oracle gating, then #110-#114 app hard variants
