### PR TITLE
feat(hosted-sites): gate scorer oracle surfaces for public sessions (#109)

### DIFF
--- a/apps/hosted-sites/src/apps/forum-lite/render.ts
+++ b/apps/hosted-sites/src/apps/forum-lite/render.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { ForumThread } from "./types.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
+import { shouldRenderScorePreview } from "../../runtime/score-preview-policy.js";
 
 type ForumSession = HostedSessionFor<"forum-lite">;
 import { escapeHtml, layout, sendHtml } from "../../templates.js";
@@ -127,6 +128,13 @@ export function renderThread(
     : "";
 
 
+  const scorePreview = shouldRenderScorePreview(session)
+    ? `<section class="panel" style="margin-top:16px;">
+        <h2>Evaluator preview</h2>
+        <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
+      </section>`
+    : "";
+
   sendHtml(
     response,
     200,
@@ -146,10 +154,7 @@ export function renderThread(
         ${lockForm}
         ${pinForm}
         ${moderationLogSection}
-        <section class="panel" style="margin-top:16px;">
-          <h2>Evaluator preview</h2>
-          <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
-        </section>`,
+        ${scorePreview}`,
       publicBaseUrl,
       defaultStartPathForApp,
     }),

--- a/apps/hosted-sites/src/apps/notes-lite/render.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/render.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { Note } from "./types.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
+import { shouldRenderScorePreview } from "../../runtime/score-preview-policy.js";
 import { escapeHtml, layout, sendHtml } from "../../templates.js";
 
 type NotesSession = HostedSessionFor<"notes-lite">;
@@ -24,6 +25,13 @@ export function renderNotesIndex(
         )
         .join("")
     : `<article class="card"><p class="muted">No notes have been created yet.</p></article>`;
+
+  const scorePreview = shouldRenderScorePreview(session)
+    ? `<section class="panel" style="margin-top:16px;">
+          <h2>Evaluator preview</h2>
+          <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
+        </section>`
+    : "";
 
   sendHtml(
     response,
@@ -51,10 +59,7 @@ export function renderNotesIndex(
           </form>
         </section>
         <section class="grid" style="margin-top:16px;">${notesHtml}</section>
-        <section class="panel" style="margin-top:16px;">
-          <h2>Evaluator preview</h2>
-          <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
-        </section>`,
+        ${scorePreview}`,
       publicBaseUrl,
       defaultStartPathForApp,
     }),

--- a/apps/hosted-sites/src/apps/repo-lite/render.ts
+++ b/apps/hosted-sites/src/apps/repo-lite/render.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { RepoFile, RepoMergeRequest } from "./types.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
+import { shouldRenderScorePreview } from "../../runtime/score-preview-policy.js";
 
 type RepoSession = HostedSessionFor<"repo-lite">;
 import { escapeHtml, layout, sendHtml } from "../../templates.js";
@@ -148,6 +149,11 @@ export function renderMRDetail(
     )
     .join("");
 
+  const scorePreview = shouldRenderScorePreview(session)
+    ? `<h3 style="margin-top:16px;">Evaluator preview</h3>
+        <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>`
+    : "";
+
   sendHtml(
     response,
     200,
@@ -159,8 +165,7 @@ export function renderMRDetail(
         <p class="muted">Target branch: <strong>${escapeHtml(mr.targetBranch)}</strong></p>
         <h3>Changed files</h3>
         ${changedFilesHtml}
-        <h3 style="margin-top:16px;">Evaluator preview</h3>
-        <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
+        ${scorePreview}
       </section>`,
       publicBaseUrl,
       defaultStartPathForApp,

--- a/apps/hosted-sites/src/apps/shopping-lite/render.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/render.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { Order } from "./types.js";
 import type { HostedSessionFor } from "../../runtime/types.js";
+import { shouldRenderScorePreview } from "../../runtime/score-preview-policy.js";
 
 type ShoppingSession = HostedSessionFor<"shopping-lite">;
 import { getCartRows, getCartTotal } from "./actions.js";
@@ -144,6 +145,11 @@ export function renderOrder(
     shippingDetail += " (free)";
   }
 
+  const scorePreview = shouldRenderScorePreview(session)
+    ? `<h2>Evaluator preview</h2>
+        <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>`
+    : "";
+
   sendHtml(
     response,
     200,
@@ -155,8 +161,7 @@ export function renderOrder(
         <p>Order id: <strong>${escapeHtml(order.id)}</strong></p>
         <p>Total: <strong>${money(order.total)}</strong></p>
         <p>Shipping: <strong>${shippingDetail}</strong></p>
-        <h2>Evaluator preview</h2>
-        <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>
+        ${scorePreview}
       </section>`,
       publicBaseUrl,
       defaultStartPathForApp,

--- a/apps/hosted-sites/src/routes/api.ts
+++ b/apps/hosted-sites/src/routes/api.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HostedWebScoreResult } from "@agentbench/scoring";
 import type { HostedSession } from "../runtime/types.js";
 import { sendJson } from "../runtime/http.js";
+import { isActiveScoreApiAllowed } from "../runtime/score-preview-policy.js";
 
 function sanitizeTelemetryUrl(value: unknown, publicBaseUrl: string) {
   if (typeof value !== "string") {
@@ -170,6 +171,10 @@ export function createApiRoutes(deps: ApiRoutesDeps) {
       const session = await deps.getSessionByToken(token, request);
       if (!session) {
         deps.notFound(response);
+        return true;
+      }
+      if (!isActiveScoreApiAllowed(session)) {
+        sendJson(response, 403, { error: "Score preview is not available for this session." });
         return true;
       }
       sendJson(response, 200, await deps.resolveSessionResult(session));

--- a/apps/hosted-sites/src/runtime/score-preview-policy.ts
+++ b/apps/hosted-sites/src/runtime/score-preview-policy.ts
@@ -1,0 +1,53 @@
+import type { HostedSession } from "./types.js";
+import { isTerminalHostedSessionStatus } from "./types.js";
+import type { HostedWebScoreResult } from "@agentbench/scoring";
+
+export type ScorePreviewMode = "disabled" | "dev" | "token";
+
+export function parseScorePreviewMode(value: string | undefined): ScorePreviewMode {
+  if (value === "disabled" || value === "token") {
+    return value;
+  }
+  return "dev";
+}
+
+export function isScorePreviewAllowed(session: HostedSession): boolean {
+  const mode = session.scorePreviewMode ?? "dev";
+  if (mode === "dev") {
+    return true;
+  }
+  if (mode === "disabled") {
+    return false;
+  }
+  return session.accessMode === "viewer";
+}
+
+export function isActiveScoreApiAllowed(session: HostedSession): boolean {
+  if (isTerminalHostedSessionStatus(session.status)) {
+    return true;
+  }
+  return isScorePreviewAllowed(session);
+}
+
+export function shouldRenderScorePreview(session: HostedSession): boolean {
+  if (isTerminalHostedSessionStatus(session.status)) {
+    return true;
+  }
+  return isScorePreviewAllowed(session);
+}
+
+export function sanitizeScoreResult(
+  result: HostedWebScoreResult,
+  session: HostedSession,
+): HostedWebScoreResult {
+  if (isScorePreviewAllowed(session)) {
+    return result;
+  }
+  return {
+    ...result,
+    evaluators: result.evaluators.map((evaluator) => {
+      const { evidence: _evidence, ...redacted } = evaluator;
+      return redacted;
+    }),
+  };
+}

--- a/apps/hosted-sites/src/runtime/session-store.ts
+++ b/apps/hosted-sites/src/runtime/session-store.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import { verifyHostedViewerToken, type HostedWebSessionMetadata } from "@agentbench/shared";
+import type { ScorePreviewMode } from "./score-preview-policy.js";
 import type { SessionCache } from "./session-cache.js";
 import type { HostedAppPersistenceState, HostedAppSessionState, HostedSession } from "./types.js";
 
@@ -35,6 +36,7 @@ type SessionStoreDeps = {
   now: () => string;
   makeId: (prefix: string) => string;
   viewerTokenSecret?: string;
+  scorePreviewMode: ScorePreviewMode;
   recoverSession: (params: { token?: string; sessionId?: string }) => Promise<PersistedHostedSession | null>;
   persistSessionSnapshotDurably?: (
     session: HostedSession,
@@ -130,6 +132,7 @@ export function createSessionStore(deps: SessionStoreDeps) {
       suiteVersion: typeof metadata.suiteVersion === "string" ? metadata.suiteVersion : "v1",
       taskSlug: params.row.task_slug,
       taskVersion: params.row.task_version,
+      scorePreviewMode: deps.scorePreviewMode,
       sequenceIndex: params.row.sequence_index,
       weight: params.row.weight,
       required: params.row.required,
@@ -294,6 +297,7 @@ export function createSessionStore(deps: SessionStoreDeps) {
       suiteVersion: params.suiteVersion ?? "v1",
       taskSlug,
       taskVersion: params.taskVersion ?? "v1",
+      scorePreviewMode: deps.scorePreviewMode,
       sequenceIndex:
         typeof params.sequenceIndex === "number" && Number.isFinite(params.sequenceIndex)
           ? Math.max(Math.trunc(params.sequenceIndex), 0)
@@ -348,6 +352,7 @@ export function createSessionStore(deps: SessionStoreDeps) {
       try {
         const cached = await deps.sessionCache.get(token);
         if (cached) {
+          cached.scorePreviewMode = deps.scorePreviewMode;
           deps.sessions.set(token, cached);
           if (isExpired(cached) || cached.status === "expired") {
             await markSessionExpired(cached, request);

--- a/apps/hosted-sites/src/runtime/types.ts
+++ b/apps/hosted-sites/src/runtime/types.ts
@@ -24,6 +24,7 @@ type HostedSessionBase = {
   suiteVersion: string;
   taskSlug: string;
   taskVersion: string;
+  scorePreviewMode?: "disabled" | "dev" | "token";
   sequenceIndex: number;
   weight: number;
   required: boolean;

--- a/apps/hosted-sites/src/server.ts
+++ b/apps/hosted-sites/src/server.ts
@@ -26,6 +26,7 @@ import { createRedisSessionCache } from "./runtime/session-cache.js";
 import { createSessionStore } from "./runtime/session-store.js";
 import { createTelemetryRuntime } from "./runtime/telemetry.js";
 import { isHostedViewerMutation } from "./runtime/viewer-access.js";
+import { parseScorePreviewMode, sanitizeScoreResult } from "./runtime/score-preview-policy.js";
 
 const port = Number(process.env.HOSTED_SITES_PORT ?? 3003);
 const publicBaseUrl = process.env.HOSTED_SITES_PUBLIC_URL ?? `http://localhost:${port}`;
@@ -36,6 +37,7 @@ const viewerTokenSecret = process.env.HOSTED_VIEWER_SECRET ?? runnerSharedSecret
 const instanceId = process.env.HOSTED_SITES_INSTANCE_ID ?? `${hostname()}:${process.pid}`;
 const redisUrl = process.env.HOSTED_SESSION_REDIS_URL;
 const sessionRedisTtlMs = Number(process.env.HOSTED_SESSION_REDIS_TTL_MS ?? 1000 * 60 * 60 * 6);
+const scorePreviewMode = parseScorePreviewMode(process.env.HOSTED_SCORE_PREVIEW_MODE);
 
 const sessions = new Map<string, HostedSession>();
 const sessionCache = redisUrl
@@ -79,6 +81,7 @@ const sessionStore = createSessionStore({
   now,
   makeId,
   viewerTokenSecret,
+  scorePreviewMode,
   recoverSession: orchestratorClient.recoverSession,
   persistSessionSnapshotDurably: orchestratorClient.persistSessionSnapshot,
   persistSessionAccess: orchestratorClient.recordSessionAccess,
@@ -120,11 +123,11 @@ async function resolveSessionResult(session: HostedSession) {
   if (isTerminalHostedSessionStatus(session.status)) {
     const persistedResult = await getSessionResultViaOrchestrator(session);
     if (persistedResult) {
-      return persistedResult;
+      return sanitizeScoreResult(persistedResult, session);
     }
     throw new Error("Persisted terminal session result is unavailable.");
   }
-  return evaluateSession(session);
+  return sanitizeScoreResult(evaluateSession(session), session);
 }
 
 function rejectTerminalMutation(session: HostedSession, response: ServerResponse) {

--- a/apps/hosted-sites/src/templates.ts
+++ b/apps/hosted-sites/src/templates.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { HostedSession } from "./runtime/types.js";
 import { readUiTheme, readUiVariant } from "./runtime/question-config.js";
+import { shouldRenderScorePreview } from "./runtime/score-preview-policy.js";
 
 export function escapeHtml(value: string) {
   return value
@@ -343,7 +344,7 @@ export function layout(params: {
       </div>
       <nav class="nav">
         ${appNav}
-        <a href="/api/sessions/${encodeURIComponent(params.session.token)}/score">Score JSON</a>
+        ${shouldRenderScorePreview(params.session) ? `<a href="/api/sessions/${encodeURIComponent(params.session.token)}/score">Score JSON</a>` : ""}
       </nav>
     </header>
     <main>${params.body}</main>

--- a/apps/hosted-sites/tests/unit/app-registry.test.ts
+++ b/apps/hosted-sites/tests/unit/app-registry.test.ts
@@ -44,6 +44,7 @@ function makeSession<TApp extends HostedAppId>(app: TApp): HostedSessionFor<TApp
     suiteVersion: "v1",
     taskSlug: `${app}-task`,
     taskVersion: "v1",
+    scorePreviewMode: "dev",
     sequenceIndex: 0,
     weight: 1,
     required: true,

--- a/apps/hosted-sites/tests/unit/routes/api.test.ts
+++ b/apps/hosted-sites/tests/unit/routes/api.test.ts
@@ -22,6 +22,7 @@ function makeSession(accessMode: "write" | "viewer" = "write"): HostedSession {
     suiteVersion: "v1",
     taskSlug: "shopping-lite-task",
     taskVersion: "v1",
+    scorePreviewMode: "dev",
     sequenceIndex: 0,
     weight: 1,
     required: true,
@@ -63,6 +64,7 @@ async function withApiServer<T>(
   handler: (baseUrl: string) => Promise<T>,
   accessMode: "write" | "viewer" = "write",
   status: HostedSession["status"] = "active",
+  scorePreviewMode: HostedSession["scorePreviewMode"] = "dev",
 ) {
   const requestedTokens: string[] = [];
   const completedSessions: string[] = [];
@@ -70,6 +72,7 @@ async function withApiServer<T>(
   const recordedEvents: string[] = [];
   const session = makeSession(accessMode);
   session.status = status;
+  session.scorePreviewMode = scorePreviewMode;
   const persistedResult = {
     status: "failed" as const,
     score: 0,
@@ -286,4 +289,55 @@ test("viewer token in complete route cannot complete a session", async () => {
   assert.equal(result.body.error, "Viewer sessions are read-only");
   assert.deepEqual(requestedTokens, ["tok_1"]);
   assert.deepEqual(completedSessions, []);
+});
+
+test("score route denies active sessions when score preview is disabled", async () => {
+  const { result } = await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/sessions/tok_1/score`);
+    return {
+      status: response.status,
+      body: (await response.json()) as Record<string, unknown>,
+    };
+  }, "write", "active", "disabled");
+
+  assert.equal(result.status, 403);
+  assert.equal(result.body.error, "Score preview is not available for this session.");
+});
+
+test("score route denies active write sessions in token mode", async () => {
+  const { result } = await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/sessions/tok_1/score`);
+    return {
+      status: response.status,
+      body: (await response.json()) as Record<string, unknown>,
+    };
+  }, "write", "active", "token");
+
+  assert.equal(result.status, 403);
+});
+
+test("score route allows active viewer sessions in token mode", async () => {
+  const { result } = await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/sessions/tok_1/score`);
+    return {
+      status: response.status,
+      body: (await response.json()) as Record<string, unknown>,
+    };
+  }, "viewer", "active", "token");
+
+  assert.equal(result.status, 200);
+  assert.equal(typeof result.body.score, "number");
+});
+
+test("score route allows terminal sessions even when score preview is disabled", async () => {
+  const { result } = await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/sessions/tok_1/score`);
+    return {
+      status: response.status,
+      body: (await response.json()) as Record<string, unknown>,
+    };
+  }, "write", "completed", "disabled");
+
+  assert.equal(result.status, 200);
+  assert.equal(result.body.summary, "first persisted result");
 });

--- a/apps/hosted-sites/tests/unit/runtime/score-preview-policy.test.ts
+++ b/apps/hosted-sites/tests/unit/runtime/score-preview-policy.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { HostedSession } from "../../../src/runtime/types.js";
+import {
+  isActiveScoreApiAllowed,
+  isScorePreviewAllowed,
+  parseScorePreviewMode,
+  sanitizeScoreResult,
+  shouldRenderScorePreview,
+} from "../../../src/runtime/score-preview-policy.js";
+
+function makeSession(overrides?: Partial<HostedSession>): HostedSession {
+  return {
+    id: "session-1",
+    token: "tok_1",
+    accessMode: "write",
+    runId: "run-1",
+    caseId: "case-1",
+    attemptId: "attempt-1",
+    callbackSecret: null,
+    app: "shopping-lite",
+    suiteSlug: "hosted-web-suite-v1",
+    suiteVersion: "v1",
+    taskSlug: "shopping-constrained-checkout",
+    taskVersion: "v1",
+    scorePreviewMode: "dev",
+    sequenceIndex: 0,
+    weight: 1,
+    required: true,
+    title: "Shopping Checkout",
+    goal: "Buy a charger",
+    startPath: "/shopping",
+    seedVersion: "shopping-lite-v1",
+    metadata: {},
+    status: "active",
+    expiresAt: null,
+    accessCount: 0,
+    lastAccessedAt: null,
+    firstSeenIp: null,
+    lastSeenIp: null,
+    firstSeenUserAgent: null,
+    lastSeenUserAgent: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    events: [],
+    state: { products: [], cart: [], orders: [] },
+    persisted: false,
+    ...overrides,
+  } as unknown as HostedSession;
+}
+
+function makeResult() {
+  return {
+    score: 1,
+    status: "passed" as const,
+    summary: "ok",
+    evaluators: [
+      {
+        type: "backend_state" as const,
+        name: "order persisted",
+        score: 1,
+        status: "passed" as const,
+        required: true,
+        evidence: { orderId: "order-1", secret: "should-be-redacted" },
+      },
+      {
+        type: "retrieve_value" as const,
+        name: "answer",
+        score: 1,
+        status: "passed" as const,
+        required: true,
+        evidence: { expectedAnswer: "42" },
+      },
+    ],
+  };
+}
+
+test("parseScorePreviewMode defaults to dev", () => {
+  assert.equal(parseScorePreviewMode(undefined), "dev");
+  assert.equal(parseScorePreviewMode(""), "dev");
+  assert.equal(parseScorePreviewMode("invalid"), "dev");
+});
+
+test("parseScorePreviewMode accepts disabled and token", () => {
+  assert.equal(parseScorePreviewMode("disabled"), "disabled");
+  assert.equal(parseScorePreviewMode("token"), "token");
+});
+
+test("isScorePreviewAllowed is true in dev mode", () => {
+  assert.equal(isScorePreviewAllowed(makeSession({ scorePreviewMode: "dev", accessMode: "write" })), true);
+  assert.equal(isScorePreviewAllowed(makeSession({ scorePreviewMode: "dev", accessMode: "viewer" })), true);
+});
+
+test("isScorePreviewAllowed is false in disabled mode", () => {
+  assert.equal(isScorePreviewAllowed(makeSession({ scorePreviewMode: "disabled", accessMode: "write" })), false);
+  assert.equal(isScorePreviewAllowed(makeSession({ scorePreviewMode: "disabled", accessMode: "viewer" })), false);
+});
+
+test("isScorePreviewAllowed is true in token mode only for viewer sessions", () => {
+  assert.equal(isScorePreviewAllowed(makeSession({ scorePreviewMode: "token", accessMode: "write" })), false);
+  assert.equal(isScorePreviewAllowed(makeSession({ scorePreviewMode: "token", accessMode: "viewer" })), true);
+});
+
+test("isActiveScoreApiAllowed is true for terminal sessions regardless of mode", () => {
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "disabled", status: "completed" })), true);
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "disabled", status: "failed" })), true);
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "disabled", status: "expired" })), true);
+});
+
+test("isActiveScoreApiAllowed follows isScorePreviewAllowed for active sessions", () => {
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "dev" })), true);
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "disabled" })), false);
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "token", accessMode: "write" })), false);
+  assert.equal(isActiveScoreApiAllowed(makeSession({ scorePreviewMode: "token", accessMode: "viewer" })), true);
+});
+
+test("shouldRenderScorePreview is true for terminal sessions regardless of mode", () => {
+  assert.equal(shouldRenderScorePreview(makeSession({ scorePreviewMode: "disabled", status: "completed" })), true);
+  assert.equal(shouldRenderScorePreview(makeSession({ scorePreviewMode: "disabled", status: "failed" })), true);
+});
+
+test("shouldRenderScorePreview follows isScorePreviewAllowed for active sessions", () => {
+  assert.equal(shouldRenderScorePreview(makeSession({ scorePreviewMode: "dev" })), true);
+  assert.equal(shouldRenderScorePreview(makeSession({ scorePreviewMode: "disabled" })), false);
+  assert.equal(shouldRenderScorePreview(makeSession({ scorePreviewMode: "token", accessMode: "write" })), false);
+  assert.equal(shouldRenderScorePreview(makeSession({ scorePreviewMode: "token", accessMode: "viewer" })), true);
+});
+
+test("sanitizeScoreResult returns full result when preview is allowed", () => {
+  const session = makeSession({ scorePreviewMode: "dev" });
+  const result = makeResult();
+  const sanitized = sanitizeScoreResult(result, session);
+  assert.deepEqual(sanitized, result);
+  assert.ok("evidence" in sanitized.evaluators[0]!);
+});
+
+test("sanitizeScoreResult redacts evidence when preview is not allowed", () => {
+  const session = makeSession({ scorePreviewMode: "disabled" });
+  const result = makeResult();
+  const sanitized = sanitizeScoreResult(result, session);
+  assert.equal(sanitized.score, result.score);
+  assert.equal(sanitized.status, result.status);
+  assert.equal(sanitized.summary, result.summary);
+  assert.equal(sanitized.evaluators.length, result.evaluators.length);
+  for (const evaluator of sanitized.evaluators) {
+    assert.equal("evidence" in evaluator, false);
+    assert.equal(typeof evaluator.name, "string");
+    assert.equal(typeof evaluator.status, "string");
+  }
+});
+
+test("sanitizeScoreResult redacts evidence in token mode for non-viewer sessions", () => {
+  const session = makeSession({ scorePreviewMode: "token", accessMode: "write" });
+  const result = makeResult();
+  const sanitized = sanitizeScoreResult(result, session);
+  assert.equal("evidence" in sanitized.evaluators[0]!, false);
+});
+
+test("sanitizeScoreResult returns full result in token mode for viewer sessions", () => {
+  const session = makeSession({ scorePreviewMode: "token", accessMode: "viewer" });
+  const result = makeResult();
+  const sanitized = sanitizeScoreResult(result, session);
+  assert.deepEqual(sanitized, result);
+});
+
+test("sanitizeScoreResult defaults to dev when mode is missing", () => {
+  const session = makeSession({ scorePreviewMode: undefined });
+  const result = makeResult();
+  const sanitized = sanitizeScoreResult(result, session);
+  assert.deepEqual(sanitized, result);
+});

