### PR TITLE
feat(web): tag-and-version suite labels with backend-driven defaults

### DIFF
--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -6,6 +6,22 @@ import { RunDetailTabs } from "./RunDetailTabs";
 import { usePlaygroundStore } from "@/lib/playground-store";
 import { SiteSelect } from "@/components/ui/SiteSelect";
 
+function BenchmarkTag({ tag }: { tag: string }) {
+  let hash = 0;
+  for (let index = 0; index < tag.length; index += 1) {
+    hash = tag.charCodeAt(index) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash % 360);
+  return (
+    <span
+      className="inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider"
+      style={{ backgroundColor: `hsla(${hue}, 75%, 55%, 0.15)`, color: `hsl(${hue}, 75%, 55%)` }}
+    >
+      {tag}
+    </span>
+  );
+}
+
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
   const benchmarks = usePlaygroundStore((state) => state.benchmarks);
@@ -147,12 +163,28 @@ export function ConnectAgentCard() {
             value={benchmark}
             onValueChange={(value) => setBenchmark(value)}
             ariaLabel="Benchmark"
-            options={benchmarks.map((item) => ({ value: item.id, label: item.label }))}
+            options={benchmarks.map((item) => ({
+              value: item.id,
+              label: (
+                <span className="flex items-center gap-2">
+                  <BenchmarkTag tag={item.tag} />
+                  <span className="truncate">
+                    {item.version} · {item.label}
+                  </span>
+                </span>
+              ),
+            }))}
             compact
           />
         </label>
 
         <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
+          <div className="mb-1.5 flex items-center gap-2">
+            {selectedBenchmark ? <BenchmarkTag tag={selectedBenchmark.tag} /> : null}
+            <span className="text-[11px] font-medium uppercase tracking-wider text-[#777064]">
+              {selectedBenchmark?.version ?? ""}
+            </span>
+          </div>
           {selectedBenchmark?.description ?? "Loading available benchmark suites…"}
         </div>
 

--- a/apps/web/components/landing/Leaderboard.tsx
+++ b/apps/web/components/landing/Leaderboard.tsx
@@ -4,19 +4,21 @@ import { LeaderboardRanking, type LeaderboardBoard } from "./LeaderboardRanking"
 async function loadBoards(): Promise<LeaderboardBoard[]> {
   const versions = await listPublicLeaderboardVersions();
   if (versions.length === 0) {
-    return [{ version: "all", entries: await listPublicLeaderboard(20) }];
+    return [{ version: "all", tag: "easy", slug: "", entries: await listPublicLeaderboard(20) }];
   }
 
-  return Promise.all(versions.map(async (version) => ({
-    version,
-    entries: await listPublicLeaderboard(20, version),
+  return Promise.all(versions.map(async (item) => ({
+    version: item.version,
+    tag: item.tag,
+    slug: item.slug,
+    entries: await listPublicLeaderboard(20, item.version, item.slug),
   })));
 }
 
 export async function Leaderboard() {
   const boards = await loadBoards().catch((error) => {
     console.error("[web] failed to load public leaderboard", error);
-    return [{ version: "all", entries: [] }];
+    return [{ version: "all", tag: "easy" as const, slug: "", entries: [] }];
   });
 
   return (

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -18,20 +18,11 @@ function formatDuration(durationMs: number | null) {
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
-function formatCompletedAt(value: string) {
-  return new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(new Date(value));
-}
-
 function PlaceholderRow({ position }: { position: number }) {
   return (
-    <div className="grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_52px] items-center gap-3 border-b border-white/10 px-4 py-4 last:border-b-0 lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.8fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6">
+    <div className="grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_52px_64px] items-center gap-3 border-b border-white/10 px-4 py-4 last:border-b-0 lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6">
       <span className="text-xl text-white/20 lg:text-2xl">{position.toString().padStart(2, "0")}</span>
-      <div className="lg:col-span-4">
+      <div className="col-span-2 lg:col-span-3">
         <div className="h-2.5 w-28 rounded-full bg-white/[0.07] lg:h-3 lg:w-36" />
         <div className="mt-2 truncate text-[10px] uppercase tracking-[0.14em] text-white/25 lg:mt-3 lg:text-xs lg:tracking-[0.16em]">
           Awaiting benchmark result
@@ -95,9 +86,9 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
       <div className="overflow-hidden rounded-[1.5rem] border border-[#d8d0c2] bg-[#111111] shadow-[0_32px_90px_rgba(77,63,36,0.16)] lg:rounded-[2rem]">
         <div className="hidden grid-cols-[64px_1.35fr_1.2fr_0.75fr_96px] gap-4 border-b border-white/10 px-6 py-4 text-[10px] uppercase tracking-[0.2em] text-white/40 lg:grid">
           <span>Rank</span>
-          <span>Agent / model</span>
-          <span>Benchmark</span>
-          <span>Finished</span>
+          <span>Agent</span>
+          <span>Platform</span>
+          <span>Duration</span>
           <span className="text-right">Score</span>
         </div>
 
@@ -106,7 +97,7 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
             <a
               key={entry.runId}
               href={`/results/${entry.runId}`}
-              className="group grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_64px] items-center gap-3 border-b border-white/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-white/[0.045] lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6"
+              className="group grid min-h-[84px] grid-cols-[38px_minmax(0,1fr)_52px_64px] items-center gap-3 border-b border-white/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-white/[0.045] lg:min-h-0 lg:grid-cols-[64px_1.35fr_1.2fr_0.75fr_96px] lg:gap-4 lg:px-6 lg:py-6"
             >
               <span className={entry.rank <= 3 ? "text-xl font-medium text-[#d7ff00] lg:text-3xl" : "text-xl text-white/45 lg:text-2xl"}>
                 {entry.rank.toString().padStart(2, "0")}
@@ -114,8 +105,8 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
               <div className="min-w-0">
                 <div className="truncate text-sm font-medium text-white lg:text-lg">{entry.agentName}</div>
                 <div className="mt-1 truncate text-[11px] text-white/45 lg:text-xs">
-                  <span className="lg:hidden">{entry.baseModel}</span>
-                  <span className="hidden lg:inline">{entry.browser ?? "Unknown browser"} · {entry.platform ?? "Unknown platform"}</span>
+                  <span>{entry.baseModel}</span>
+                  <span className="lg:hidden"> · {entry.browser ?? "Unknown browser"} / {entry.platform ?? "Unknown platform"}</span>
                 </div>
                 {entry.status === "timeout" ? (
                   <div className="mt-2 inline-flex rounded-full bg-[#ffb627]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ffc44d]">
@@ -128,10 +119,10 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
                 ) : null}
               </div>
               <div className="hidden min-w-0 lg:block">
-                <div className="truncate text-sm text-white/85">{entry.benchmark}</div>
-                <div className="mt-1 text-xs text-white/40">{formatDuration(entry.durationMs)}</div>
+                <div className="truncate text-sm text-white/85">{entry.browser ?? "Unknown browser"}</div>
+                <div className="mt-1 truncate text-xs text-white/40">{entry.platform ?? "Unknown platform"}</div>
               </div>
-              <div className="hidden text-sm text-white/70 lg:block">{formatCompletedAt(entry.completedAt)}</div>
+              <div className="min-w-0 text-sm font-medium text-white/85 lg:text-base">{formatDuration(entry.durationMs)}</div>
               <div className="text-right">
                 <span className={`text-2xl font-medium tracking-[-0.04em] lg:text-3xl ${
                   entry.status === "failed"

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -7,6 +7,8 @@ import { SiteSelect } from "@/components/ui/SiteSelect";
 
 export type LeaderboardBoard = {
   version: string;
+  tag: string;
+  slug: string;
   entries: LeaderboardEntry[];
 };
 
@@ -16,6 +18,46 @@ function formatDuration(durationMs: number | null) {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function boardValue(board: LeaderboardBoard) {
+  return board.version === "all" ? "all" : `${board.slug}:${board.version}`;
+}
+
+function tagColor(tag: string) {
+  let hash = 0;
+  for (let index = 0; index < tag.length; index += 1) {
+    hash = tag.charCodeAt(index) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash % 360);
+  return {
+    background: `hsla(${hue}, 75%, 55%, 0.15)`,
+    text: `hsl(${hue}, 75%, 55%)`,
+  };
+}
+
+function SuiteTag({ tag, compact = false }: { tag: string; compact?: boolean }) {
+  const colors = tagColor(tag);
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider ${compact ? "text-[9px]" : "text-[10px]"}`}
+      style={{ backgroundColor: colors.background, color: colors.text }}
+    >
+      {tag}
+    </span>
+  );
+}
+
+function SuiteLabel({ board }: { board: LeaderboardBoard }) {
+  if (board.version === "all") {
+    return <span>All versions</span>;
+  }
+  return (
+    <span className="flex items-center gap-2">
+      <SuiteTag tag={board.tag} compact />
+      <span>{board.version}</span>
+    </span>
+  );
 }
 
 function PlaceholderRow({ position }: { position: number }) {
@@ -34,11 +76,12 @@ function PlaceholderRow({ position }: { position: number }) {
 }
 
 export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
-  const [activeVersion, setActiveVersion] = useState(boards[0]?.version ?? "all");
+  const defaultBoard = boards.find((board) => board.tag === "hard") ?? boards[0];
+  const [activeVersion, setActiveVersion] = useState(boardValue(defaultBoard) ?? "all");
   const [page, setPage] = useState(1);
   const latestBoard = boards[0];
   const otherBoards = boards.slice(1);
-  const activeBoard = boards.find((board) => board.version === activeVersion) ?? boards[0];
+  const activeBoard = boards.find((board) => boardValue(board) === activeVersion) ?? boards[0];
   const pagination = paginateLeaderboard(activeBoard?.entries ?? [], page);
   const { entries, page: currentPage, pageCount, pageEntries, placeholderPositions } = pagination;
 
@@ -54,24 +97,24 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
           {latestBoard ? (
             <button
               type="button"
-              aria-pressed={latestBoard.version === activeVersion}
-              onClick={() => selectVersion(latestBoard.version)}
-              className={latestBoard.version === activeVersion
+              aria-pressed={boardValue(latestBoard) === activeVersion}
+              onClick={() => selectVersion(boardValue(latestBoard))}
+              className={boardValue(latestBoard) === activeVersion
                 ? "rounded-[0.6rem] bg-[#111111] px-4 py-2.5 text-xs font-medium text-white"
                 : "rounded-[0.6rem] border border-[#d8d0c2] bg-white/55 px-4 py-2.5 text-xs text-[#625c52] transition-colors hover:border-[#111111] hover:text-[#111111]"}
             >
-              {latestBoard.version === "all" ? "All versions" : `Suite ${latestBoard.version}`}
+              <SuiteLabel board={latestBoard} />
             </button>
           ) : null}
           {otherBoards.length > 0 ? (
             <SiteSelect
               compact
               ariaLabel="Other benchmark suites"
-              value={otherBoards.some((board) => board.version === activeVersion) ? activeVersion : ""}
+              value={otherBoards.some((board) => boardValue(board) === activeVersion) ? activeVersion : ""}
               onValueChange={selectVersion}
               options={[
                 { value: "", label: "Other suites", disabled: true },
-                ...otherBoards.map((board) => ({ value: board.version, label: `Suite ${board.version}` })),
+                ...otherBoards.map((board) => ({ value: boardValue(board), label: <SuiteLabel board={board} /> })),
               ]}
               className="min-w-[10rem]"
               triggerClassName="bg-white/55 py-2.5 text-xs text-[#625c52]"

--- a/apps/web/components/ui/SiteSelect.tsx
+++ b/apps/web/components/ui/SiteSelect.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 export type SiteSelectOption = {
   value: string;
-  label: string;
+  label: ReactNode;
   disabled?: boolean;
 };
 

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 import { createSupabaseAdminClient } from "./supabase/admin";
 import { buildInitialRunMetadata, buildRunMetadataUpdate, parseBrowserEnvironment } from "./run-metadata";
 import { completableRunStatuses, terminalRunStatuses } from "./run-lifecycle";
+import { hostedWebCatalogReleases } from "@agentbench/test-cases/release";
 
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
 const DEVELOPMENT_GUEST_RUN_LIMIT = 10;
@@ -130,11 +131,12 @@ export async function listBenchmarkCases(): Promise<BenchmarkCase[]> {
 export type PublicBenchmarkCase = Pick<
   BenchmarkCase,
   "id" | "slug" | "title" | "description" | "difficulty"
->;
+> & { tag: string; version: string };
 
 // Display-safe projection for the public suite picker. Deliberately omits
 // `metadata` and `current_revision_id` so scorer-oracle surfaces never leak to
-// unauthenticated clients. Ordered easy-before-hard deterministically.
+// unauthenticated clients. The default suite (hard, when published) is ordered
+// first so the frontend can simply select the first option.
 export async function listPublicHostedBenchmarkCases(): Promise<PublicBenchmarkCase[]> {
   const supabase = getSupabase();
 
@@ -143,20 +145,28 @@ export async function listPublicHostedBenchmarkCases(): Promise<PublicBenchmarkC
     .select("id, slug, title, description, difficulty, created_at")
     .eq("is_public", true)
     .eq("provider", "hosted-web")
-    .order("difficulty", { ascending: true })
+    .order("difficulty", { ascending: false })
     .order("created_at", { ascending: true });
 
   if (error || !data) {
     throw error ?? new Error("Failed to list public benchmark cases");
   }
 
-  return data.map((item) => ({
-    id: item.id,
-    slug: item.slug,
-    title: item.title,
-    description: item.description,
-    difficulty: item.difficulty,
-  }));
+  const releases = hostedWebCatalogReleases();
+  const releaseByCaseId = new Map(releases.map((release) => [release.benchmarkCase.id, release]));
+
+  return data.map((item) => {
+    const release = releaseByCaseId.get(item.id);
+    return {
+      id: item.id,
+      slug: item.slug,
+      title: item.title,
+      description: item.description,
+      difficulty: item.difficulty,
+      tag: item.difficulty === "hard" ? "hard" : "easy",
+      version: release?.manifest.suiteVersion ?? "",
+    };
+  });
 }
 
 export async function getBenchmarkCase(caseId: string): Promise<BenchmarkCase | null> {  const supabase = getSupabase();
@@ -655,7 +665,13 @@ export async function getPublicBenchmarkResult(runId: string): Promise<PublicBen
   };
 }
 
-export async function listPublicLeaderboardVersions(): Promise<string[]> {
+export type LeaderboardVersion = {
+  version: string;
+  slug: string;
+  tag: string;
+};
+
+export async function listPublicLeaderboardVersions(): Promise<LeaderboardVersion[]> {
   const supabase = getSupabase();
 
   const { data: publicRuns, error: runError } = await supabase
@@ -675,28 +691,51 @@ export async function listPublicLeaderboardVersions(): Promise<string[]> {
 
   const { data: attempts, error: attemptError } = await supabase
     .from("public_hosted_run_summaries")
-    .select("suite_version")
-    .in("run_id", publicRuns.map((run) => run.id))
-    .order("suite_version", { ascending: false });
+    .select("suite_slug, suite_version")
+    .in("run_id", publicRuns.map((run) => run.id));
 
   if (attemptError || !attempts) {
     throw attemptError ?? new Error("Failed to load leaderboard versions");
   }
 
-  return [...new Set(attempts.map((attempt) => attempt.suite_version).filter((version): version is string => Boolean(version)))]
-    .sort((left, right) => right.localeCompare(left, undefined, { numeric: true, sensitivity: "base" }));
+  const seen = new Set<string>();
+  const versions: LeaderboardVersion[] = [];
+  for (const attempt of attempts) {
+    if (!attempt.suite_version || !attempt.suite_slug) continue;
+    const key = `${attempt.suite_slug}:${attempt.suite_version}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    versions.push({
+      version: attempt.suite_version,
+      slug: attempt.suite_slug,
+      tag: attempt.suite_slug.includes("hard") ? "hard" : "easy",
+    });
+  }
+
+  return versions.sort((left, right) => {
+    if (left.tag !== right.tag) {
+      return left.tag === "hard" ? -1 : 1;
+    }
+    return right.version.localeCompare(left.version, undefined, { numeric: true, sensitivity: "base" });
+  });
 }
 
-export async function listPublicLeaderboard(limit = 20, suiteVersion?: string): Promise<LeaderboardEntry[]> {
+export async function listPublicLeaderboard(limit = 20, suiteVersion?: string, suiteSlug?: string): Promise<LeaderboardEntry[]> {
   const supabase = getSupabase();
 
   let versionRunIds: string[] | null = null;
   if (suiteVersion) {
-    const { data: versionAttempts, error: versionError } = await supabase
+    let versionAttemptsQuery = supabase
       .from("public_hosted_run_summaries")
       .select("run_id")
       .eq("suite_version", suiteVersion)
       .limit(1000);
+
+    if (suiteSlug) {
+      versionAttemptsQuery = versionAttemptsQuery.eq("suite_slug", suiteSlug);
+    }
+
+    const { data: versionAttempts, error: versionError } = await versionAttemptsQuery;
 
     if (versionError || !versionAttempts) {
       throw versionError ?? new Error("Failed to load leaderboard version");

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -581,10 +581,14 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
         description: item.description,
         difficulty: item.difficulty,
       }));
+      const defaultBenchmark =
+        benchmarks.find((item) => item.difficulty === "hard")?.id ??
+        benchmarks[0]?.id ??
+        "";
       set((state) => ({
         benchmarks,
         benchmarksLoading: false,
-        benchmark: state.benchmark || benchmarks[0]?.id || "",
+        benchmark: state.benchmark || defaultBenchmark,
       }));
     } catch {
       set({ benchmarksLoading: false, runError: "Failed to load benchmark catalog." });

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -24,6 +24,8 @@ export type BenchmarkOption = {
   label: string;
   description: string;
   difficulty: string;
+  tag: string;
+  version: string;
 };
 
 export type RunPhase = "idle" | "booting" | "running" | "completed" | "failed";
@@ -443,7 +445,7 @@ async function requestBenchmarks() {
   }
 
   return (await response.json()) as {
-    cases: Array<{ id: string; slug: string; title: string; description: string; difficulty: string }>;
+    cases: Array<{ id: string; slug: string; title: string; description: string; difficulty: string; tag: string; version: string }>;
   };
 }
 
@@ -580,15 +582,13 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
         label: item.title,
         description: item.description,
         difficulty: item.difficulty,
+        tag: item.tag,
+        version: item.version,
       }));
-      const defaultBenchmark =
-        benchmarks.find((item) => item.difficulty === "hard")?.id ??
-        benchmarks[0]?.id ??
-        "";
       set((state) => ({
         benchmarks,
         benchmarksLoading: false,
-        benchmark: state.benchmark || defaultBenchmark,
+        benchmark: state.benchmark || benchmarks[0]?.id || "",
       }));
     } catch {
       set({ benchmarksLoading: false, runError: "Failed to load benchmark catalog." });

--- a/packages/test-cases/package.json
+++ b/packages/test-cases/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./release": {
+      "types": "./dist/release.d.ts",
+      "import": "./dist/release.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
- Backend returns suite tag + version; frontend renders colored tag cards.
- Default suite is selected by backend ordering (hard first).
- Leaderboard selector defaults to hard suite.

🤖 Generated with [Claude Code](https://claude.com/code)