### PR TITLE
refactor(hosted-web): treat all suites as catalog rows; difficulty is a tag

### DIFF
--- a/apps/web/app/api/benchmark-cases/route.ts
+++ b/apps/web/app/api/benchmark-cases/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { listPublicHostedBenchmarkCases } from "@/lib/db";
+
+export async function GET() {
+  try {
+    const cases = await listPublicHostedBenchmarkCases();
+    return NextResponse.json({ cases });
+  } catch (error) {
+    console.error("[web] failed to list benchmark cases", error);
+    return NextResponse.json(
+      { error: "service_unavailable", message: "Failed to load benchmark cases." },
+      { status: 503 },
+    );
+  }
+}

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import { benchmarkOptions } from "./data";
 import { RunConnectionCard } from "./RunConnectionCard";
 import { RunDetailTabs } from "./RunDetailTabs";
 import { usePlaygroundStore } from "@/lib/playground-store";
@@ -9,6 +8,7 @@ import { SiteSelect } from "@/components/ui/SiteSelect";
 
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
+  const benchmarks = usePlaygroundStore((state) => state.benchmarks);
   const phase = usePlaygroundStore((state) => state.phase);
   const quota = usePlaygroundStore((state) => state.quota);
   const quotaLoading = usePlaygroundStore((state) => state.quotaLoading);
@@ -16,6 +16,7 @@ export function ConnectAgentCard() {
   const score = usePlaygroundStore((state) => state.score);
   const setBenchmark = usePlaygroundStore((state) => state.setBenchmark);
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
+  const fetchBenchmarks = usePlaygroundStore((state) => state.fetchBenchmarks);
   const startRun = usePlaygroundStore((state) => state.startRun);
   const stopRun = usePlaygroundStore((state) => state.stopRun);
   const reset = usePlaygroundStore((state) => state.reset);
@@ -23,10 +24,12 @@ export function ConnectAgentCard() {
   const isRunning = phase === "booting" || phase === "running";
   const isDone = phase === "completed" || phase === "failed";
   const isQuotaBlocked = Boolean(quota && quota.remaining <= 0);
+  const selectedBenchmark = benchmarks.find((item) => item.id === benchmark);
 
   useEffect(() => {
     void fetchQuota();
-  }, [fetchQuota]);
+    void fetchBenchmarks();
+  }, [fetchQuota, fetchBenchmarks]);
 
   const quotaBadge = quotaLoading
     ? "Loading quota"
