### PR TITLE
feat(hosted-orchestrator,web): per-testcase time limits, leaderboard timeout fixes, and iframe height

### DIFF
--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -132,6 +132,15 @@ function tokenFromStartUrl(startUrl: string) {
   }
 }
 
+const DEFAULT_SESSION_TIME_LIMIT_MINUTES = 360;
+
+function sessionExpiresAt(baseTime: string | number | Date, timeLimitMinutes?: number) {
+  const minutes = typeof timeLimitMinutes === "number" && Number.isFinite(timeLimitMinutes) && timeLimitMinutes > 0
+    ? timeLimitMinutes
+    : DEFAULT_SESSION_TIME_LIMIT_MINUTES;
+  return new Date(new Date(baseTime).getTime() + minutes * 60 * 1000).toISOString();
+}
+
 function buildViewerStartUrl(sessionId: string, startPath: string, expiresAt: string) {
   if (!viewerTokenSecret) {
     return null;
@@ -680,13 +689,16 @@ async function initializeAttempt(params: InitializeAttemptParams) {
     throw attemptError ?? new Error("Failed to create hosted attempt");
   }
 
-  const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 6).toISOString();
+  const suiteTimeLimitMinutes = revision.timeLimitMinutesPerTestcase;
   const orderedSessions = [...generatedSessions].sort((left, right) => left.sequenceIndex - right.sequenceIndex);
   const rows = orderedSessions.map((session) => {
     const token = makeId("tok");
     const startPath = session.startPath ?? defaultStartPathForApp(session.app);
     const startUrl = `${hostedSitesPublicBaseUrl}${startPath}?session=${encodeURIComponent(token)}`;
     const status: HostedSessionStatus = session.sequenceIndex > 0 ? "created" : "active";
+    const sessionExpiresAtValue = status === "active"
+      ? sessionExpiresAt(Date.now(), suiteTimeLimitMinutes)
+      : null;
     const sessionMetadata = {
       ...session.metadata,
       schemaVersion: 1,
@@ -698,6 +710,7 @@ async function initializeAttempt(params: InitializeAttemptParams) {
       title: session.title,
       goal: session.goal,
       startPath,
+      timeLimitMinutesPerTestcase: suiteTimeLimitMinutes,
     } satisfies HostedWebSessionMetadata;
 
     return {
@@ -717,7 +730,7 @@ async function initializeAttempt(params: InitializeAttemptParams) {
       status,
       metadata: sessionMetadata,
       activated_at: now(),
-      expires_at: expiresAt,
+      expires_at: sessionExpiresAtValue,
       token,
     };
   });
@@ -757,7 +770,9 @@ async function initializeAttempt(params: InitializeAttemptParams) {
         weight: row.weight,
         required: row.required,
         startUrl: row.start_url,
-        viewerStartUrl: buildViewerStartUrl(row.id, new URL(seed.start_url).pathname, expiresAt),
+        viewerStartUrl: seed.expires_at
+          ? buildViewerStartUrl(row.id, new URL(seed.start_url).pathname, seed.expires_at)
+          : null,
         goal: metadata.goal,
         title: typeof metadata.title === "string" ? metadata.title : null,
         status: row.status,
@@ -1193,7 +1208,9 @@ async function sweepExpiredSessions() {
   const sweepStartedAt = now();
   const { data, error } = await supabase
     .from("hosted_web_sessions")
-    .select("id, attempt_id, run_id, task_slug, app")
+    .select(
+      "id, run_id, case_id, attempt_id, app, task_slug, task_version, sequence_index, weight, required, seed_version, status, metadata, start_url, expires_at, created_at",
+    )
     .lt("expires_at", sweepStartedAt)
     .in("status", ["created", "active", "scoring"])
     .limit(500);
@@ -1203,7 +1220,7 @@ async function sweepExpiredSessions() {
     return 0;
   }
 
-  const expiredRows = data ?? [];
+  const expiredRows = (data ?? []) as PersistedSessionRow[];
   if (expiredRows.length === 0) {
     return 0;
   }
@@ -1225,25 +1242,28 @@ async function sweepExpiredSessions() {
     console.error("[hosted-orchestrator] failed to persist expiry sweep logs", accessLogError);
   }
 
-  const attemptsToTimeout = new Map<string, { runId: string | null; sessionId: string; taskSlug: string }>();
   for (const row of expiredRows) {
-    if (!row.attempt_id || attemptsToTimeout.has(row.attempt_id)) {
+    const token = tokenFromStartUrl(row.start_url);
+    if (!token || !row.attempt_id) {
       continue;
     }
-    attemptsToTimeout.set(row.attempt_id, {
-      runId: row.run_id,
-      sessionId: row.id,
-      taskSlug: row.task_slug,
-    });
-  }
-
-  for (const [attemptId, timeoutSeed] of attemptsToTimeout) {
-    await attemptHandlers.handleTimeoutAttempt({
-      attemptId,
-      runId: timeoutSeed.runId,
-      expiredSessionId: timeoutSeed.sessionId,
-      expiredTaskSlug: timeoutSeed.taskSlug,
-    });
+    const session = buildLifecycleSessionFromRow(row, token);
+    try {
+      await attemptHandlers.handleCompleteSession({
+        session,
+        result: {
+          status: "failed",
+          score: 0,
+          summary: `Hosted session ${row.task_slug} timed out after ${row.metadata?.timeLimitMinutesPerTestcase ?? 360} minutes.`,
+          evaluators: [],
+        },
+      });
+    } catch (error) {
+      console.error(
+        `[hosted-orchestrator] failed to finalize timed-out session ${row.id} (${row.task_slug})`,
+        error,
+      );
+    }
   }
 
   return expiredRows.length;

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -93,11 +93,10 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
       </div>
 
       <div className="overflow-hidden rounded-[1.5rem] border border-[#d8d0c2] bg-[#111111] shadow-[0_32px_90px_rgba(77,63,36,0.16)] lg:rounded-[2rem]">
-        <div className="hidden grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] gap-4 border-b border-white/10 px-6 py-4 text-[10px] uppercase tracking-[0.2em] text-white/40 lg:grid">
+        <div className="hidden grid-cols-[64px_1.35fr_1.2fr_0.75fr_96px] gap-4 border-b border-white/10 px-6 py-4 text-[10px] uppercase tracking-[0.2em] text-white/40 lg:grid">
           <span>Rank</span>
           <span>Agent / model</span>
           <span>Benchmark</span>
-          <span>Browser</span>
           <span>Finished</span>
           <span className="text-right">Score</span>
         </div>
@@ -107,7 +106,7 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
             <a
               key={entry.runId}
               href={`/results/${entry.runId}`}
-              className="group grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_64px] items-center gap-3 border-b border-white/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-white/[0.045] lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6"
+              className="group grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_64px] items-center gap-3 border-b border-white/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-white/[0.045] lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6"
             >
               <span className={entry.rank <= 3 ? "text-xl font-medium text-[#d7ff00] lg:text-3xl" : "text-xl text-white/45 lg:text-2xl"}>
                 {entry.rank.toString().padStart(2, "0")}
@@ -116,9 +115,13 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
                 <div className="truncate text-sm font-medium text-white lg:text-lg">{entry.agentName}</div>
                 <div className="mt-1 truncate text-[11px] text-white/45 lg:text-xs">
                   <span className="lg:hidden">{entry.baseModel}</span>
-                  <span className="hidden lg:inline">{entry.agentVersion} · {entry.baseModel}</span>
+                  <span className="hidden lg:inline">{entry.browser ?? "Unknown browser"} · {entry.platform ?? "Unknown platform"}</span>
                 </div>
-                {entry.status === "failed" ? (
+                {entry.status === "timeout" ? (
+                  <div className="mt-2 inline-flex rounded-full bg-[#ffb627]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ffc44d]">
+                    Timed out
+                  </div>
+                ) : entry.status === "failed" ? (
                   <div className="mt-2 inline-flex rounded-full bg-[#ff8d7a]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ff9f90]">
                     Failed run
                   </div>
@@ -126,18 +129,16 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
               </div>
               <div className="hidden min-w-0 lg:block">
                 <div className="truncate text-sm text-white/85">{entry.benchmark}</div>
-                <div className="mt-1 text-xs text-white/40">
-                  {entry.suiteVersion ?? "suite version unavailable"} · {formatDuration(entry.durationMs)}
-                </div>
-              </div>
-              <div className="hidden text-sm text-white/70 lg:block">
-                {entry.browser ?? "Unknown browser"}
-                <div className="mt-1 text-xs text-white/35">{entry.platform ?? "Unknown platform"}</div>
+                <div className="mt-1 text-xs text-white/40">{formatDuration(entry.durationMs)}</div>
               </div>
               <div className="hidden text-sm text-white/70 lg:block">{formatCompletedAt(entry.completedAt)}</div>
               <div className="text-right">
                 <span className={`text-2xl font-medium tracking-[-0.04em] lg:text-3xl ${
-                  entry.status === "failed" ? "text-[#ff9f90]" : "text-white group-hover:text-[#d7ff00]"
+                  entry.status === "failed"
+                    ? "text-[#ff9f90]"
+                    : entry.status === "timeout"
+                      ? "text-[#ffc44d]"
+                      : "text-white group-hover:text-[#d7ff00]"
                 }`}>
                   {Math.round(entry.score * 100)}
                 </span>

--- a/apps/web/components/run/LiveRunViewer.tsx
+++ b/apps/web/components/run/LiveRunViewer.tsx
@@ -174,8 +174,8 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
 
   if (embedded) {
     return (
-      <main className="h-full bg-[#111111] text-[#f7f2e7]">
-        <div className="relative h-full bg-[#111111]">
+      <main className="h-screen bg-[#111111] text-[#f7f2e7]">
+        <div className="relative h-screen bg-[#111111]">
           {viewerUrl ? (
             <iframe
               key={`${viewerUrl}:${viewerRevision}`}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -589,7 +589,7 @@ export async function submitBenchmarkRunMetadata(
 export type LeaderboardEntry = {
   runId: string;
   rank: number;
-  status: "completed" | "failed";
+  status: "completed" | "failed" | "timeout";
   score: number;
   completedAt: string;
   durationMs: number | null;
@@ -661,7 +661,7 @@ export async function listPublicLeaderboardVersions(): Promise<string[]> {
   const { data: publicRuns, error: runError } = await supabase
     .from("benchmark_runs")
     .select("id")
-    .in("status", ["completed", "failed"])
+    .in("status", ["completed", "failed", "timeout"])
     .eq("is_public", true)
     .not("score", "is", null)
     .limit(1000);
@@ -710,17 +710,18 @@ export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): 
   let runsQuery = supabase
     .from("benchmark_runs")
     .select("id, case_id, status, score, started_at, completed_at, agent_name, agent_version, base_model, browser_environment")
-    .in("status", ["completed", "failed"])
+    .in("status", ["completed", "failed", "timeout"])
     .eq("is_public", true)
     .not("score", "is", null)
-    .order("score", { ascending: false })
-    .order("completed_at", { ascending: true });
+    .order("score", { ascending: false });
 
   if (versionRunIds) {
     runsQuery = runsQuery.in("id", versionRunIds);
   }
 
-  const { data: runs, error } = await runsQuery.limit(Math.max(1, Math.min(limit, 100)));
+  const fetchLimit = Math.max(limit, Math.min(limit * 5, 100));
+
+  const { data: runs, error } = await runsQuery.limit(fetchLimit);
 
   if (error || !runs) {
     throw error ?? new Error("Failed to load leaderboard");
@@ -737,21 +738,22 @@ export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): 
   }
 
   const summaryByRun = new Map((summaries ?? []).map((item) => [item.run_id, item]));
-  return runs.map((run, index) => {
+  const entries = runs.map((run) => {
     const browser = run.browser_environment && typeof run.browser_environment === "object" && !Array.isArray(run.browser_environment)
       ? run.browser_environment as Record<string, unknown>
       : {};
     const summary = summaryByRun.get(run.id);
     const observedBrowser = parseBrowserEnvironment(summary?.observed_user_agent ?? null);
+    const durationMs = run.started_at && run.completed_at
+      ? Math.max(0, new Date(run.completed_at).getTime() - new Date(run.started_at).getTime())
+      : null;
     return {
       runId: run.id,
-      rank: index + 1,
+      rank: 0,
       status: run.status as LeaderboardEntry["status"],
       score: Number(run.score),
       completedAt: run.completed_at!,
-      durationMs: run.started_at && run.completed_at
-        ? Math.max(0, new Date(run.completed_at).getTime() - new Date(run.started_at).getTime())
-        : null,
+      durationMs,
       benchmark: summary?.benchmark_title ?? "Hosted benchmark",
       suiteVersion: summary?.suite_version ?? null,
       agentName: run.agent_name ?? "Unreported agent",
@@ -761,6 +763,17 @@ export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): 
       platform: observedBrowser?.platform ?? (typeof browser.platform === "string" ? browser.platform : null),
     };
   });
+
+  entries.sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+    const leftDuration = left.durationMs ?? Number.MAX_SAFE_INTEGER;
+    const rightDuration = right.durationMs ?? Number.MAX_SAFE_INTEGER;
+    return leftDuration - rightDuration;
+  });
+
+  return entries.slice(0, limit).map((entry, index) => ({ ...entry, rank: index + 1 }));
 }
 
 export async function getQuotaStatus(params: {

--- a/packages/test-cases/src/schemas.ts
+++ b/packages/test-cases/src/schemas.ts
@@ -23,6 +23,7 @@ export type HostedSuiteConsistencyCheck = z.infer<typeof hostedSuiteConsistencyC
 export const hostedSuiteMetadataSchema = z.object({
   suiteSlug: z.string().min(1),
   suiteVersion: z.string().min(1),
+  timeLimitMinutesPerTestcase: z.number().int().positive().optional(),
   sessions: z.array(hostedSessionDefinitionSchema).min(1),
   // Optional so suites without a chain (the easy suite) parse to byte-identical
   // manifests — the key is simply absent rather than defaulted in.

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -14,6 +14,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-hard-suite-v1",
   suiteVersion: "v1.0.0",
+  timeLimitMinutesPerTestcase: 60,
   sessions: [
     {
       app: "shopping-lite",
@@ -37,6 +38,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 1,
       weight: 1,
       required: true,
+      timeLimitMinutes: 60,
       metadata: { questionVariants: forumQuestionVariants },
     },
     {
@@ -49,6 +51,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 2,
       weight: 1,
       required: true,
+      timeLimitMinutes: 60,
       metadata: { questionVariants: repoQuestionVariants },
     },
     {
@@ -61,6 +64,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 3,
       weight: 1,
       required: true,
+      timeLimitMinutes: 60,
       metadata: { questionVariants: wikiHardQuestionVariants },
     },
     {
@@ -73,6 +77,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 4,
       weight: 1,
       required: true,
+      timeLimitMinutes: 60,
       metadata: { questionVariants: wikiHardQuestionVariants },
     },
     {
@@ -85,6 +90,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 5,
       weight: 1,
       required: true,
+      timeLimitMinutes: 60,
       metadata: { questionVariants: notesQuestionVariants },
     },
     {
@@ -97,6 +103,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 6,
       weight: 1,
       required: true,
+      timeLimitMinutes: 60,
       metadata: { questionVariants: calendarQuestionVariants },
     },
   ],

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -12,6 +12,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
   suiteVersion: "v3.0.8",
+  timeLimitMinutesPerTestcase: 30,
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -46,6 +46,15 @@ test("every hosted suite catalog release has a stable revision identity and cont
   }
 });
 
+test("every hosted suite declares a positive per-testcase time limit", () => {
+  for (const { case: benchmarkCase, metadata } of hostedWebSuites) {
+    assert.ok(
+      typeof metadata.timeLimitMinutesPerTestcase === "number" && metadata.timeLimitMinutesPerTestcase > 0,
+      `${benchmarkCase.slug} declares a positive timeLimitMinutesPerTestcase`,
+    );
+  }
+});
+
 test("hosted suite cases have distinct ids, slugs, and suite slugs", () => {
   const ids = hostedWebSuites.map((suite) => suite.case.id);
   const slugs = hostedWebSuites.map((suite) => suite.case.slug);

--- a/supabase/migrations/20260630000026_per_session_time_limits.sql
+++ b/supabase/migrations/20260630000026_per_session_time_limits.sql
@@ -1,0 +1,176 @@
+create or replace function public.complete_hosted_attempt_session(
+  p_attempt_id uuid,
+  p_session_id uuid,
+  p_completed_at timestamptz,
+  p_result jsonb,
+  p_attempt_update jsonb
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  attempt_row public.benchmark_attempts%rowtype;
+  session_row public.hosted_web_sessions%rowtype;
+  result_row public.hosted_web_results%rowtype;
+  score_row public.benchmark_attempt_scores%rowtype;
+  next_session_id uuid;
+  is_complete boolean := coalesce((p_attempt_update ->> 'complete')::boolean, false);
+  next_time_limit_minutes int;
+begin
+  select * into attempt_row
+  from public.benchmark_attempts attempts
+  where attempts.id = p_attempt_id
+  for update;
+
+  if not found then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'attempt_not_found');
+  end if;
+
+  select * into result_row
+  from public.hosted_web_results results
+  where results.session_id = p_session_id;
+
+  if found then
+    select * into score_row
+    from public.benchmark_attempt_scores scores
+    where scores.attempt_id = p_attempt_id;
+    return jsonb_build_object(
+      'transitioned', false,
+      'duplicate', true,
+      'conflict', null,
+      'result', jsonb_build_object(
+        'status', result_row.status,
+        'score', result_row.score,
+        'summary', result_row.summary,
+        'evaluators', result_row.evaluators
+      ),
+      'complete', score_row.id is not null,
+      'aggregate', case when score_row.id is null then null else jsonb_build_object(
+        'status', score_row.status,
+        'score', score_row.score,
+        'summary', score_row.summary,
+        'breakdown', score_row.breakdown
+      ) end
+    );
+  end if;
+
+  if attempt_row.status in ('completed', 'failed', 'cancelled', 'timeout') then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'attempt_terminal');
+  end if;
+
+  if nullif(attempt_row.metadata ->> 'activeSessionId', '') is distinct from p_session_id::text then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'session_not_active');
+  end if;
+
+  select * into session_row
+  from public.hosted_web_sessions sessions
+  where sessions.id = p_session_id
+    and sessions.attempt_id = p_attempt_id
+  for update;
+
+  if not found or session_row.status not in ('active', 'scoring') then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'session_not_completable');
+  end if;
+
+  insert into public.hosted_web_results (
+    session_id, run_id, attempt_id, app, task_slug, weight,
+    status, score, summary, final_state, evaluators
+  ) values (
+    p_session_id,
+    attempt_row.run_id,
+    p_attempt_id,
+    session_row.app,
+    session_row.task_slug,
+    session_row.weight,
+    p_result ->> 'status',
+    (p_result ->> 'score')::numeric,
+    p_result ->> 'summary',
+    coalesce(p_result -> 'finalState', 'null'::jsonb),
+    coalesce(p_result -> 'evaluators', '[]'::jsonb)
+  )
+  returning * into result_row;
+
+  update public.hosted_web_sessions
+  set
+    status = case when result_row.status = 'passed' then 'completed' else 'failed' end,
+    completed_at = p_completed_at
+  where id = p_session_id;
+
+  if is_complete then
+    insert into public.benchmark_attempt_scores (
+      run_id, attempt_id, status, score, summary, breakdown
+    ) values (
+      attempt_row.run_id,
+      p_attempt_id,
+      p_attempt_update -> 'aggregate' ->> 'status',
+      (p_attempt_update -> 'aggregate' ->> 'score')::numeric,
+      p_attempt_update -> 'aggregate' ->> 'summary',
+      p_attempt_update -> 'aggregate' -> 'breakdown'
+    )
+    returning * into score_row;
+
+    update public.benchmark_attempts
+    set
+      status = p_attempt_update ->> 'status',
+      aggregate_score = score_row.score,
+      metadata = p_attempt_update -> 'metadata',
+      scoring_summary = p_attempt_update -> 'scoringSummary',
+      completed_at = p_completed_at
+    where id = p_attempt_id;
+  else
+    next_session_id := nullif(p_attempt_update ->> 'nextSessionId', '')::uuid;
+    next_time_limit_minutes := coalesce((
+      select (metadata ->> 'timeLimitMinutesPerTestcase')::int
+      from public.hosted_web_sessions
+      where id = next_session_id
+        and attempt_id = p_attempt_id
+    ), 360);
+
+    update public.hosted_web_sessions
+    set
+      status = 'active',
+      activated_at = coalesce(activated_at, p_completed_at),
+      expires_at = p_completed_at + (next_time_limit_minutes || ' minutes')::interval
+    where id = next_session_id
+      and attempt_id = p_attempt_id
+      and status = 'created';
+
+    if not found then
+      raise exception 'Next session % cannot be promoted for attempt %', next_session_id, p_attempt_id;
+    end if;
+
+    update public.benchmark_attempts
+    set
+      status = 'running',
+      metadata = p_attempt_update -> 'metadata',
+      scoring_summary = p_attempt_update -> 'scoringSummary'
+    where id = p_attempt_id;
+  end if;
+
+  return jsonb_build_object(
+    'transitioned', true,
+    'duplicate', false,
+    'conflict', null,
+    'result', jsonb_build_object(
+      'status', result_row.status,
+      'score', result_row.score,
+      'summary', result_row.summary,
+      'evaluators', result_row.evaluators
+    ),
+    'complete', is_complete,
+    'aggregate', case when is_complete then jsonb_build_object(
+      'status', score_row.status,
+      'score', score_row.score,
+      'summary', score_row.summary,
+      'breakdown', score_row.breakdown
+    ) else null end
+  );
+end;
+$$;
+
+revoke all on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) from public;
+revoke all on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) from anon;
+revoke all on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) from authenticated;
+grant execute on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) to service_role;

--- a/supabase/migrations/20260630000027_include_timeout_leaderboard.sql
+++ b/supabase/migrations/20260630000027_include_timeout_leaderboard.sql
@@ -1,0 +1,57 @@
+drop index if exists public.idx_benchmark_runs_public_leaderboard;
+
+create index idx_benchmark_runs_public_leaderboard
+  on public.benchmark_runs (score desc, completed_at asc)
+  where status in ('completed', 'failed', 'timeout')
+    and is_public = true
+    and score is not null;
+
+create or replace view public.public_hosted_run_summaries
+with (security_barrier = true)
+as
+select
+  runs.id as run_id,
+  runs.case_id,
+  cases.title as benchmark_title,
+  attempts.suite_slug,
+  attempts.suite_version,
+  (
+    select sessions.first_seen_user_agent
+    from public.hosted_web_sessions as sessions
+    where sessions.run_id = runs.id
+      and sessions.first_seen_user_agent is not null
+    order by sessions.sequence_index asc
+    limit 1
+  ) as observed_user_agent
+from public.benchmark_runs as runs
+join public.benchmark_cases as cases on cases.id = runs.case_id
+join public.benchmark_attempts as attempts on attempts.run_id = runs.id
+where runs.status in ('completed', 'failed', 'timeout')
+  and runs.is_public = true
+  and attempts.status in ('completed', 'failed', 'timeout');
+
+create or replace view public.public_hosted_run_tasks
+with (security_barrier = true)
+as
+select
+  results.run_id,
+  results.app,
+  results.task_slug,
+  results.status,
+  results.score,
+  results.summary,
+  results.created_at
+from public.hosted_web_results as results
+join public.benchmark_runs as runs on runs.id = results.run_id
+where runs.status in ('completed', 'failed', 'timeout')
+  and runs.is_public = true;
+
+revoke all on table public.public_hosted_run_summaries from public;
+revoke all on table public.public_hosted_run_tasks from public;
+grant select on table public.public_hosted_run_summaries to anon, authenticated, service_role;
+grant select on table public.public_hosted_run_tasks to anon, authenticated, service_role;
+
+comment on view public.public_hosted_run_summaries is
+  'Public terminal scored-run suite identity and observed browser projection. Includes timed-out attempts so hard-suite results are visible. Web must not read hosted lifecycle tables directly.';
+comment on view public.public_hosted_run_tasks is
+  'Public terminal scored-run task result projection. Includes timed-out attempts so hard-suite task results are visible. Web must not read hosted lifecycle tables directly.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -15,6 +15,7 @@ select public.publish_benchmark_case_catalog(
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
   "suiteVersion": "v3.0.8",
+  "timeLimitMinutesPerTestcase": 30,
   "sessions": [
     {
       "app": "shopping-lite",
@@ -592,7 +593,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '7e4bc4d598f3240e29487673714fccee5eac5d8e97572806c3910cdd1852bf5f'
+  '878f213de9cbdae693b265de097bd588d22a3ef7a04fcb362e3b2c05a76dff4d'
 );
 
 select public.publish_benchmark_case_catalog(
@@ -611,6 +612,7 @@ select public.publish_benchmark_case_catalog(
   $catalog${
   "suiteSlug": "hosted-web-hard-suite-v1",
   "suiteVersion": "v1.0.0",
+  "timeLimitMinutesPerTestcase": 60,
   "sessions": [
     {
       "app": "shopping-lite",
@@ -1235,7 +1237,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '3460f642bf312a81e8dca10758b3ee0d6f82a26ae8c10937e4f0fdc60d39cde1'
+  'fbd404f24cbb010caa3c364af9bec3861399d9f1939f96660eef92ccbe1a1ef2'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
This PR includes:

- Per-testcase time limits with suite-level `timeLimitMinutesPerTestcase` (30 min easy / 60 min hard).
- Session expiry computed per hosted web session; timed-out sessions are scored as failed and the suite continues.
- Leaderboard now includes `timeout` status runs/attempts so hard-suite results appear.
- Leaderboard ranking is now score primary, completion duration secondary (fastest first).
- Leaderboard UI removes the Browser column, moves browser/platform below the agent name, drops suite version, and emphasizes duration.
- Embedded live viewer uses `h-screen` so the iframe fills the scaled Mac frame.

Build and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/code)