### PR TITLE
fix(web,hosted-sites): playground live preview, quota, score JSON

### DIFF
--- a/apps/hosted-sites/src/templates.ts
+++ b/apps/hosted-sites/src/templates.ts
@@ -1,7 +1,6 @@
 import type { ServerResponse } from "node:http";
 import type { HostedSession } from "./runtime/types.js";
 import { readUiTheme, readUiVariant } from "./runtime/question-config.js";
-import { shouldRenderScorePreview } from "./runtime/score-preview-policy.js";
 
 export function escapeHtml(value: string) {
   return value
@@ -344,7 +343,6 @@ export function layout(params: {
       </div>
       <nav class="nav">
         ${appNav}
-        ${shouldRenderScorePreview(params.session) ? `<a href="/api/sessions/${encodeURIComponent(params.session.token)}/score">Score JSON</a>` : ""}
       </nav>
     </header>
     <main>${params.body}</main>

--- a/apps/hosted-sites/tests/unit/templates.test.ts
+++ b/apps/hosted-sites/tests/unit/templates.test.ts
@@ -84,68 +84,40 @@ test("terminal layout disables forms and does not emit telemetry", () => {
   assert.doesNotMatch(html, /abTelemetry/);
 });
 
-test("layout renders Score JSON link in dev mode for active sessions", () => {
-  const html = layout({
-    title: "Dev preview",
-    session: makeSession("workspace", "light", "dev"),
-    body: '<section class="panel">Body</section>',
-    publicBaseUrl: "http://localhost:3003",
-    defaultStartPathForApp: () => "/wiki",
-  });
+test("layout never renders Score JSON link", () => {
+  for (const scorePreviewMode of ["dev", "token", "disabled"] as const) {
+    const session = makeSession("workspace", "light", scorePreviewMode);
+    const html = layout({
+      title: "No score preview",
+      session,
+      body: '<section class="panel">Body</section>',
+      publicBaseUrl: "http://localhost:3003",
+      defaultStartPathForApp: () => "/wiki",
+    });
 
-  assert.match(html, /Score JSON/);
-  assert.match(html, /href="\/api\/sessions\/tok_layout\/score"/);
-});
+    assert.doesNotMatch(html, /Score JSON/);
+    assert.doesNotMatch(html, /href="\/api\/sessions\/tok_layout\/score"/);
+  }
 
-test("layout hides Score JSON link in disabled mode for active sessions", () => {
-  const html = layout({
-    title: "Disabled preview",
-    session: makeSession("workspace", "light", "disabled"),
-    body: '<section class="panel">Body</section>',
-    publicBaseUrl: "http://localhost:3003",
-    defaultStartPathForApp: () => "/wiki",
-  });
-
-  assert.doesNotMatch(html, /Score JSON/);
-  assert.doesNotMatch(html, /href="\/api\/sessions\/tok_layout\/score"/);
-});
-
-test("layout hides Score JSON link in token mode for non-viewer active sessions", () => {
-  const html = layout({
-    title: "Token preview",
-    session: makeSession("workspace", "light", "token"),
-    body: '<section class="panel">Body</section>',
-    publicBaseUrl: "http://localhost:3003",
-    defaultStartPathForApp: () => "/wiki",
-  });
-
-  assert.doesNotMatch(html, /Score JSON/);
-});
-
-test("layout renders Score JSON link in token mode for viewer sessions", () => {
-  const session = makeSession("workspace", "light", "token");
-  session.accessMode = "viewer";
-  const html = layout({
+  const viewerSession = makeSession("workspace", "light", "token");
+  viewerSession.accessMode = "viewer";
+  const viewerHtml = layout({
     title: "Viewer preview",
-    session,
+    session: viewerSession,
     body: '<section class="panel">Body</section>',
     publicBaseUrl: "http://localhost:3003",
     defaultStartPathForApp: () => "/wiki",
   });
+  assert.doesNotMatch(viewerHtml, /Score JSON/);
 
-  assert.match(html, /Score JSON/);
-});
-
-test("layout renders Score JSON link for terminal sessions regardless of mode", () => {
-  const session = makeSession("workspace", "light", "disabled");
-  session.status = "failed";
-  const html = layout({
+  const terminalSession = makeSession("workspace", "light", "disabled");
+  terminalSession.status = "failed";
+  const terminalHtml = layout({
     title: "Terminal disabled preview",
-    session,
+    session: terminalSession,
     body: '<section class="panel">Body</section>',
     publicBaseUrl: "http://localhost:3003",
     defaultStartPathForApp: () => "/wiki",
   });
-
-  assert.match(html, /Score JSON/);
+  assert.doesNotMatch(terminalHtml, /Score JSON/);
 });

--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import { HeroMacFrame } from "./HeroMacFrame";
 import { cn } from "@/lib/utils";
+import { usePlaygroundStore } from "@/lib/playground-store";
 
 const stats = [
   { label: "Practical Tasks", value: "Real workflows, not toy demos" },
@@ -19,6 +21,24 @@ export function HeroSection({
   embedded?: boolean;
   sectionId?: string;
 }) {
+  const quota = usePlaygroundStore((state) => state.quota);
+  const quotaLoading = usePlaygroundStore((state) => state.quotaLoading);
+  const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
+
+  useEffect(() => {
+    void fetchQuota();
+  }, [fetchQuota]);
+
+  const quotaBadge = quotaLoading
+    ? "Loading quota…"
+    : quota
+      ? quota.mode === "guest"
+        ? quota.remaining <= 0
+          ? "Guest trial used"
+          : `${Math.max(quota.remaining, 0)} free run${quota.remaining === 1 ? "" : "s"} today`
+        : `${Math.max(quota.remaining, 0)} of ${quota.limit} runs today`
+      : "1 free run today";
+
   return (
     <section
       id={sectionId}
@@ -47,7 +67,7 @@ export function HeroSection({
                 Run Your Agent
               </a>
               <div className="rounded-full bg-[#f0f0ed] px-6 py-4 text-base font-medium text-[#111111]">
-                1 free run today
+                {quotaBadge}
               </div>
             </div>
             <div className="mt-10 grid max-w-[35rem] gap-3 sm:grid-cols-2">

--- a/apps/web/components/landing/LiveMacContainer.tsx
+++ b/apps/web/components/landing/LiveMacContainer.tsx
@@ -86,7 +86,7 @@ export function LiveMacScreenContent() {
           <iframe
             src={embeddedLiveViewUrl}
             title="Embedded live run viewer"
-            className="absolute left-0 top-0 h-[300%] w-[300%] origin-top-left scale-[0.334] border-0 bg-[#111111]"
+            className="absolute left-0 top-0 h-[300%] w-[300%] origin-top-left scale-[0.333333] border-0 bg-[#111111]"
           />
         </div>
       ) : liveFrameUrl ? (

--- a/apps/web/components/run/LiveRunViewer.tsx
+++ b/apps/web/components/run/LiveRunViewer.tsx
@@ -175,39 +175,33 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
   if (embedded) {
     return (
       <main className="h-full bg-[#111111] text-[#f7f2e7]">
-        <div className="flex h-full flex-col">
-          <div className="flex items-center justify-between border-b border-white/10 px-3 py-2 text-[9px] uppercase tracking-[0.16em] text-[#8f897e]">
-            <span className="truncate">browser-session.live</span>
-            <span>{status}</span>
-          </div>
-          <div className="relative flex-1 bg-[#111111]">
-            {viewerUrl ? (
-              <iframe
-                key={`${viewerUrl}:${viewerRevision}`}
-                src={viewerUrl}
-                title="Read-only hosted session"
-                sandbox="allow-same-origin"
-                referrerPolicy="no-referrer"
-                className="h-full w-full border-0 bg-white"
-              />
-            ) : frameUrl ? (
-              <img
-                src={frameUrl}
-                alt="Live browser session"
-                className="h-full w-full object-contain"
-              />
-            ) : (
-              <HostedEventFallback events={hostedEvents} compact />
-            )}
-            {latestHostedEvent ? (
-              <div className="pointer-events-none absolute left-2 top-2 max-w-[75%] rounded-full bg-black/70 px-3 py-1.5 text-[9px] text-[#f1ebde]">
-                {hostedEventLabel(latestHostedEvent)}
-              </div>
-            ) : null}
-            <div className="pointer-events-none absolute bottom-2 left-2 right-2 flex items-center justify-between rounded-full bg-black/55 px-3 py-1.5 text-[9px] uppercase tracking-[0.15em] text-[#f1ebde]">
-              <span className="truncate">{initialTitle}</span>
-              <span>Score {score === null ? "--" : `${Math.round(score * 100)}%`}</span>
+        <div className="relative h-full bg-[#111111]">
+          {viewerUrl ? (
+            <iframe
+              key={`${viewerUrl}:${viewerRevision}`}
+              src={viewerUrl}
+              title="Read-only hosted session"
+              sandbox="allow-same-origin"
+              referrerPolicy="no-referrer"
+              className="h-full w-full border-0 bg-white"
+            />
+          ) : frameUrl ? (
+            <img
+              src={frameUrl}
+              alt="Live browser session"
+              className="h-full w-full object-contain"
+            />
+          ) : (
+            <HostedEventFallback events={hostedEvents} compact />
+          )}
+          {latestHostedEvent ? (
+            <div className="pointer-events-none absolute left-2 top-2 max-w-[75%] rounded-full bg-black/70 px-3 py-1.5 text-[9px] text-[#f1ebde]">
+              {hostedEventLabel(latestHostedEvent)}
             </div>
+          ) : null}
+          <div className="pointer-events-none absolute bottom-2 left-2 right-2 flex items-center justify-between rounded-full bg-black/55 px-3 py-1.5 text-[9px] uppercase tracking-[0.15em] text-[#f1ebde]">
+            <span className="truncate">{initialTitle}</span>
+            <span>Score {score === null ? "--" : `${Math.round(score * 100)}%`}</span>
           </div>
         </div>
       </main>

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -812,7 +812,8 @@ export async function getQuotaStatus(params: {
     const countResult = await getSupabase()
       .from("benchmark_runs")
       .select("*", { count: "exact", head: true })
-      .eq("guest_id", guestId);
+      .eq("guest_id", guestId)
+      .gte("created_at", startOfUtcDay());
     if (countResult.error) {
       throw countResult.error;
     }


### PR DESCRIPTION
## What

Follow-up fixes after #122 was merged.

## Changes

- **Playground live preview** (`PlaygroundSection` → `LiveMacContainer`):
  - Use exact 1/3 scale (`0.333333`) so the 300% iframe fits the Mac CRT content area without overflow clipping.
  - Remove the embedded `LiveRunViewer` header so the hosted-site iframe gets the full height; status/title overlays remain as non-blocking `pointer-events-none` badges.
- **Landing quota badge** (`HeroSection`):
  - Replace hardcoded `"1 free run today"` with live quota from `usePlaygroundStore`.
  - Fetch quota on mount so the badge updates in real time.
- **Daily quota reset**:
  - Guest quota query was counting every run ever made with the guest id.
  - Add `.gte("created_at", startOfUtcDay())` so guest runs reset at UTC midnight like user runs.
- **Score JSON links**:
  - Remove the "Score JSON" nav link from the shared hosted-app layout template.
  - Update `templates.test.ts` to assert the link is never rendered.

## Verification

- `pnpm --filter web build` ✅
- `pnpm --filter web test` ✅ 28 pass
- `pnpm --filter hosted-sites test` ✅ 248 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)