@@ -44,7 +47,7 @@ export function ConnectAgentCard() {
           <div>
             <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Connect Agent</div>
             <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
-              {benchmarkOptions.find((b) => b.value === benchmark)?.label ?? "Running"}
+              {selectedBenchmark?.label ?? "Running"}
             </h3>
           </div>
           <div className="rounded-full bg-[#d7ff00] px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-[#111111]">
@@ -73,7 +76,7 @@ export function ConnectAgentCard() {
           <div>
             <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Connect Agent</div>
             <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
-              {benchmarkOptions.find((b) => b.value === benchmark)?.label ?? "Run complete"}
+              {selectedBenchmark?.label ?? "Run complete"}
             </h3>
           </div>
           <div className="rounded-full bg-[#d7ff00] px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-[#111111]">
@@ -142,15 +145,15 @@ export function ConnectAgentCard() {
           <span className="mb-2 block text-[13px] text-[#5d574d]">Benchmark</span>
           <SiteSelect
             value={benchmark}
-            onValueChange={(value) => setBenchmark(value as typeof benchmark)}
+            onValueChange={(value) => setBenchmark(value)}
             ariaLabel="Benchmark"
-            options={benchmarkOptions.map((item) => ({ value: item.value, label: item.label }))}
+            options={benchmarks.map((item) => ({ value: item.id, label: item.label }))}
             compact
           />
         </label>
 
         <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
-          {benchmarkOptions.find((item) => item.value === benchmark)?.description}
+          {selectedBenchmark?.description ?? "Loading available benchmark suites…"}
         </div>
 
         <p className="text-[12px] leading-5 text-[#777064]">
@@ -166,7 +169,7 @@ export function ConnectAgentCard() {
         <button
           type="button"
           onClick={() => void startRun("external-agent")}
-          disabled={quotaLoading || isQuotaBlocked}
+          disabled={quotaLoading || isQuotaBlocked || !benchmark}
           className="w-full rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111] disabled:cursor-not-allowed disabled:opacity-70"
         >
           {isQuotaBlocked

--- a/apps/web/components/landing/data.ts
+++ b/apps/web/components/landing/data.ts
@@ -1,22 +1,3 @@
-import type { PlaygroundBenchmark } from "@/lib/playground-store";
-
-export const benchmarkOptions: Array<{
-  value: PlaygroundBenchmark;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "hosted-web-suite",
-    label: "Hosted Web Suite",
-    description: "Versioned multi-session benchmark with deterministic tasks and server-side scoring.",
-  },
-  {
-    value: "hosted-web-hard-suite",
-    label: "Hosted Web Hard Suite",
-    description: "Harder deterministic hosted-web benchmark with multi-step reasoning and cross-page state tasks.",
-  },
-];
-
 export const docsBlocks = {
   createRun: `curl -X POST https://agentbench.app/api/runs \\
   -H "Content-Type: application/json" \\

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -127,8 +127,39 @@ export async function listBenchmarkCases(): Promise<BenchmarkCase[]> {
   }));
 }
 
-export async function getBenchmarkCase(caseId: string): Promise<BenchmarkCase | null> {
+export type PublicBenchmarkCase = Pick<
+  BenchmarkCase,
+  "id" | "slug" | "title" | "description" | "difficulty"
+>;
+
+// Display-safe projection for the public suite picker. Deliberately omits
+// `metadata` and `current_revision_id` so scorer-oracle surfaces never leak to
+// unauthenticated clients. Ordered easy-before-hard deterministically.
+export async function listPublicHostedBenchmarkCases(): Promise<PublicBenchmarkCase[]> {
   const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from("benchmark_cases")
+    .select("id, slug, title, description, difficulty, created_at")
+    .eq("is_public", true)
+    .eq("provider", "hosted-web")
+    .order("difficulty", { ascending: true })
+    .order("created_at", { ascending: true });
+
+  if (error || !data) {
+    throw error ?? new Error("Failed to list public benchmark cases");
+  }
+
+  return data.map((item) => ({
+    id: item.id,
+    slug: item.slug,
+    title: item.title,
+    description: item.description,
+    difficulty: item.difficulty,
+  }));
+}
+
+export async function getBenchmarkCase(caseId: string): Promise<BenchmarkCase | null> {  const supabase = getSupabase();
 
   const byId = await supabase
     .from("benchmark_cases")

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -14,7 +14,17 @@ import {
   type HostedSessionBreakdown,
 } from "./hosted-scoring";
 
-export type PlaygroundBenchmark = "hosted-web-suite" | "hosted-web-hard-suite";
+// The selected benchmark is a catalog case id; suites are discovered at runtime
+// from the public catalog rather than hardcoded.
+export type PlaygroundBenchmark = string;
+
+export type BenchmarkOption = {
+  id: string;
+  slug: string;
+  label: string;
+  description: string;
+  difficulty: string;
+};
 
 export type RunPhase = "idle" | "booting" | "running" | "completed" | "failed";
 export type PanelTab = "events" | "files" | "screenshots" | "score";
@@ -39,6 +49,8 @@ type PlaygroundStore = {
   endpoint: string;
   apiKey: string;
   benchmark: PlaygroundBenchmark;
+  benchmarks: BenchmarkOption[];
+  benchmarksLoading: boolean;
   currentRunId: string | null;
   currentExecutionMode: RunExecutionMode | null;
   liveViewUrl: string | null;
@@ -63,6 +75,7 @@ type PlaygroundStore = {
   setActiveTab: (value: PanelTab) => void;
   setLiveSlide: (index: number) => void;
   fetchQuota: () => Promise<void>;
+  fetchBenchmarks: () => Promise<void>;
   startRun: (mode?: RunExecutionMode) => Promise<void>;
   stopRun: () => void;
   reset: () => void;
@@ -74,15 +87,12 @@ type RunSnapshot = {
   artifacts: Artifact[];
 };
 
-const BENCHMARK_CASE_IDS: Record<PlaygroundBenchmark, string> = {
-  "hosted-web-suite": "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",
-  "hosted-web-hard-suite": "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",
-};
-
 const initialState = {
   endpoint: "",
   apiKey: "",
-  benchmark: "hosted-web-suite" as PlaygroundBenchmark,
+  benchmark: "" as PlaygroundBenchmark,
+  benchmarks: [] as BenchmarkOption[],
+  benchmarksLoading: false,
   currentRunId: null,
   currentExecutionMode: null,
   liveViewUrl: null,
@@ -422,6 +432,21 @@ async function requestQuota() {
   return (await response.json()) as { quota: QuotaStatus };
 }
 
+async function requestBenchmarks() {
+  const response = await fetch("/api/benchmark-cases", {
+    method: "GET",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to load benchmark cases");
+  }
+
+  return (await response.json()) as {
+    cases: Array<{ id: string; slug: string; title: string; description: string; difficulty: string }>;
+  };
+}
+
 async function fetchRunSnapshot(runId: string) {
   const [runResponse, eventsResponse, artifactsResponse] = await Promise.all([
     fetch(`/api/runs/${runId}`, { cache: "no-store" }),
@@ -544,6 +569,27 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
       set({ quotaLoading: false, runError: "Failed to load quota." });
     }
   },
+  fetchBenchmarks: async () => {
+    set({ benchmarksLoading: true });
+
+    try {
+      const result = await requestBenchmarks();
+      const benchmarks: BenchmarkOption[] = result.cases.map((item) => ({
+        id: item.id,
+        slug: item.slug,
+        label: item.title,
+        description: item.description,
+        difficulty: item.difficulty,
+      }));
+      set((state) => ({
+        benchmarks,
+        benchmarksLoading: false,
+        benchmark: state.benchmark || benchmarks[0]?.id || "",
+      }));
+    } catch {
+      set({ benchmarksLoading: false, runError: "Failed to load benchmark catalog." });
+    }
+  },
   stopRun: () => {
     clearRunSync();
     set({ phase: "failed", statusLine: "Stopped", streamMode: "idle" });
@@ -569,6 +615,16 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
     try {
       const state = get();
       const benchmark = state.benchmark;
+      if (!benchmark) {
+        set({
+          quotaLoading: false,
+          runError: "Select a benchmark suite first.",
+          phase: "idle",
+          statusLine: "Select a benchmark suite first.",
+          streamMode: "idle",
+        });
+        return;
+      }
       const response = await fetch("/api/runs", {
         method: "POST",
         headers: {
@@ -576,7 +632,7 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
         },
         credentials: "include",
         body: JSON.stringify({
-          caseId: BENCHMARK_CASE_IDS[benchmark],
+          caseId: benchmark,
           executionMode: mode,
           isPublic: true,
         }),

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -43,6 +43,8 @@ flowchart TD
 
 This is the only documentation table that enumerates the changing suite contents. The catalog source remains authoritative; update this summary when publishing a revision instead of copying the list into other documents.
 
+> This table reflects the easy `hosted-web-suite`. All published suites (easy and hard) live as independent rows in `public.benchmark_cases`, differentiated only by their `difficulty` tag — see [Suites & Difficulty](./hosted-web-benchmark.md#suites--difficulty).
+
 <!-- generated:hosted-testcases:start -->
 | Task | App | Variants |
 | --- | --- | --- |

--- a/docs/hosted-web-benchmark.md
+++ b/docs/hosted-web-benchmark.md
@@ -19,6 +19,14 @@ benchmark run
 
 The published testcase catalog defines the current app list and ordered sessions. See the single authoritative [current testcase table](./hosted-site-app-authoring.md#current-hosted-testcases). Each session defines app, task and seed versions, order, weight, required flag, goal, and start path.
 
+## Suites & Difficulty
+
+There can be more than one published suite (today: `hosted-web-suite` and `hosted-web-hard-suite`). They are treated uniformly — difficulty is a tag, not a code path.
+
+- **Boundary.** Each suite is one row in `public.benchmark_cases` with its own `id`, `slug`, `title`, and immutable published `revision`. Suites are independent catalog entries, not modes of a single entry, so their sessions, versions, and scores evolve separately.
+- **Shared components.** Suites reuse the same hosted apps (definitions, evaluators, render/actions under `apps/hosted-sites/src/apps/*` and `packages/test-cases/src/apps/*`), the same release/publish/seed machinery (the single `hostedWebSuites` registry in [packages/test-cases/src/suites/registry.ts](../packages/test-cases/src/suites/registry.ts), consumed by `release.ts`, `scripts/publish.ts`, and `seed-sql.ts`), and the same run flow (`POST /api/runs` → `getBenchmarkCase` → hosted connect). Neither the backend tooling nor the frontend branches on which suite was chosen.
+- **Difficulty dimension.** The `difficulty` column tags each row (`"easy"` / `"hard"`). Easy sessions draw from each app's `default` variant pools; hard sessions draw from `hard` variant pools and additionally declare cross-app `consistencyChecks` in the suite manifest. Adding a suite means creating a suite source file and appending one entry to `hostedWebSuites` — the row's `difficulty` is all that distinguishes it. The frontend picker is populated dynamically from the public catalog (`GET /api/benchmark-cases`), so new suites appear without code changes.
+
 ## Session Isolation
 
 - Every task URL contains an opaque token.

--- a/packages/test-cases/scripts/publish.ts
+++ b/packages/test-cases/scripts/publish.ts
@@ -1,5 +1,5 @@
 import { hostedSuiteMetadataSchema } from "../src/schemas.js";
-import { createHostedWebCatalogRelease } from "../src/release.js";
+import { hostedWebCatalogReleases } from "../src/release.js";
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -8,26 +8,31 @@ if (!supabaseUrl || !serviceRoleKey) {
   throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.");
 }
 
-const release = createHostedWebCatalogRelease();
-hostedSuiteMetadataSchema.parse(release.manifest);
+const rpcUrl = `${supabaseUrl.replace(/\/$/, "")}/rest/v1/rpc/publish_benchmark_case_catalog`;
 
-const response = await fetch(`${supabaseUrl.replace(/\/$/, "")}/rest/v1/rpc/publish_benchmark_case_catalog`, {
-  method: "POST",
-  headers: {
-    apikey: serviceRoleKey,
-    Authorization: `Bearer ${serviceRoleKey}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    target_case: release.benchmarkCase,
-    target_revision: release.revision,
-    target_manifest: release.manifest,
-    target_content_hash: release.contentHash,
-  }),
-});
+for (const release of hostedWebCatalogReleases()) {
+  hostedSuiteMetadataSchema.parse(release.manifest);
 
-if (!response.ok) {
-  throw new Error(`Catalog publication failed (${response.status}): ${await response.text()}`);
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      target_case: release.benchmarkCase,
+      target_revision: release.revision,
+      target_manifest: release.manifest,
+      target_content_hash: release.contentHash,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Catalog publication failed for ${release.revision} (${response.status}): ${await response.text()}`,
+    );
+  }
+
+  console.log(`published ${release.revision} as ${await response.text()}`);
 }
-
-console.log(`published ${release.revision} as ${await response.text()}`);

--- a/packages/test-cases/src/index.ts
+++ b/packages/test-cases/src/index.ts
@@ -3,3 +3,4 @@ export * from "./generated-app-registry.js";
 export * from "./schemas.js";
 export * from "./suites/hosted-web.js";
 export * from "./suites/hosted-web-hard.js";
+export * from "./suites/registry.js";

--- a/packages/test-cases/src/release.ts
+++ b/packages/test-cases/src/release.ts
@@ -1,31 +1,15 @@
 import { createHash } from "node:crypto";
-import {
-  hostedWebHardSuiteCase,
-  hostedWebHardSuiteMetadata,
-  hostedWebHardSuiteRevision,
-  hostedWebSuiteCase,
-  hostedWebSuiteMetadata,
-  hostedWebSuiteRevision,
-} from "./index.js";
+import { hostedWebSuites, type HostedSuiteDefinition } from "./suites/registry.js";
 
-export function createHostedWebCatalogRelease() {
-  const manifest = hostedWebSuiteMetadata;
+export function createCatalogRelease(suite: HostedSuiteDefinition) {
+  const manifest = suite.metadata;
   return {
-    caseId: hostedWebSuiteCase.id,
-    benchmarkCase: hostedWebSuiteCase,
-    revision: hostedWebSuiteRevision,
+    caseId: suite.case.id,
+    benchmarkCase: suite.case,
+    revision: suite.revision,
     manifest,
     contentHash: createHash("sha256").update(JSON.stringify(manifest)).digest("hex"),
   };
 }
 
-export function createHostedWebHardCatalogRelease() {
-  const manifest = hostedWebHardSuiteMetadata;
-  return {
-    caseId: hostedWebHardSuiteCase.id,
-    benchmarkCase: hostedWebHardSuiteCase,
-    revision: hostedWebHardSuiteRevision,
-    manifest,
-    contentHash: createHash("sha256").update(JSON.stringify(manifest)).digest("hex"),
-  };
-}
+export const hostedWebCatalogReleases = () => hostedWebSuites.map(createCatalogRelease);

--- a/packages/test-cases/src/seed-sql.ts
+++ b/packages/test-cases/src/seed-sql.ts
@@ -1,26 +1,21 @@
-import { hostedWebHardSuiteCase, hostedWebSuiteCase } from "./index.js";
-import { createHostedWebCatalogRelease, createHostedWebHardCatalogRelease } from "./release.js";
+import { hostedWebCatalogReleases } from "./release.js";
 
 export function generateSupabaseSeedSql() {
-  const easyRelease = createHostedWebCatalogRelease();
-  const easyManifest = JSON.stringify(easyRelease.manifest, null, 2);
-  const hardRelease = createHostedWebHardCatalogRelease();
-  const hardManifest = JSON.stringify(hardRelease.manifest, null, 2);
+  const catalogStatements = hostedWebCatalogReleases()
+    .map((release) =>
+      [
+        "select public.publish_benchmark_case_catalog(",
+        `  $case$${JSON.stringify(release.benchmarkCase, null, 2)}$case$::jsonb,`,
+        `  '${release.revision}',`,
+        `  $catalog$${JSON.stringify(release.manifest, null, 2)}$catalog$::jsonb,`,
+        `  '${release.contentHash}'`,
+        ");",
+      ].join("\n"),
+    )
+    .join("\n\n");
 
   return `-- Generated from packages/test-cases. Run \`pnpm catalog:generate\`; do not edit by hand.
-select public.publish_benchmark_case_catalog(
-  $case$${JSON.stringify(hostedWebSuiteCase, null, 2)}$case$::jsonb,
-  '${easyRelease.revision}',
-  $catalog$${easyManifest}$catalog$::jsonb,
-  '${easyRelease.contentHash}'
-);
-
-select public.publish_benchmark_case_catalog(
-  $case$${JSON.stringify(hostedWebHardSuiteCase, null, 2)}$case$::jsonb,
-  '${hardRelease.revision}',
-  $catalog$${hardManifest}$catalog$::jsonb,
-  '${hardRelease.contentHash}'
-);
+${catalogStatements}
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)
 values (

--- a/packages/test-cases/src/suites/registry.ts
+++ b/packages/test-cases/src/suites/registry.ts
@@ -1,0 +1,47 @@
+import type { HostedSuiteMetadata } from "../schemas.js";
+import {
+  hostedWebSuiteCase,
+  hostedWebSuiteMetadata,
+  hostedWebSuiteRevision,
+} from "./hosted-web.js";
+import {
+  hostedWebHardSuiteCase,
+  hostedWebHardSuiteMetadata,
+  hostedWebHardSuiteRevision,
+} from "./hosted-web-hard.js";
+
+// Display-and-catalog shape shared by every hosted-web suite case. `difficulty`
+// is just a tag on the row; nothing branches on suite identity.
+export interface HostedSuiteCase {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  category: string;
+  difficulty: string;
+  provider: "hosted-web";
+  metadata: Record<string, unknown>;
+  isPublic: boolean;
+}
+
+export interface HostedSuiteDefinition {
+  case: HostedSuiteCase;
+  metadata: HostedSuiteMetadata;
+  revision: string;
+}
+
+// The single authoritative list of hosted-web suites. Add a new suite by
+// creating its source file and appending one entry here — release/publish/seed
+// tooling all iterate this list, so no other file names a suite.
+export const hostedWebSuites: HostedSuiteDefinition[] = [
+  {
+    case: hostedWebSuiteCase,
+    metadata: hostedWebSuiteMetadata,
+    revision: hostedWebSuiteRevision,
+  },
+  {
+    case: hostedWebHardSuiteCase,
+    metadata: hostedWebHardSuiteMetadata,
+    revision: hostedWebHardSuiteRevision,
+  },
+];

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -2,82 +2,68 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   hostedSuiteMetadataSchema,
-  hostedWebHardSuiteCase,
   hostedWebHardSuiteMetadata,
-  hostedWebSuiteCase,
-  hostedWebSuiteMetadata,
+  hostedWebSuites,
 } from "../../src/index.js";
-import { createHostedWebCatalogRelease, createHostedWebHardCatalogRelease } from "../../src/release.js";
+import { createCatalogRelease } from "../../src/release.js";
 
-test("hosted catalog is valid and has unique app/task definitions", () => {
-  assert.equal(hostedWebSuiteCase.slug, "hosted-web-suite");
-  assert.deepEqual(hostedWebSuiteCase.metadata, {});
-  const suite = hostedSuiteMetadataSchema.parse(hostedWebSuiteMetadata);
-  assert.ok(suite.sessions.length > 0);
-  assert.equal(new Set(suite.sessions.map((session) => session.taskSlug)).size, suite.sessions.length);
-  assert.ok(suite.sessions.every((session, index) => session.sequenceIndex === index));
-  assert.ok(suite.sessions.every((session) => session.metadata.questionVariants.length >= 2));
+test("every hosted suite catalog is valid and has unique app/task definitions", () => {
+  for (const { case: benchmarkCase, metadata } of hostedWebSuites) {
+    assert.deepEqual(benchmarkCase.metadata, {}, `${benchmarkCase.slug} case metadata`);
+    const suite = hostedSuiteMetadataSchema.parse(metadata);
+    assert.ok(suite.sessions.length > 0, `${benchmarkCase.slug} has sessions`);
+    assert.equal(
+      new Set(suite.sessions.map((session) => session.taskSlug)).size,
+      suite.sessions.length,
+      `${benchmarkCase.slug} task slugs unique`,
+    );
+    assert.ok(suite.sessions.every((session, index) => session.sequenceIndex === index));
+    assert.ok(suite.sessions.every((session) => session.metadata.questionVariants.length >= 2));
+  }
 });
 
-test("hosted catalog rejects cross-app task config", () => {
-  const invalid = structuredClone(hostedWebSuiteMetadata);
-  invalid.sessions[0]!.metadata.questionVariants[0]!.taskConfig = {
-    targetThreadId: "thr-battery",
-    expectedReplyValue: "https://example.com",
-    expectedLockReason: "wrong app",
-  } as never;
-  assert.throws(() => hostedSuiteMetadataSchema.parse(invalid));
+test("every hosted suite catalog rejects cross-app task config", () => {
+  for (const { case: benchmarkCase, metadata } of hostedWebSuites) {
+    const invalid = structuredClone(metadata);
+    invalid.sessions[0]!.metadata.questionVariants[0]!.taskConfig = {
+      targetThreadId: "thr-battery",
+      expectedReplyValue: "https://example.com",
+      expectedLockReason: "wrong app",
+    } as never;
+    assert.throws(() => hostedSuiteMetadataSchema.parse(invalid), `${benchmarkCase.slug} rejects cross-app config`);
+  }
 });
 
-test("hosted catalog release has a stable revision identity and content hash", () => {
-  const first = createHostedWebCatalogRelease();
-  const second = createHostedWebCatalogRelease();
+test("every hosted suite catalog release has a stable revision identity and content hash", () => {
+  for (const suite of hostedWebSuites) {
+    const first = createCatalogRelease(suite);
+    const second = createCatalogRelease(suite);
 
-  assert.equal(first.revision, "hosted-web-suite-v3.0.8");
-  assert.match(first.contentHash, /^[0-9a-f]{64}$/);
-  assert.deepEqual(second, first);
+    assert.equal(first.revision, suite.revision);
+    assert.equal(first.caseId, suite.case.id);
+    assert.match(first.contentHash, /^[0-9a-f]{64}$/);
+    assert.deepEqual(second, first);
+  }
 });
 
-test("hosted hard catalog is valid and has unique app/task definitions", () => {
-  assert.equal(hostedWebHardSuiteCase.slug, "hosted-web-hard-suite");
-  assert.equal(hostedWebHardSuiteCase.difficulty, "hard");
-  assert.deepEqual(hostedWebHardSuiteCase.metadata, {});
-  const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
-  assert.ok(suite.sessions.length > 0);
-  assert.equal(new Set(suite.sessions.map((session) => session.taskSlug)).size, suite.sessions.length);
-  assert.ok(suite.sessions.every((session, index) => session.sequenceIndex === index));
-  assert.ok(suite.sessions.every((session) => session.metadata.questionVariants.length >= 2));
+test("hosted suite cases have distinct ids, slugs, and suite slugs", () => {
+  const ids = hostedWebSuites.map((suite) => suite.case.id);
+  const slugs = hostedWebSuites.map((suite) => suite.case.slug);
+  const suiteSlugs = hostedWebSuites.map((suite) => suite.metadata.suiteSlug);
+  assert.equal(new Set(ids).size, ids.length);
+  assert.equal(new Set(slugs).size, slugs.length);
+  assert.equal(new Set(suiteSlugs).size, suiteSlugs.length);
 });
 
-test("hosted hard catalog rejects cross-app task config", () => {
-  const invalid = structuredClone(hostedWebHardSuiteMetadata);
-  invalid.sessions[0]!.metadata.questionVariants[0]!.taskConfig = {
-    targetThreadId: "thr-battery",
-    expectedReplyValue: "https://example.com",
-    expectedLockReason: "wrong app",
-  } as never;
-  assert.throws(() => hostedSuiteMetadataSchema.parse(invalid));
-});
-
-test("hosted hard catalog release has a stable revision identity and content hash", () => {
-  const first = createHostedWebHardCatalogRelease();
-  const second = createHostedWebHardCatalogRelease();
-
-  assert.equal(first.revision, "hosted-web-hard-suite-v1.0.0");
-  assert.match(first.contentHash, /^[0-9a-f]{64}$/);
-  assert.deepEqual(second, first);
-});
-
-test("hosted easy and hard suite cases are distinct", () => {
-  assert.notEqual(hostedWebSuiteCase.id, hostedWebHardSuiteCase.id);
-  assert.notEqual(hostedWebSuiteCase.slug, hostedWebHardSuiteCase.slug);
-  assert.notEqual(hostedWebSuiteMetadata.suiteSlug, hostedWebHardSuiteMetadata.suiteSlug);
-});
-
-test("only the hard suite declares cross-app consistency checks", () => {
-  assert.equal((hostedWebSuiteMetadata as { consistencyChecks?: unknown[] }).consistencyChecks, undefined);
-  const checks = (hostedWebHardSuiteMetadata as { consistencyChecks?: unknown[] }).consistencyChecks ?? [];
-  assert.ok(checks.length > 0);
+test("difficulty is a tag: only hard suites declare cross-app consistency checks", () => {
+  for (const { case: benchmarkCase, metadata } of hostedWebSuites) {
+    const checks = (metadata as { consistencyChecks?: unknown[] }).consistencyChecks ?? [];
+    if (benchmarkCase.difficulty === "hard") {
+      assert.ok(checks.length > 0, `${benchmarkCase.slug} declares consistency checks`);
+    } else {
+      assert.equal(checks.length, 0, `${benchmarkCase.slug} declares no consistency checks`);
+    }
+  }
 });
 
 test("hard consistency checks reference real sessions with source before target", () => {


### PR DESCRIPTION
## Why

After #121 added the hard hosted-web suite, the suite could not be started in the browser: `scripts/publish.ts` published only the easy suite, so the `hosted-web-hard-suite` row/revision never existed in the DB while the frontend listed it and POSTed its id. Rather than special-case publishing the second suite, this removes the underlying cause — suites were hardcoded per-difficulty in both backend tooling and the frontend.

Both suites are already distinct rows in `public.benchmark_cases`, each carrying a `difficulty` column. This change treats every suite uniformly: `difficulty` is just a tag, and **adding a future suite means appending one entry to a single registry** — no new per-suite functions, union types, id maps, or hardcoded option lists.

## Backend — `packages/test-cases`

- **New `src/suites/registry.ts`** — the single `hostedWebSuites` list (`HostedSuiteDefinition[]`), the one place that enumerates published suites. Re-exported from `index.ts`.
- **`release.ts`** — replaced the two named builders with generic `createCatalogRelease(suite)` + `hostedWebCatalogReleases()`.
- **`scripts/publish.ts`** and **`seed-sql.ts`** now iterate the registry; no suite is named. `supabase/seed.sql` output stays **byte-identical** (easy-then-hard order preserved), so `pnpm catalog:check` is green.
- **`catalog.test.ts`** — generic assertions iterate the registry; the cross-app consistency-check test filters by `difficulty === "hard"`.

## Frontend — `apps/web`

- **`lib/db.ts`** — `listPublicHostedBenchmarkCases()` returns only display-safe fields (`id, slug, title, description, difficulty`), filtered to public hosted-web rows, ordered difficulty-then-created. `metadata` / `current_revision_id` stay service-role-only.
- **New `GET /api/benchmark-cases`** — exposes the public catalog; 503 on DB failure (mirrors the runs route).
- **`playground-store.ts`** — discovers suites at runtime via `fetchBenchmarks()`; `benchmark` is now the case id; removed the hardcoded option list and id union; `startRun` sends `caseId: <id>` (protocol's `caseId: uuid` contract unchanged).
- **`ConnectAgentCard.tsx` / `data.ts`** — picker is populated dynamically from the store; removed `benchmarkOptions`.

## Docs

- **`docs/hosted-web-benchmark.md`** — new "Suites & Difficulty" section (boundary, shared components, difficulty dimension).
- **`docs/hosted-site-app-authoring.md`** — note that the generated table reflects the easy suite and all suites are independent catalog rows.

## Verification

- `pnpm --filter @agentbench/test-cases test` — 9 pass
- `pnpm catalog:check` — seed.sql + docs byte-identical
- `pnpm --filter web test` — 28 pass
- `pnpm --filter web build` — clean, `/api/benchmark-cases` route registered
- Browser E2E — dynamic picker lists both suites (easy first), endpoint leaks no scorer-oracle fields, and starting the hard suite created a run with `case_id = bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb`.

## Deploy caveat

Production (main deploy) still has the original single-suite publish bug. Once this reaches main, the catalog must be re-published so **both** rows exist in the prod DB. That re-publish needs prod service-role credentials (not in local `.env.local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)