--- a/apps/hosted-sites/tests/unit/runtime/session-store.test.ts
+++ b/apps/hosted-sites/tests/unit/runtime/session-store.test.ts
@@ -40,6 +40,7 @@ function createStore(params: {
     publicBaseUrl: "http://localhost:3003",
     now: () => "2026-06-01T00:00:00.000Z",
     makeId: (prefix) => `${prefix}_1`,
+    scorePreviewMode: "dev",
     recoverSession: params.recoverSession ?? (async () => null),
     persistSessionSnapshotDurably: async () => undefined,
     persistSessionAccess: async () => undefined,

--- a/apps/hosted-sites/tests/unit/templates.test.ts
+++ b/apps/hosted-sites/tests/unit/templates.test.ts
@@ -6,12 +6,13 @@ import type { HostedSession } from "../../src/runtime/types.js";
 type UiVariant = "workspace" | "sidebar" | "compact" | "dashboard" | "editorial";
 type UiTheme = "light" | "dark";
 
-function makeSession(uiVariant: UiVariant, uiTheme: UiTheme) {
+function makeSession(uiVariant: UiVariant, uiTheme: UiTheme, scorePreviewMode: HostedSession["scorePreviewMode"] = "dev") {
   return {
     app: "wiki-lite",
     token: "tok_layout",
     taskSlug: "wiki-generated",
     goal: "Find and submit the requested value.",
+    scorePreviewMode,
     metadata: {
       questionGeneration: {
         schemaVersion: 1,
@@ -81,4 +82,70 @@ test("terminal layout disables forms and does not emit telemetry", () => {
   assert.match(html, /return to the AgentBench Connection Page to continue/);
   assert.match(html, /href="http:\/\/localhost:3000\/runs\/run-1\/connect"/);
   assert.doesNotMatch(html, /abTelemetry/);
+});
+
+test("layout renders Score JSON link in dev mode for active sessions", () => {
+  const html = layout({
+    title: "Dev preview",
+    session: makeSession("workspace", "light", "dev"),
+    body: '<section class="panel">Body</section>',
+    publicBaseUrl: "http://localhost:3003",
+    defaultStartPathForApp: () => "/wiki",
+  });
+
+  assert.match(html, /Score JSON/);
+  assert.match(html, /href="\/api\/sessions\/tok_layout\/score"/);
+});
+
+test("layout hides Score JSON link in disabled mode for active sessions", () => {
+  const html = layout({
+    title: "Disabled preview",
+    session: makeSession("workspace", "light", "disabled"),
+    body: '<section class="panel">Body</section>',
+    publicBaseUrl: "http://localhost:3003",
+    defaultStartPathForApp: () => "/wiki",
+  });
+
+  assert.doesNotMatch(html, /Score JSON/);
+  assert.doesNotMatch(html, /href="\/api\/sessions\/tok_layout\/score"/);
+});
+
+test("layout hides Score JSON link in token mode for non-viewer active sessions", () => {
+  const html = layout({
+    title: "Token preview",
+    session: makeSession("workspace", "light", "token"),
+    body: '<section class="panel">Body</section>',
+    publicBaseUrl: "http://localhost:3003",
+    defaultStartPathForApp: () => "/wiki",
+  });
+
+  assert.doesNotMatch(html, /Score JSON/);
+});
+
+test("layout renders Score JSON link in token mode for viewer sessions", () => {
+  const session = makeSession("workspace", "light", "token");
+  session.accessMode = "viewer";
+  const html = layout({
+    title: "Viewer preview",
+    session,
+    body: '<section class="panel">Body</section>',
+    publicBaseUrl: "http://localhost:3003",
+    defaultStartPathForApp: () => "/wiki",
+  });
+
+  assert.match(html, /Score JSON/);
+});
+
+test("layout renders Score JSON link for terminal sessions regardless of mode", () => {
+  const session = makeSession("workspace", "light", "disabled");
+  session.status = "failed";
+  const html = layout({
+    title: "Terminal disabled preview",
+    session,
+    body: '<section class="panel">Body</section>',
+    publicBaseUrl: "http://localhost:3003",
+    defaultStartPathForApp: () => "/wiki",
+  });
+
+  assert.match(html, /Score JSON/);
 });

--- a/tests/e2e/hosted-lifecycle-smoke.sh
+++ b/tests/e2e/hosted-lifecycle-smoke.sh
@@ -69,6 +69,7 @@ if [[ "${START_LOCAL_SERVICES}" == "true" ]]; then
   HOSTED_ORCHESTRATOR_URL="${ORCHESTRATOR_BASE_URL}" \
   AGENTBENCH_WEB_URL="${WEB_URL}" \
   RUNNER_SHARED_SECRET="${RUNNER_SHARED_SECRET}" \
+  HOSTED_SCORE_PREVIEW_MODE="dev" \
   pnpm --filter hosted-sites exec tsx src/server.ts >/tmp/agentbench-hosted-sites-smoke.log 2>&1 &
   HOSTED_PID=$!
 fi

--- a/tests/e2e/smoke-local.sh
+++ b/tests/e2e/smoke-local.sh
@@ -63,6 +63,7 @@ HOSTED_SITES_PUBLIC_URL="${HOSTED_URL}" \
 HOSTED_ORCHESTRATOR_URL="${ORCHESTRATOR_URL}" \
 RUNNER_SHARED_SECRET="${SECRET}" \
 HOSTED_SESSION_REDIS_URL="${REDIS_URL}" \
+HOSTED_SCORE_PREVIEW_MODE="dev" \
 pnpm --filter hosted-sites exec tsx src/server.ts >"${LOG_DIR}/hosted-sites.log" 2>&1 &
 HOSTED_PID=$!
 


### PR DESCRIPTION
Closes #109.

## Summary

Gates scorer oracle surfaces in hosted-sites using a single runtime policy controlled by `HOSTED_SCORE_PREVIEW_MODE=disabled|dev|token`.

## Changes

- New `apps/hosted-sites/src/runtime/score-preview-policy.ts` with:
  - `parseScorePreviewMode` (defaults to `"dev"`)
  - `isScorePreviewAllowed`
  - `isActiveScoreApiAllowed`
  - `shouldRenderScorePreview`
  - `sanitizeScoreResult` (redacts evaluator `evidence` when preview is restricted)
- Added `scorePreviewMode` to `HostedSessionBase` and wired it through `createSessionStore` so the current deployment mode is authoritative for created, hydrated, and cached sessions.
- `resolveSessionResult` now applies `sanitizeScoreResult`, so both HTML and JSON consumers receive appropriately redacted results.
- `/api/sessions/:token/score` returns 403 for active sessions when preview is disabled or in token mode without a viewer token.
- The shared layout conditionally renders the "Score JSON" link based on the policy.
- Forum, notes, shopping, and repo renderers conditionally render "Evaluator preview" blocks.
- Added `apps/hosted-sites/tests/unit/runtime/score-preview-policy.test.ts` and updated existing route/template tests.
- Explicitly set `HOSTED_SCORE_PREVIEW_MODE=dev` in `smoke-local.sh` and `hosted-lifecycle-smoke.sh`.

## Policy Behavior

| Session state | `disabled` | `dev` | `token` write | `token` viewer |
|---|---|---|---|---|
| Active score API | 403 | 200 full | 403 | 200 full |
| Active preview | hidden | shown | hidden | shown |
| Terminal score API | 200 sanitized | 200 full | 200 sanitized | 200 full |
| Terminal preview | shown sanitized | shown full | shown sanitized | shown full |

## Verification

- `pnpm --filter hosted-sites test` — 166/166 passed
- `pnpm --filter hosted-sites build` — passed
- `pnpm verify:ci` — passed

## Related

- Parent roadmap: #107
- Previous: #108 hard suite catalog
- Next: #110-#114 app hard variants
