### PR TITLE
fix(web): use agent benchmark [tag-version] copy everywhere

### DIFF
--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -153,9 +153,7 @@ export function ConnectAgentCard() {
               label: (
                 <span className="flex items-center gap-2">
                   <SuiteTag tag={item.tag} />
-                  <span className="truncate">
-                    {item.version} · {item.label}
-                  </span>
+                  <span className="truncate">{item.label}</span>
                 </span>
               ),
             }))}

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -32,7 +32,7 @@ function SuiteLabel({ board }: { board: LeaderboardBoard }) {
   return (
     <span className="flex items-center gap-2">
       <SuiteTag tag={board.tag} compact />
-      <span>{board.version}</span>
+      <span className="truncate">agent benchmark [{board.tag}-{board.version}]</span>
     </span>
   );
 }

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -579,8 +579,8 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
       const benchmarks: BenchmarkOption[] = result.cases.map((item) => ({
         id: item.id,
         slug: item.slug,
-        label: item.title,
-        description: item.description,
+        label: `agent benchmark [${item.tag}-${item.version}]`,
+        description: `Run the ${item.tag} agent benchmark suite.`,
         difficulty: item.difficulty,
         tag: item.tag,
         version: item.version,


### PR DESCRIPTION
Replace the hosted-web suite titles ('Hosted Web Hard Suite', etc.) with generic 'agent benchmark [hard-v1.0.1]' labels in the playground dropdown, run card headings, and leaderboard version selector.