### PR TITLE
feat(web): display per-task countdown in live run viewer

### DIFF
--- a/apps/web/app/api/runs/[runId]/hosted-sessions/route.ts
+++ b/apps/web/app/api/runs/[runId]/hosted-sessions/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { listHostedSessionDeadlines } from "@/lib/db";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const { runId } = await params;
+
+  try {
+    const sessions = await listHostedSessionDeadlines(runId);
+    return NextResponse.json({ sessions });
+  } catch (error) {
+    console.error("[web] failed to load hosted session deadlines", error);
+    return NextResponse.json(
+      { error: "Failed to load hosted session deadlines" },
+      { status: 503 },
+    );
+  }
+}

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -153,9 +153,7 @@ export function ConnectAgentCard() {
               label: (
                 <span className="flex items-center gap-2">
                   <SuiteTag tag={item.tag} />
-                  <span className="truncate">
-                    {item.version} · {item.label}
-                  </span>
+                  <span className="truncate">{item.label}</span>
                 </span>
               ),
             }))}

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -32,7 +32,7 @@ function SuiteLabel({ board }: { board: LeaderboardBoard }) {
   return (
     <span className="flex items-center gap-2">
       <SuiteTag tag={board.tag} compact />
-      <span>{board.version}</span>
+      <span className="truncate">agent benchmark [{board.tag}-{board.version}]</span>
     </span>
   );
 }

--- a/apps/web/components/run/LiveRunViewer.tsx
+++ b/apps/web/components/run/LiveRunViewer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { deriveHostedViewerRevision, deriveHostedViewerUrl } from "@/lib/hosted-viewer";
 import { deriveHostedScoring } from "@/lib/hosted-scoring";
