### PR TITLE
fix(test-cases): bump hosted-web suite revisions after time-limit metadata change

### DIFF
--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.8");
+  assert.equal(suite.suiteVersion, "v3.0.9");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -48,7 +48,7 @@ The generic matrix iterates every published suite. The easy suite (`hosted-web-s
 
 ## Independent Suite Versioning
 
-The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v1.<...>` and `hosted-web-hard-suite-v1.0.0`). A change to a hard variant, the hard pool composition, or a hard cross-app chain bumps only the hard suite's version and content hash; the easy suite's revision identity must stay byte-identical.
+The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.9` and `hosted-web-hard-suite-v1.0.1`). A change to a hard variant, the hard pool composition, or a hard cross-app chain bumps only the hard suite's version and content hash; the easy suite's revision identity must stay byte-identical.
 
 This is enforced mechanically: new task-config fields used by hard variants are optional and only inspected when present, and `consistencyChecks` is an optional manifest key that is absent from the easy manifest. The easy catalog's "stable revision identity and content hash" test fails if a hard-suite change leaks into the easy manifest.
 

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -13,7 +13,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-hard-suite-v1",
-  suiteVersion: "v1.0.0",
+  suiteVersion: "v1.0.1",
   timeLimitMinutesPerTestcase: 60,
   sessions: [
     {
@@ -125,7 +125,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.0";
+export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.1";
 
 export const hostedWebHardSuiteCase = {
   id: "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,7 +11,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.8",
+  suiteVersion: "v3.0.9",
   timeLimitMinutesPerTestcase: 30,
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
@@ -24,7 +24,7 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.8";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.9";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,10 +11,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.8',
+  'hosted-web-suite-v3.0.9',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.8",
+  "suiteVersion": "v3.0.9",
   "timeLimitMinutesPerTestcase": 30,
   "sessions": [
     {
@@ -593,7 +593,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '878f213de9cbdae693b265de097bd588d22a3ef7a04fcb362e3b2c05a76dff4d'
+  '080899876b1c3b548a38bf4b94215ffc8c201c4fc28fcf3860e9f797c5a67b32'
 );
 
 select public.publish_benchmark_case_catalog(
@@ -608,10 +608,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-hard-suite-v1.0.0',
+  'hosted-web-hard-suite-v1.0.1',
   $catalog${
   "suiteSlug": "hosted-web-hard-suite-v1",
-  "suiteVersion": "v1.0.0",
+  "suiteVersion": "v1.0.1",
   "timeLimitMinutesPerTestcase": 60,
   "sessions": [
     {
@@ -1237,7 +1237,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  'fbd404f24cbb010caa3c364af9bec3861399d9f1939f96660eef92ccbe1a1ef2'
+  '0c603bb52ef501e7be5e6adf9eb79c3de35f696baab5f17744e284278010addb'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
The per-testcase time-limit feature changed the suite manifest shape, so the published revisions conflict on deploy. This bumps both revisions and regenerates seed/docs.

- hosted-web-suite: v3.0.8 → v3.0.9
- hosted-web-hard-suite: v1.0.0 → v1.0.1

🤖 Generated with [Claude Code](https://claude.com/code)