### PR TITLE
feat(hosted-sites): add hard shopping optimizer variants (#110)

### DIFF
--- a/apps/hosted-sites/src/apps/shopping-lite/actions.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/actions.ts
@@ -3,6 +3,7 @@ import { configNumberOrNull, readTaskConfig } from "../../runtime/question-confi
 
 type ShoppingSession = HostedSessionFor<"shopping-lite">;
 import type { Order } from "./types.js";
+import { shoppingCoupons } from "./seed.js";
 
 export function getCartRows(session: ShoppingSession) {
   return session.state.cart.map((item) => {
@@ -26,14 +27,27 @@ export function getCartTotal(session: ShoppingSession) {
   return getCartRows(session).reduce((sum, row) => sum + row.lineTotal, 0);
 }
 
-export function addProductToCart(session: ShoppingSession, productId: string) {
+export type CartMutationResult = { success: true } | { success: false; error: string };
+
+export function addProductToCart(session: ShoppingSession, productId: string): CartMutationResult {
+  const product = session.state.products.find((candidate) => candidate.id === productId);
+  if (!product) {
+    return { success: false, error: "Unknown product" };
+  }
+
   const existing = session.state.cart.find((item) => item.productId === productId);
+  const nextQuantity = (existing?.quantity ?? 0) + 1;
+  if (product.stock != null && nextQuantity > product.stock) {
+    return { success: false, error: "Out of stock" };
+  }
+
   if (existing) {
-    existing.quantity += 1;
-    return;
+    existing.quantity = nextQuantity;
+    return { success: true };
   }
 
   session.state.cart.push({ productId, quantity: 1 });
+  return { success: true };
 }
 
 function roundMoney(value: number): number {
@@ -44,13 +58,22 @@ export function removeProductFromCart(session: ShoppingSession, productId: strin
   session.state.cart = session.state.cart.filter((item) => item.productId !== productId);
 }
 
-export function setCartItemQuantity(session: ShoppingSession, productId: string, quantity: number) {
+export function setCartItemQuantity(
+  session: ShoppingSession,
+  productId: string,
+  quantity: number,
+): CartMutationResult {
   if (!Number.isInteger(quantity)) {
     throw new Error("Quantity must be an integer.");
   }
   if (quantity <= 0) {
     removeProductFromCart(session, productId);
-    return;
+    return { success: true };
+  }
+
+  const product = session.state.products.find((candidate) => candidate.id === productId);
+  if (product?.stock != null && quantity > product.stock) {
+    return { success: false, error: "Out of stock" };
   }
 
   const existing = session.state.cart.find((item) => item.productId === productId);
@@ -59,6 +82,7 @@ export function setCartItemQuantity(session: ShoppingSession, productId: string,
   } else {
     session.state.cart.push({ productId, quantity });
   }
+  return { success: true };
 }
 
 export function getShippingCost(
@@ -79,6 +103,21 @@ export function getShippingCost(
   return subtotal >= freeShippingThreshold ? 0 : shippingCost;
 }
 
+export function resolveCoupon(rawCode: string | null | undefined): { code: string; discountPercent: number } | null {
+  if (typeof rawCode !== "string") {
+    return null;
+  }
+  const code = rawCode.trim().toUpperCase();
+  if (code.length === 0) {
+    return null;
+  }
+  const discountPercent = shoppingCoupons[code];
+  if (discountPercent == null) {
+    return null;
+  }
+  return { code, discountPercent };
+}
+
 export function submitCheckoutOrder(
   session: ShoppingSession,
   params: {
@@ -86,19 +125,27 @@ export function submitCheckoutOrder(
     now: () => string;
     shippingMethod: "standard" | "express";
     shippingCost?: number;
+    coupon?: { code: string; discountPercent: number } | null;
   },
 ) {
   const subtotal = roundMoney(getCartTotal(session));
   const shippingCost = roundMoney(params.shippingCost ?? 0);
+  const discountAmount = params.coupon
+    ? roundMoney((subtotal * params.coupon.discountPercent) / 100)
+    : 0;
   const order: Order = {
     id: params.makeId("ord"),
     items: session.state.cart.map((item) => ({ ...item })),
     subtotal,
-    total: roundMoney(subtotal + shippingCost),
+    total: roundMoney(subtotal - discountAmount + shippingCost),
     shippingMethod: params.shippingMethod,
     shippingCost,
     submittedAt: params.now(),
   };
+  if (params.coupon) {
+    order.couponCode = params.coupon.code;
+    order.discountAmount = discountAmount;
+  }
   session.state.orders.push(order);
   session.state.cart = [];
   return order;

--- a/apps/hosted-sites/src/apps/shopping-lite/definition.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/definition.ts
@@ -11,7 +11,10 @@ function isProduct(value: unknown): value is Product {
     typeof value.id === "string" &&
     typeof value.name === "string" &&
     typeof value.category === "string" &&
-    typeof value.price === "number"
+    typeof value.price === "number" &&
+    (value.stock === undefined || typeof value.stock === "number") &&
+    (value.compatibleWith === undefined ||
+      (Array.isArray(value.compatibleWith) && value.compatibleWith.every((entry) => typeof entry === "string")))
   );
 }
 
@@ -28,6 +31,8 @@ function isOrder(value: unknown): value is Order {
     typeof value.total === "number" &&
     (value.subtotal === undefined || typeof value.subtotal === "number") &&
     (value.shippingCost === undefined || typeof value.shippingCost === "number") &&
+    (value.couponCode === undefined || typeof value.couponCode === "string") &&
+    (value.discountAmount === undefined || typeof value.discountAmount === "number") &&
     (value.shippingMethod === "standard" || value.shippingMethod === "express") &&
     typeof value.submittedAt === "string"
   );

--- a/apps/hosted-sites/src/apps/shopping-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/evaluate.ts
@@ -66,6 +66,8 @@ export function evaluateShoppingBackendState(
   const avoidRestricted = configBoolean(config, "avoidRestricted");
   const secondaryCategory = configStringOrNull(config, "secondaryCategory");
   const secondaryQuantity = configNumberOrNull(config, "secondaryQuantity") ?? 1;
+  const requiredDevice = configStringOrNull(config, "requiredDevice");
+  const couponCode = configStringOrNull(config, "couponCode");
 
   const rows = order.items.map((item) => {
     const product = session.state.products.find((candidate) => candidate.id === item.productId);
@@ -82,6 +84,22 @@ export function evaluateShoppingBackendState(
   const secondaryItemQuantity = secondaryItems.reduce((sum, row) => sum + row.item.quantity, 0);
   const expectedItemCount = expectedQuantity + (secondaryCategory ? secondaryQuantity : 0);
 
+  // Hard variants require every target item to be certified for the generated
+  // device; easy variants leave requiredDevice unset and skip the check.
+  const compatibleTargets =
+    !requiredDevice ||
+    (targetItems.length > 0 &&
+      targetItems.every((row) => row.product?.compatibleWith?.includes(requiredDevice) ?? false));
+
+  // Stock can never be exceeded; this guards against persisted state that
+  // bypassed the cart action enforcement.
+  const stockRespected = order.items.every((item) => {
+    const product = session.state.products.find((candidate) => candidate.id === item.productId);
+    return product?.stock == null || item.quantity <= product.stock;
+  });
+
+  const couponApplied = !couponCode || order.couponCode === couponCode;
+
   const evidence = {
     orderId: order.id,
     itemCount,
@@ -90,6 +108,11 @@ export function evaluateShoppingBackendState(
     secondaryCategory,
     secondaryItems: secondaryItems.map((row) => row.product?.name),
     restrictedItems: restrictedItems.map((row) => row.product?.name),
+    requiredDevice,
+    couponCode,
+    appliedCoupon: order.couponCode ?? null,
+    discountAmount: order.discountAmount ?? 0,
+    subtotal: order.subtotal ?? order.total,
     total: order.total,
     shippingMethod: order.shippingMethod,
   };
@@ -99,6 +122,9 @@ export function evaluateShoppingBackendState(
     targetQuantity === expectedQuantity &&
     (!secondaryCategory || secondaryItemQuantity === secondaryQuantity) &&
     (!avoidRestricted || restrictedItems.length === 0) &&
+    compatibleTargets &&
+    stockRespected &&
+    couponApplied &&
     order.total <= maxTotal &&
     order.shippingMethod === shippingMethod;
 
@@ -112,6 +138,7 @@ export function evaluateShoppingBackendState(
         type: "backend_state",
         name: "submitted generated constrained order",
         evidence,
-        errorMessage: "Order does not satisfy the generated category, quantity, budget, restriction, and shipping constraints.",
+        errorMessage:
+          "Order does not satisfy the generated category, quantity, budget, restriction, compatibility, stock, coupon, and shipping constraints.",
       });
 }

--- a/apps/hosted-sites/src/apps/shopping-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/final-state.ts
@@ -12,6 +12,8 @@ export function buildShoppingFinalState(session: HostedSessionFor<"shopping-lite
           subtotal: order.subtotal ?? order.total,
           shippingMethod: order.shippingMethod,
           shippingCost: order.shippingCost ?? 0,
+          couponCode: order.couponCode ?? null,
+          discountAmount: order.discountAmount ?? 0,
           submittedAt: order.submittedAt,
           items: order.items.map((item) => {
             const product = session.state.products.find((candidate) => candidate.id === item.productId);
@@ -21,6 +23,7 @@ export function buildShoppingFinalState(session: HostedSessionFor<"shopping-lite
               category: product?.category ?? null,
               price: product?.price ?? null,
               restricted: Boolean(product?.restricted),
+              compatibleWith: product?.compatibleWith ?? [],
               quantity: item.quantity,
             };
           }),

--- a/apps/hosted-sites/src/apps/shopping-lite/render.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/render.ts
@@ -17,14 +17,29 @@ export function renderProducts(
   const cards = session.state.products
     .map((product) => {
       const restricted = product.restricted ? `<p class="danger">Restricted product</p>` : "";
+      const compatibility = product.compatibleWith?.length
+        ? `<p class="muted">Compatible with: ${escapeHtml(product.compatibleWith.join(", "))}</p>`
+        : "";
+      const outOfStock = product.stock != null && product.stock <= 0;
+      const stockLine =
+        product.stock == null
+          ? ""
+          : outOfStock
+            ? `<p class="danger">Out of stock</p>`
+            : `<p class="muted">In stock: ${product.stock}</p>`;
+      const addButton = outOfStock
+        ? `<button type="submit" disabled>Out of stock</button>`
+        : `<button type="submit">Add to cart</button>`;
       return `<article class="card">
         <h2>${escapeHtml(product.name)}</h2>
         <p class="muted">Category: ${escapeHtml(product.category)}</p>
         <p class="price">${money(product.price)}</p>
+        ${compatibility}
+        ${stockLine}
         ${restricted}
         <form method="post" action="/shopping/cart?session=${encodeURIComponent(session.token)}">
           <input type="hidden" name="productId" value="${escapeHtml(product.id)}" />
-          <button type="submit">Add to cart</button>
+          ${addButton}
         </form>
       </article>`;
     })
@@ -121,6 +136,10 @@ export function renderCart(
               <option value="express">Express</option>
             </select>
           </label>
+          <label>
+            Coupon code
+            <input type="text" name="couponCode" placeholder="Optional coupon" autocomplete="off" />
+          </label>
           <button type="submit">Submit order</button>
         </form>
       </section>`,
@@ -150,6 +169,11 @@ export function renderOrder(
         <pre class="score">${escapeHtml(JSON.stringify(score, null, 2))}</pre>`
     : "";
 
+  const couponLine =
+    order.couponCode && order.discountAmount != null && order.discountAmount > 0
+      ? `<p>Coupon: <strong>${escapeHtml(order.couponCode)}</strong> (−${money(order.discountAmount)})</p>`
+      : "";
+
   sendHtml(
     response,
     200,
@@ -159,6 +183,7 @@ export function renderOrder(
       body: `<section class="panel">
         <h2>Order submitted</h2>
         <p>Order id: <strong>${escapeHtml(order.id)}</strong></p>
+        ${couponLine}
         <p>Total: <strong>${money(order.total)}</strong></p>
         <p>Shipping: <strong>${shippingDetail}</strong></p>
         ${scorePreview}

--- a/apps/hosted-sites/src/apps/shopping-lite/routes.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/routes.ts
@@ -3,7 +3,7 @@ import type { HostedAppRouteDeps } from "../../runtime/app-definition.js";
 import { redirect, sendJson } from "../../runtime/http.js";
 import { readTaskConfig } from "../../runtime/question-config.js";
 import { isHostedSessionForApp } from "../../runtime/types.js";
-import { addProductToCart, getShippingCost, removeProductFromCart, setCartItemQuantity, submitCheckoutOrder } from "./actions.js";
+import { addProductToCart, getShippingCost, removeProductFromCart, resolveCoupon, setCartItemQuantity, submitCheckoutOrder } from "./actions.js";
 import { renderCart, renderOrder, renderProducts } from "./render.js";
 
 export function createShoppingRoutes(deps: HostedAppRouteDeps) {
@@ -39,7 +39,11 @@ export function createShoppingRoutes(deps: HostedAppRouteDeps) {
         return true;
       }
 
-      addProductToCart(session, productId);
+      const added = addProductToCart(session, productId);
+      if (!added.success) {
+        deps.badRequest(response, added.error);
+        return true;
+      }
       await deps.persistSessionSnapshot(session);
       await deps.recordEvent(session, { type: "task.signal", name: "cart.item_added", productId });
       await deps.forwardRunEvent(session, "hosted.task_signal", {
@@ -77,7 +81,11 @@ export function createShoppingRoutes(deps: HostedAppRouteDeps) {
           deps.badRequest(response, "Invalid quantity");
           return true;
         }
-        setCartItemQuantity(session, productId, quantity);
+        const updated = setCartItemQuantity(session, productId, quantity);
+        if (!updated.success) {
+          deps.badRequest(response, updated.error);
+          return true;
+        }
       }
 
       await deps.persistSessionSnapshot(session);
@@ -118,6 +126,7 @@ export function createShoppingRoutes(deps: HostedAppRouteDeps) {
 
       const form = await deps.readForm(request);
       const shippingMethod = form.get("shippingMethod") === "express" ? "express" : "standard";
+      const coupon = resolveCoupon(form.get("couponCode"));
       const taskConfig = readTaskConfig(session.metadata);
       const shippingCost = getShippingCost(session, shippingMethod, taskConfig);
       const order = submitCheckoutOrder(session, {
@@ -125,6 +134,7 @@ export function createShoppingRoutes(deps: HostedAppRouteDeps) {
         now: deps.now,
         shippingMethod,
         shippingCost,
+        coupon,
       });
       await deps.persistSessionSnapshot(session);
       await deps.recordEvent(session, { type: "task.signal", name: "order.submitted", orderId: order.id });

--- a/apps/hosted-sites/src/apps/shopping-lite/seed.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/seed.ts
@@ -6,6 +6,7 @@ export const shoppingSeedProducts: Product[] = [
     name: "VoltEdge 20W USB-C Charger",
     category: "charger",
     price: 18.99,
+    stock: 10,
   },
   {
     id: "prod-charger-30w",
@@ -24,6 +25,7 @@ export const shoppingSeedProducts: Product[] = [
     name: "Braided USB-C Cable 1m",
     category: "cable",
     price: 9.99,
+    stock: 20,
   },
   {
     id: "prod-cable-2m",
@@ -44,7 +46,39 @@ export const shoppingSeedProducts: Product[] = [
     category: "case",
     price: 12.5,
   },
+  {
+    id: "prod-charger-probook-100w",
+    name: "ProBook 100W GaN Charger",
+    category: "charger",
+    price: 32.99,
+    // The obvious high-wattage match for a ProBook, but unavailable: a careful
+    // agent must fall back to the in-stock compatible charger.
+    stock: 0,
+    compatibleWith: ["ProBook"],
+  },
+  {
+    id: "prod-charger-probook-30w",
+    name: "ProBook 30W Travel Charger",
+    category: "charger",
+    price: 27.99,
+    stock: 6,
+    compatibleWith: ["ProBook"],
+  },
+  {
+    id: "prod-charger-airlite-45w",
+    name: "AirLite 45W Charger",
+    category: "charger",
+    price: 29.99,
+    stock: 4,
+    compatibleWith: ["AirLite"],
+  },
 ];
+
+// Redeemable coupon codes mapped to their discount percentage. Hard variants
+// require applying the right coupon to bring an order under budget.
+export const shoppingCoupons: Record<string, number> = {
+  CABLE20: 20,
+};
 
 export function getShoppingStartPath() {
   return "/shopping";
@@ -53,3 +87,4 @@ export function getShoppingStartPath() {
 export function getShoppingDefaultGoal() {
   return "Buy exactly one USB-C charger with total price at or below $30. Use standard shipping. Do not buy restricted products.";
 }
+

--- a/apps/hosted-sites/src/apps/shopping-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/shopping-lite/test-driver.mjs
@@ -4,9 +4,22 @@ export async function complete({ session, config, checkedFetch, postForm, requir
     cable: "prod-cable-1m",
     case: "prod-case",
   };
-  const primaryProductId = cheapestByCategory[config.targetCategory];
+  // In-stock products certified for a specific device, keyed by device then category.
+  const compatibleByDevice = {
+    ProBook: { charger: "prod-charger-probook-30w" },
+    AirLite: { charger: "prod-charger-airlite-45w" },
+  };
+
+  const requiredDevice = typeof config.requiredDevice === "string" ? config.requiredDevice : null;
+  const primaryProductId = requiredDevice
+    ? compatibleByDevice[requiredDevice]?.[config.targetCategory]
+    : cheapestByCategory[config.targetCategory];
   if (!primaryProductId) {
-    throw new Error(`Unsupported shopping category: ${config.targetCategory}`);
+    throw new Error(
+      requiredDevice
+        ? `No in-stock ${config.targetCategory} compatible with ${requiredDevice}`
+        : `Unsupported shopping category: ${config.targetCategory}`,
+    );
   }
   const quantity = Number(config.quantity);
   if (!Number.isInteger(quantity) || quantity < 1) {
@@ -29,7 +42,11 @@ export async function complete({ session, config, checkedFetch, postForm, requir
     }
   }
 
-  await postForm("/shopping/checkout", session.token, {
+  const checkoutValues = {
     shippingMethod: requireString(config.shippingMethod, "shopping shippingMethod"),
-  });
+  };
+  if (typeof config.couponCode === "string" && config.couponCode.length > 0) {
+    checkoutValues.couponCode = config.couponCode;
+  }
+  await postForm("/shopping/checkout", session.token, checkoutValues);
 }

--- a/apps/hosted-sites/src/apps/shopping-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/test-support.ts
@@ -14,14 +14,21 @@ export const shoppingLiteTestSupport: HostedAppTestSupport<"shopping-lite"> = {
   },
   applyPassingState(session, config) {
     const category = configString(config, "targetCategory");
-    const maxTotal = Number(config.maxTotal);
+    const quantity = Number(config.quantity);
+    const requiredDevice = configStringOrNull(config, "requiredDevice");
+    const couponCode = configStringOrNull(config, "couponCode");
+    const discountPercent = configNumberOrNull(config, "discountPercent");
+
     const product = session.state.products.find(
-      (candidate) => candidate.category === category && !candidate.restricted && candidate.price <= maxTotal,
+      (candidate) =>
+        candidate.category === category &&
+        !candidate.restricted &&
+        (candidate.stock == null || candidate.stock >= quantity) &&
+        (!requiredDevice || (candidate.compatibleWith?.includes(requiredDevice) ?? false)),
     );
     if (!product) {
       throw new Error(`missing valid ${category} fixture`);
     }
-    const quantity = Number(config.quantity);
     const items = [{ productId: product.id, quantity }];
     let subtotal = product.price * quantity;
 
@@ -29,7 +36,10 @@ export const shoppingLiteTestSupport: HostedAppTestSupport<"shopping-lite"> = {
     if (secondaryCategory) {
       const secondaryQuantity = configNumberOrNull(config, "secondaryQuantity") ?? 1;
       const secondaryProduct = session.state.products.find(
-        (candidate) => candidate.category === secondaryCategory && !candidate.restricted,
+        (candidate) =>
+          candidate.category === secondaryCategory &&
+          !candidate.restricted &&
+          (candidate.stock == null || candidate.stock >= secondaryQuantity),
       );
       if (!secondaryProduct) {
         throw new Error(`missing valid ${secondaryCategory} fixture`);
@@ -48,13 +58,16 @@ export const shoppingLiteTestSupport: HostedAppTestSupport<"shopping-lite"> = {
           : shippingCostConfig
         : 0;
 
+    const discountAmount = couponCode && discountPercent != null ? roundMoney((subtotal * discountPercent) / 100) : 0;
+
     session.state.orders.push({
       id: "order-matrix",
       items,
       subtotal: roundMoney(subtotal),
-      total: roundMoney(subtotal + shippingCost),
+      total: roundMoney(subtotal - discountAmount + shippingCost),
       shippingMethod,
       shippingCost: roundMoney(shippingCost),
+      ...(couponCode ? { couponCode, discountAmount } : {}),
       submittedAt: "2026-06-01T00:00:00.000Z",
     });
   },

--- a/apps/hosted-sites/src/apps/shopping-lite/types.ts
+++ b/apps/hosted-sites/src/apps/shopping-lite/types.ts
@@ -4,6 +4,13 @@ export type Product = {
   category: "charger" | "cable" | "adapter" | "case";
   price: number;
   restricted?: boolean;
+  // Undefined stock means the product is always available; a finite stock caps
+  // how many units a single order may contain. Hard variants rely on this to
+  // make an obvious-but-unavailable option unusable.
+  stock?: number;
+  // Devices the product is certified to work with. Hard variants require the
+  // ordered product to be compatible with a generated target device.
+  compatibleWith?: string[];
 };
 
 export type CartItem = {
@@ -18,6 +25,10 @@ export type Order = {
   subtotal?: number;
   shippingMethod: "standard" | "express";
   shippingCost?: number;
+  // Coupon redeemed at checkout and the resulting discount, when a hard variant
+  // requires the agent to apply one to stay under budget.
+  couponCode?: string;
+  discountAmount?: number;
   submittedAt: string;
 };
 

--- a/apps/hosted-sites/tests/unit/actions.test.ts
+++ b/apps/hosted-sites/tests/unit/actions.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { addReplyToThread, lockThread, pinThread, reportThread } from "../../src/apps/forum-lite/actions.js";
 import { createNote, updateNote } from "../../src/apps/notes-lite/actions.js";
 import { createMergeRequest, updateFileContent } from "../../src/apps/repo-lite/actions.js";
-import { addProductToCart, getCartTotal, removeProductFromCart, setCartItemQuantity, submitCheckoutOrder } from "../../src/apps/shopping-lite/actions.js";
+import { addProductToCart, getCartTotal, removeProductFromCart, resolveCoupon, setCartItemQuantity, submitCheckoutOrder } from "../../src/apps/shopping-lite/actions.js";
 import { markArticleViewed, submitWikiAnswer } from "../../src/apps/wiki-lite/actions.js";
 import { buildInitialSessionState, defaultGoalForSession, defaultStartPathForApp } from "../../src/runtime/app-registry.js";
 import type { HostedAppId, HostedSessionFor } from "../../src/runtime/types.js";
@@ -125,6 +125,58 @@ test("shopping actions remove cart items and adjust quantities", () => {
   assert.deepEqual(session.state.cart, []);
 
   assert.throws(() => setCartItemQuantity(session, "prod-charger-30w", 1.5), /integer/);
+});
+
+test("addProductToCart refuses an out-of-stock product", () => {
+  const session = makeSession("shopping-lite");
+  const result = addProductToCart(session, "prod-charger-probook-100w");
+  assert.deepEqual(result, { success: false, error: "Out of stock" });
+  assert.deepEqual(session.state.cart, []);
+});
+
+test("addProductToCart refuses adding beyond the available stock", () => {
+  const session = makeSession("shopping-lite");
+  for (let count = 0; count < 6; count += 1) {
+    assert.equal(addProductToCart(session, "prod-charger-probook-30w").success, true);
+  }
+  const overflow = addProductToCart(session, "prod-charger-probook-30w");
+  assert.deepEqual(overflow, { success: false, error: "Out of stock" });
+  assert.deepEqual(session.state.cart, [{ productId: "prod-charger-probook-30w", quantity: 6 }]);
+});
+
+test("setCartItemQuantity refuses quantities beyond the available stock", () => {
+  const session = makeSession("shopping-lite");
+  addProductToCart(session, "prod-charger-probook-30w");
+  const result = setCartItemQuantity(session, "prod-charger-probook-30w", 7);
+  assert.deepEqual(result, { success: false, error: "Out of stock" });
+  assert.deepEqual(session.state.cart, [{ productId: "prod-charger-probook-30w", quantity: 1 }]);
+});
+
+test("resolveCoupon resolves known codes and rejects unknown ones", () => {
+  assert.deepEqual(resolveCoupon("CABLE20"), { code: "CABLE20", discountPercent: 20 });
+  assert.deepEqual(resolveCoupon("  cable20  "), { code: "CABLE20", discountPercent: 20 });
+  assert.equal(resolveCoupon("UNKNOWN"), null);
+  assert.equal(resolveCoupon(""), null);
+  assert.equal(resolveCoupon(null), null);
+});
+
+test("submitCheckoutOrder applies the resolved coupon discount", () => {
+  const session = makeSession("shopping-lite");
+  for (let count = 0; count < 3; count += 1) {
+    addProductToCart(session, "prod-cable-1m");
+  }
+
+  const order = submitCheckoutOrder(session, {
+    makeId: (prefix) => `${prefix}_1`,
+    now: () => "2026-06-01T00:00:00.000Z",
+    shippingMethod: "standard",
+    coupon: resolveCoupon("CABLE20"),
+  });
+
+  assert.equal(order.subtotal, 29.97);
+  assert.equal(order.discountAmount, 5.99);
+  assert.equal(order.total, 23.98);
+  assert.equal(order.couponCode, "CABLE20");
 });
 
 test("wiki actions dedupe viewed articles and trim submitted answers", () => {

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -325,6 +325,212 @@ test("evaluateShopping fails when paid shipping pushes total over budget", () =>
   assert.equal(result.score, 0);
 });
 
+const hardShoppingProducts: ShoppingEvaluationSession["state"]["products"] = [
+  { id: "prod-charger-20w", name: "VoltEdge 20W USB-C Charger", category: "charger", price: 18.99, stock: 10 },
+  { id: "prod-charger-30w", name: "VoltEdge 30W USB-C Charger", category: "charger", price: 24.99 },
+  { id: "prod-cable-1m", name: "Braided USB-C Cable 1m", category: "cable", price: 9.99, stock: 20 },
+  {
+    id: "prod-charger-probook-100w",
+    name: "ProBook 100W GaN Charger",
+    category: "charger",
+    price: 32.99,
+    stock: 0,
+    compatibleWith: ["ProBook"],
+  },
+  {
+    id: "prod-charger-probook-30w",
+    name: "ProBook 30W Travel Charger",
+    category: "charger",
+    price: 27.99,
+    stock: 6,
+    compatibleWith: ["ProBook"],
+  },
+];
+
+const compatibleChargerConfig = generatedTaskConfig({
+  targetCategory: "charger",
+  quantity: 1,
+  maxTotal: 35,
+  shippingMethod: "standard",
+  avoidRestricted: true,
+  requiredDevice: "ProBook",
+});
+
+test("evaluateShopping passes when a compatible in-stock charger is ordered for the required device", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        products: hardShoppingProducts,
+        orders: [
+          {
+            id: "ord_probook",
+            items: [{ productId: "prod-charger-probook-30w", quantity: 1 }],
+            subtotal: 27.99,
+            total: 27.99,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      compatibleChargerConfig,
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateShopping fails when the ordered charger is not compatible with the required device", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        products: hardShoppingProducts,
+        orders: [
+          {
+            id: "ord_incompatible",
+            items: [{ productId: "prod-charger-30w", quantity: 1 }],
+            subtotal: 24.99,
+            total: 24.99,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      compatibleChargerConfig,
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+test("evaluateShopping fails when an order exceeds available stock", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        products: hardShoppingProducts,
+        orders: [
+          {
+            id: "ord_overstock",
+            items: [{ productId: "prod-charger-probook-30w", quantity: 9 }],
+            subtotal: 251.91,
+            total: 30,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 9,
+        maxTotal: 300,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+        requiredDevice: "ProBook",
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+const couponBundleConfig = generatedTaskConfig({
+  targetCategory: "cable",
+  quantity: 3,
+  maxTotal: 28,
+  shippingMethod: "standard",
+  avoidRestricted: true,
+  couponCode: "CABLE20",
+  discountPercent: 20,
+});
+
+test("evaluateShopping passes when the required coupon brings the bundle under budget", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        products: hardShoppingProducts,
+        orders: [
+          {
+            id: "ord_coupon",
+            items: [{ productId: "prod-cable-1m", quantity: 3 }],
+            subtotal: 29.97,
+            total: 23.98,
+            couponCode: "CABLE20",
+            discountAmount: 5.99,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      couponBundleConfig,
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
+test("evaluateShopping fails when the coupon is missing and the bundle exceeds budget", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        products: hardShoppingProducts,
+        orders: [
+          {
+            id: "ord_nocoupon",
+            items: [{ productId: "prod-cable-1m", quantity: 3 }],
+            subtotal: 29.97,
+            total: 29.97,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      couponBundleConfig,
+    ),
+  );
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.score, 0);
+});
+
+test("evaluateShopping passes for a five-unit team charger order within budget", () => {
+  const result = evaluateShopping(
+    makeShoppingSession(
+      {
+        products: hardShoppingProducts,
+        orders: [
+          {
+            id: "ord_team",
+            items: [{ productId: "prod-charger-20w", quantity: 5 }],
+            subtotal: 94.95,
+            total: 94.95,
+            shippingMethod: "standard",
+            shippingCost: 0,
+            submittedAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({
+        targetCategory: "charger",
+        quantity: 5,
+        maxTotal: 120,
+        shippingMethod: "standard",
+        avoidRestricted: true,
+      }),
+    ),
+  );
+
+  assert.equal(result.status, "passed");
+  assert.equal(result.score, 1);
+});
+
 test("evaluateWiki passes when article was viewed and exact answer submitted", () => {
   const result = evaluateWiki(
     makeWikiSession({

--- a/packages/test-cases/src/apps/shopping-lite/definition.ts
+++ b/packages/test-cases/src/apps/shopping-lite/definition.ts
@@ -13,6 +13,9 @@ export const shoppingLiteTestcaseDefinition = defineHostedTestcaseApp({
     secondaryQuantity: z.number().int().positive().optional(),
     freeShippingThreshold: z.number().nonnegative().optional(),
     shippingCost: z.number().nonnegative().optional(),
+    requiredDevice: z.string().min(1).optional(),
+    couponCode: z.string().min(1).optional(),
+    discountPercent: z.number().positive().max(100).optional(),
   }),
   variantPools: {
     default: [
@@ -22,6 +25,11 @@ export const shoppingLiteTestcaseDefinition = defineHostedTestcaseApp({
       { id: "combo-charger-cable", goal: "Buy one charger and one USB-C cable with a total price at or below $35, use standard shipping, and avoid restricted products.", taskConfig: { targetCategory: "charger", quantity: 1, maxTotal: 35, shippingMethod: "standard", avoidRestricted: true, secondaryCategory: "cable", secondaryQuantity: 1 } },
       { id: "travel-kit-free-shipping", goal: "Buy one charger and one travel case with a total price at or below $40. Standard shipping is free for orders $35 and over; otherwise standard shipping costs $5. Avoid restricted products.", taskConfig: { targetCategory: "charger", quantity: 1, maxTotal: 40, shippingMethod: "standard", avoidRestricted: true, secondaryCategory: "case", secondaryQuantity: 1, freeShippingThreshold: 35, shippingCost: 5 } },
       { id: "cable-budget-shipping", goal: "Buy one USB-C cable and one travel case with a total price at or below $25. Standard shipping is free for orders $20 and over; otherwise standard shipping costs $4. Avoid restricted products.", taskConfig: { targetCategory: "cable", quantity: 1, maxTotal: 25, shippingMethod: "standard", avoidRestricted: true, secondaryCategory: "case", secondaryQuantity: 1, freeShippingThreshold: 20, shippingCost: 4 } },
+    ],
+    hard: [
+      { id: "out-of-stock-compatible-charger", goal: "Buy exactly one charger that is compatible with the ProBook laptop, with a total at or below $35, using standard shipping. Avoid restricted products. The obvious high-wattage option is out of stock, so choose the compatible charger that is actually in stock.", taskConfig: { targetCategory: "charger", quantity: 1, maxTotal: 35, shippingMethod: "standard", avoidRestricted: true, requiredDevice: "ProBook" } },
+      { id: "coupon-cable-bundle", goal: "Buy exactly three USB-C cables for a team with a total at or below $28, using standard shipping. The order only fits the budget after applying coupon code CABLE20 for 20% off. Avoid restricted products.", taskConfig: { targetCategory: "cable", quantity: 3, maxTotal: 28, shippingMethod: "standard", avoidRestricted: true, couponCode: "CABLE20", discountPercent: 20 } },
+      { id: "team-charger-order", goal: "Buy exactly five chargers for a team with a total at or below $120, using standard shipping. Only the in-stock budget charger keeps the order within budget. Avoid restricted products.", taskConfig: { targetCategory: "charger", quantity: 5, maxTotal: 120, shippingMethod: "standard", avoidRestricted: true } },
     ],
   },
 });

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -1,9 +1,10 @@
 import { hostedTestcaseApps } from "../generated-app-registry.js";
 import { hostedSuiteMetadataSchema } from "../schemas.js";
 
-// TODO(#110-#114): replace default/release/policy pools with hard-specific variant pools.
-// The hard suite currently reuses easy-suite pools as a placeholder while app hard variants are built.
-const shoppingQuestionVariants = hostedTestcaseApps["shopping-lite"].variantPools.default;
+// TODO(#111-#114): replace the remaining default/release/policy pools with
+// hard-specific variant pools. The shopping-lite session uses its dedicated
+// hard pool (#110); the other apps still reuse easy-suite pools as placeholders.
+const shoppingQuestionVariants = hostedTestcaseApps["shopping-lite"].variantPools.hard;
 const forumQuestionVariants = hostedTestcaseApps["forum-lite"].variantPools.default;
 const repoQuestionVariants = hostedTestcaseApps["repo-lite"].variantPools.default;
 const wikiReleaseQuestionVariants = hostedTestcaseApps["wiki-lite"].variantPools.release;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -625,79 +625,39 @@ select public.publish_benchmark_case_catalog(
       "metadata": {
         "questionVariants": [
           {
-            "id": "budget-charger-standard",
-            "goal": "Buy exactly one charger with a total price at or below $30, use standard shipping, and avoid restricted products.",
-            "taskConfig": {
-              "targetCategory": "charger",
-              "quantity": 1,
-              "maxTotal": 30,
-              "shippingMethod": "standard",
-              "avoidRestricted": true
-            }
-          },
-          {
-            "id": "cable-express",
-            "goal": "Buy exactly one USB-C cable with a total price at or below $10, use express shipping, and avoid restricted products.",
-            "taskConfig": {
-              "targetCategory": "cable",
-              "quantity": 1,
-              "maxTotal": 10,
-              "shippingMethod": "express",
-              "avoidRestricted": true
-            }
-          },
-          {
-            "id": "travel-case-standard",
-            "goal": "Buy exactly one travel case with a total price at or below $15, use standard shipping, and avoid restricted products.",
-            "taskConfig": {
-              "targetCategory": "case",
-              "quantity": 1,
-              "maxTotal": 15,
-              "shippingMethod": "standard",
-              "avoidRestricted": true
-            }
-          },
-          {
-            "id": "combo-charger-cable",
-            "goal": "Buy one charger and one USB-C cable with a total price at or below $35, use standard shipping, and avoid restricted products.",
+            "id": "out-of-stock-compatible-charger",
+            "goal": "Buy exactly one charger that is compatible with the ProBook laptop, with a total at or below $35, using standard shipping. Avoid restricted products. The obvious high-wattage option is out of stock, so choose the compatible charger that is actually in stock.",
             "taskConfig": {
               "targetCategory": "charger",
               "quantity": 1,
               "maxTotal": 35,
               "shippingMethod": "standard",
               "avoidRestricted": true,
-              "secondaryCategory": "cable",
-              "secondaryQuantity": 1
+              "requiredDevice": "ProBook"
             }
           },
           {
-            "id": "travel-kit-free-shipping",
-            "goal": "Buy one charger and one travel case with a total price at or below $40. Standard shipping is free for orders $35 and over; otherwise standard shipping costs $5. Avoid restricted products.",
-            "taskConfig": {
-              "targetCategory": "charger",
-              "quantity": 1,
-              "maxTotal": 40,
-              "shippingMethod": "standard",
-              "avoidRestricted": true,
-              "secondaryCategory": "case",
-              "secondaryQuantity": 1,
-              "freeShippingThreshold": 35,
-              "shippingCost": 5
-            }
-          },
-          {
-            "id": "cable-budget-shipping",
-            "goal": "Buy one USB-C cable and one travel case with a total price at or below $25. Standard shipping is free for orders $20 and over; otherwise standard shipping costs $4. Avoid restricted products.",
+            "id": "coupon-cable-bundle",
+            "goal": "Buy exactly three USB-C cables for a team with a total at or below $28, using standard shipping. The order only fits the budget after applying coupon code CABLE20 for 20% off. Avoid restricted products.",
             "taskConfig": {
               "targetCategory": "cable",
-              "quantity": 1,
-              "maxTotal": 25,
+              "quantity": 3,
+              "maxTotal": 28,
               "shippingMethod": "standard",
               "avoidRestricted": true,
-              "secondaryCategory": "case",
-              "secondaryQuantity": 1,
-              "freeShippingThreshold": 20,
-              "shippingCost": 4
+              "couponCode": "CABLE20",
+              "discountPercent": 20
+            }
+          },
+          {
+            "id": "team-charger-order",
+            "goal": "Buy exactly five chargers for a team with a total at or below $120, using standard shipping. Only the in-stock budget charger keeps the order within budget. Avoid restricted products.",
+            "taskConfig": {
+              "targetCategory": "charger",
+              "quantity": 5,
+              "maxTotal": 120,
+              "shippingMethod": "standard",
+              "avoidRestricted": true
             }
           }
         ]
@@ -1189,7 +1149,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '0cc0241a41f0dc4355f1e7de9ed96b1e8264278105d0bf5a1f76188940c4c9b2'
+  '1c76afdb05313397ab4b5f13064a75420afca8d581c8605d795a2e7fd110d338'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
Closes #110. Adds device-compatibility, finite-stock, and coupon-discount constraints to shopping-lite and wires three hard variants into hosted-web-hard-suite-v1. Rebased onto develop atop #108 (#117) and #109 (#118); resolved the render.ts overlap by keeping both the gated evaluator preview and the coupon line.