+import type { HostedSessionDeadline } from "@/lib/db";
 
 type LiveRunViewerProps = {
   runId: string;
@@ -40,6 +41,22 @@ type HostedSuiteSession = {
   sequenceIndex: number;
   startUrl: string | null;
 };
+
+function useNow(intervalMs = 1000) {
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+function formatCountdown(durationMs: number) {
+  const totalSeconds = Math.max(0, Math.ceil(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
 
 function deriveLiveFrameUrl(payload: StreamPayload) {
   const liveEvent = [...payload.events]
@@ -112,6 +129,22 @@ function deriveHostedSuiteSessions(events: StreamEvent[]) {
   return [...sessions.values()].sort((left, right) => left.sequenceIndex - right.sequenceIndex);
 }
 
+function deriveSessionStatusLabel(deadline: HostedSessionDeadline | undefined, now: number) {
+  if (!deadline) return null;
+
+  if (deadline.status === "active" && deadline.expiresAt) {
+    const remaining = new Date(deadline.expiresAt).getTime() - now;
+    if (remaining <= 0) return { text: "Timed out", urgent: true };
+    return { text: `Time left: ${formatCountdown(remaining)}`, urgent: remaining < 60_000 };
+  }
+
+  if (deadline.status === "completed") return { text: "Completed", urgent: false };
+  if (deadline.status === "failed") return { text: "Failed", urgent: true };
+  if (deadline.status === "created") return { text: "Pending", urgent: false };
+
+  return { text: deadline.status, urgent: false };
+}
+
 export function LiveRunViewer(props: LiveRunViewerProps) {
   const {
     runId,
@@ -131,6 +164,8 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
   const [viewerRevision, setViewerRevision] = useState(0);
   const [hostedEvents, setHostedEvents] = useState<StreamEvent[]>([]);
   const [suiteSessions, setSuiteSessions] = useState<HostedSuiteSession[]>([]);
+  const [sessionDeadlines, setSessionDeadlines] = useState<Map<string, HostedSessionDeadline>>(new Map());
+  const now = useNow();
 
   useEffect(() => {
     const source = new EventSource(`/api/runs/${runId}/stream`);
@@ -162,7 +197,28 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
     return () => {
       source.close();
     };
-  }, [initialScore, initialStatus, runId]);
+  }, [initialScore, initialStatus, initialErrorMessage, runId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    async function fetchDeadlines() {
+      try {
+        const response = await fetch(`/api/runs/${runId}/hosted-sessions`, {
+          cache: "no-store",
+        });
+        if (!response.ok) return;
+        const result = (await response.json()) as { sessions: HostedSessionDeadline[] };
+        setSessionDeadlines(new Map(result.sessions.map((session) => [session.sessionId, session])));
+      } catch (error) {
+        console.error("[live-viewer] failed to refresh session deadlines", error);
+      }
+    }
+
+    void fetchDeadlines();
+    const interval = window.setInterval(fetchDeadlines, 5000);
+    return () => window.clearInterval(interval);
+  }, [runId]);
 
   const terminalSummary =
     status === "timeout"
@@ -273,22 +329,35 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
           <section className="mt-6 rounded-[1.6rem] border border-white/10 bg-white/[0.04] p-5">
             <div className="text-xs uppercase tracking-[0.18em] text-[#8f897e]">Hosted Suite Progress</div>
             <div className="mt-4 grid gap-3 md:grid-cols-2">
-              {suiteSessions.map((session, index) => (
-                <div
-                  key={session.sessionId}
-                  className={`rounded-[1rem] border px-4 py-3 ${
-                    status === "timeout" || status === "failed"
-                      ? "border-[#6b2d22] bg-[#1b1312]"
-                      : "border-white/10 bg-black/20"
-                  }`}
-                >
-                  <div className="text-[11px] uppercase tracking-[0.18em] text-[#8f897e]">
-                    Session {index + 1}
+              {suiteSessions.map((session, index) => {
+                const deadline = sessionDeadlines.get(session.sessionId);
+                const statusLabel = deriveSessionStatusLabel(deadline, now);
+                return (
+                  <div
+                    key={session.sessionId}
+                    className={`rounded-[1rem] border px-4 py-3 ${
+                      status === "timeout" || status === "failed"
+                        ? "border-[#6b2d22] bg-[#1b1312]"
+                        : "border-white/10 bg-black/20"
+                    }`}
+                  >
+                    <div className="text-[11px] uppercase tracking-[0.18em] text-[#8f897e]">
+                      Session {index + 1}
+                    </div>
+                    <div className="mt-1 text-sm font-medium text-white">{session.taskSlug}</div>
+                    <div className="mt-1 text-xs text-[#c8c2b5]">{session.app}</div>
+                    {statusLabel ? (
+                      <div
+                        className={`mt-2 text-xs font-medium uppercase tracking-wider ${
+                          statusLabel.urgent ? "text-[#ff9f90]" : "text-[#8f897e]"
+                        }`}
+                      >
+                        {statusLabel.text}
+                      </div>
+                    ) : null}
                   </div>
-                  <div className="mt-1 text-sm font-medium text-white">{session.taskSlug}</div>
-                  <div className="mt-1 text-xs text-[#c8c2b5]">{session.app}</div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </section>
         ) : null}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -917,3 +917,46 @@ export async function getQuotaStatus(params: {
     resetAt: null,
   };
 }
+
+export type HostedSessionDeadline = {
+  sessionId: string;
+  taskSlug: string;
+  status: string;
+  sequenceIndex: number;
+  expiresAt: string | null;
+  timeLimitMinutes: number | null;
+};
+
+export async function listHostedSessionDeadlines(runId: string): Promise<HostedSessionDeadline[]> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from("hosted_web_sessions")
+    .select("id, task_slug, status, sequence_index, expires_at, metadata")
+    .eq("run_id", runId)
+    .order("sequence_index", { ascending: true });
+
+  if (error || !data) {
+    throw error ?? new Error("Failed to load hosted session deadlines");
+  }
+
+  return data.map((item) => {
+    const metadata =
+      typeof item.metadata === "object" && item.metadata !== null
+        ? (item.metadata as Record<string, unknown>)
+        : {};
+    const timeLimitMinutes =
+      typeof metadata.timeLimitMinutesPerTestcase === "number" && Number.isFinite(metadata.timeLimitMinutesPerTestcase)
+        ? metadata.timeLimitMinutesPerTestcase
+        : null;
+
+    return {
+      sessionId: item.id,
+      taskSlug: item.task_slug ?? "hosted-task",
+      status: item.status ?? "created",
+      sequenceIndex: item.sequence_index ?? 0,
+      expiresAt: item.expires_at ?? null,
+      timeLimitMinutes,
+    };
+  });
+}

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -579,8 +579,8 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
       const benchmarks: BenchmarkOption[] = result.cases.map((item) => ({
         id: item.id,
         slug: item.slug,
-        label: item.title,
-        description: item.description,
+        label: `agent benchmark [${item.tag}-${item.version}]`,
+        description: `Run the ${item.tag} agent benchmark suite.`,
         difficulty: item.difficulty,
         tag: item.tag,
         version: item.version,


### PR DESCRIPTION
Adds a live countdown for the currently active hosted task in the run viewer.\n\n- New endpoint: GET /api/runs/[runId]/hosted-sessions returns session deadlines.\n- LiveRunViewer polls it every 5s and renders 'Time left: MM:SS' under the active session card.\n- Last minute turns red; expired sessions show 'Timed out'.