### PR TITLE
fix(web): show suite tags in leaderboard, default hard, align tag colors

### DIFF
--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -5,22 +5,7 @@ import { RunConnectionCard } from "./RunConnectionCard";
 import { RunDetailTabs } from "./RunDetailTabs";
 import { usePlaygroundStore } from "@/lib/playground-store";
 import { SiteSelect } from "@/components/ui/SiteSelect";
-
-function BenchmarkTag({ tag }: { tag: string }) {
-  let hash = 0;
-  for (let index = 0; index < tag.length; index += 1) {
-    hash = tag.charCodeAt(index) + ((hash << 5) - hash);
-  }
-  const hue = Math.abs(hash % 360);
-  return (
-    <span
-      className="inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider"
-      style={{ backgroundColor: `hsla(${hue}, 75%, 55%, 0.15)`, color: `hsl(${hue}, 75%, 55%)` }}
-    >
-      {tag}
-    </span>
-  );
-}
+import { SuiteTag } from "@/components/ui/SuiteTag";
 
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
@@ -167,7 +152,7 @@ export function ConnectAgentCard() {
               value: item.id,
               label: (
                 <span className="flex items-center gap-2">
-                  <BenchmarkTag tag={item.tag} />
+                  <SuiteTag tag={item.tag} />
                   <span className="truncate">
                     {item.version} · {item.label}
                   </span>
@@ -180,7 +165,7 @@ export function ConnectAgentCard() {
 
         <div className="rounded-[1.15rem] bg-[#efede6] p-3.5 text-[13px] leading-6 text-[#5c574d]">
           <div className="mb-1.5 flex items-center gap-2">
-            {selectedBenchmark ? <BenchmarkTag tag={selectedBenchmark.tag} /> : null}
+            {selectedBenchmark ? <SuiteTag tag={selectedBenchmark.tag} /> : null}
             <span className="text-[11px] font-medium uppercase tracking-wider text-[#777064]">
               {selectedBenchmark?.version ?? ""}
             </span>

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { LeaderboardEntry } from "@/lib/db";
 import { LEADERBOARD_MAX_ENTRIES, LEADERBOARD_PAGE_SIZE, paginateLeaderboard } from "@/lib/leaderboard-pagination";
 import { SiteSelect } from "@/components/ui/SiteSelect";
+import { SuiteTag } from "@/components/ui/SuiteTag";
 
 export type LeaderboardBoard = {
   version: string;
@@ -22,30 +23,6 @@ function formatDuration(durationMs: number | null) {
 
 function boardValue(board: LeaderboardBoard) {
   return board.version === "all" ? "all" : `${board.slug}:${board.version}`;
-}
-
-function tagColor(tag: string) {
-  let hash = 0;
-  for (let index = 0; index < tag.length; index += 1) {
-    hash = tag.charCodeAt(index) + ((hash << 5) - hash);
-  }
-  const hue = Math.abs(hash % 360);
-  return {
-    background: `hsla(${hue}, 75%, 55%, 0.15)`,
-    text: `hsl(${hue}, 75%, 55%)`,
-  };
-}
-
-function SuiteTag({ tag, compact = false }: { tag: string; compact?: boolean }) {
-  const colors = tagColor(tag);
-  return (
-    <span
-      className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider ${compact ? "text-[9px]" : "text-[10px]"}`}
-      style={{ backgroundColor: colors.background, color: colors.text }}
-    >
-      {tag}
-    </span>
-  );
 }
 
 function SuiteLabel({ board }: { board: LeaderboardBoard }) {

--- a/apps/web/components/ui/SuiteTag.tsx
+++ b/apps/web/components/ui/SuiteTag.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+export function suiteTagHue(tag: string) {
+  let hash = 0;
+  for (let index = 0; index < tag.length; index += 1) {
+    hash = tag.charCodeAt(index) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash % 360);
+}
+
+export function SuiteTag({
+  tag,
+  compact = false,
+  children,
+}: {
+  tag: string;
+  compact?: boolean;
+  children?: ReactNode;
+}) {
+  const hue = suiteTagHue(tag);
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${compact ? "text-[9px]" : "text-[10px]"}`}
+      style={{ backgroundColor: `hsl(${hue}, 78%, 55%)`, color: "#111111" }}
+    >
+      {children ?? tag}
+    </span>
+  );
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -674,6 +674,45 @@ export type LeaderboardVersion = {
 export async function listPublicLeaderboardVersions(): Promise<LeaderboardVersion[]> {
   const supabase = getSupabase();
 
+  // Start from the published catalog so every public suite appears in the
+  // selector (even before it has public runs). The backend ordering puts the
+  // default suite first; the frontend just picks boards[0].
+  const { data: cases, error: casesError } = await supabase
+    .from("benchmark_cases")
+    .select("id, slug, difficulty, metadata")
+    .eq("is_public", true)
+    .eq("provider", "hosted-web");
+
+  if (casesError || !cases) {
+    throw casesError ?? new Error("Failed to load benchmark case tags");
+  }
+
+  const releases = hostedWebCatalogReleases();
+  const releaseByCaseId = new Map(releases.map((release) => [release.benchmarkCase.id, release]));
+
+  const seen = new Set<string>();
+  const versions: LeaderboardVersion[] = [];
+  const tagBySuiteSlug = new Map<string, string>();
+
+  for (const item of cases) {
+    const release = releaseByCaseId.get(item.id);
+    if (!release) continue;
+
+    const suiteSlug = release.manifest.suiteSlug;
+    const suiteVersion = release.manifest.suiteVersion;
+    const tag = item.difficulty;
+
+    tagBySuiteSlug.set(suiteSlug, tag);
+
+    const key = `${suiteSlug}:${suiteVersion}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    versions.push({ version: suiteVersion, slug: suiteSlug, tag });
+  }
+
+  // Also surface any historical versions that have public runs but are no
+  // longer in the current catalog release.
   const { data: publicRuns, error: runError } = await supabase
     .from("benchmark_runs")
     .select("id")
@@ -685,42 +724,28 @@ export async function listPublicLeaderboardVersions(): Promise<LeaderboardVersio
   if (runError || !publicRuns) {
     throw runError ?? new Error("Failed to load leaderboard versions");
   }
-  if (publicRuns.length === 0) {
-    return [];
-  }
 
-  const { data: attempts, error: attemptError } = await supabase
-    .from("public_hosted_run_summaries")
-    .select("suite_slug, suite_version")
-    .in("run_id", publicRuns.map((run) => run.id));
+  if (publicRuns.length > 0) {
+    const { data: attempts, error: attemptError } = await supabase
+      .from("public_hosted_run_summaries")
+      .select("suite_slug, suite_version")
+      .in("run_id", publicRuns.map((run) => run.id));
 
-  if (attemptError || !attempts) {
-    throw attemptError ?? new Error("Failed to load leaderboard versions");
-  }
+    if (attemptError || !attempts) {
+      throw attemptError ?? new Error("Failed to load leaderboard versions");
+    }
 
-  const { data: cases, error: casesError } = await supabase
-    .from("benchmark_cases")
-    .select("slug, difficulty")
-    .eq("provider", "hosted-web");
-
-  if (casesError || !cases) {
-    throw casesError ?? new Error("Failed to load benchmark case tags");
-  }
-
-  const tagBySlug = new Map((cases ?? []).map((item) => [item.slug, item.difficulty]));
-
-  const seen = new Set<string>();
-  const versions: LeaderboardVersion[] = [];
-  for (const attempt of attempts) {
-    if (!attempt.suite_version || !attempt.suite_slug) continue;
-    const key = `${attempt.suite_slug}:${attempt.suite_version}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    versions.push({
-      version: attempt.suite_version,
-      slug: attempt.suite_slug,
-      tag: tagBySlug.get(attempt.suite_slug) ?? "",
-    });
+    for (const attempt of attempts) {
+      if (!attempt.suite_version || !attempt.suite_slug) continue;
+      const key = `${attempt.suite_slug}:${attempt.suite_version}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      versions.push({
+        version: attempt.suite_version,
+        slug: attempt.suite_slug,
+        tag: tagBySuiteSlug.get(attempt.suite_slug) ?? "",
+      });
+    }
   }
 
   return versions.sort((left, right) => {


### PR DESCRIPTION
- Derives leaderboard versions from published catalog rows so the hard suite appears by default even before it has public runs.\n- Maps suite tags via metadata suiteSlug instead of case slug.\n- Shares a new SuiteTag component between leaderboard and playground for consistent bright tag pills.