### PR TITLE
feat(web): resume latest run for guests on refresh/revisit

### DIFF
--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -10,6 +10,7 @@ import { SuiteTag } from "@/components/ui/SuiteTag";
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
   const benchmarks = usePlaygroundStore((state) => state.benchmarks);
+  const currentRunId = usePlaygroundStore((state) => state.currentRunId);
   const phase = usePlaygroundStore((state) => state.phase);
   const quota = usePlaygroundStore((state) => state.quota);
   const quotaLoading = usePlaygroundStore((state) => state.quotaLoading);
@@ -18,6 +19,7 @@ export function ConnectAgentCard() {
   const setBenchmark = usePlaygroundStore((state) => state.setBenchmark);
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
   const fetchBenchmarks = usePlaygroundStore((state) => state.fetchBenchmarks);
+  const resumeRun = usePlaygroundStore((state) => state.resumeRun);
   const startRun = usePlaygroundStore((state) => state.startRun);
   const stopRun = usePlaygroundStore((state) => state.stopRun);
   const reset = usePlaygroundStore((state) => state.reset);
@@ -30,7 +32,16 @@ export function ConnectAgentCard() {
   useEffect(() => {
     void fetchQuota();
     void fetchBenchmarks();
-  }, [fetchQuota, fetchBenchmarks]);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const latestRunId = window.localStorage.getItem("agentbench:latestRunId");
+    if (latestRunId && phase === "idle" && !currentRunId) {
+      void resumeRun(latestRunId);
+    }
+  }, [fetchQuota, fetchBenchmarks, resumeRun, phase, currentRunId]);
 
   const quotaBadge = quotaLoading
     ? "Loading quota"

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -78,6 +78,7 @@ type PlaygroundStore = {
   setLiveSlide: (index: number) => void;
   fetchQuota: () => Promise<void>;
   fetchBenchmarks: () => Promise<void>;
+  resumeRun: (runId: string) => Promise<void>;
   startRun: (mode?: RunExecutionMode) => Promise<void>;
   stopRun: () => void;
   reset: () => void;
@@ -117,6 +118,20 @@ const initialState = {
 
 let pollInterval: number | null = null;
 let streamSource: EventSource | null = null;
+
+const LATEST_RUN_STORAGE_KEY = "agentbench:latestRunId";
+
+function setStoredLatestRunId(runId: string | null) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (runId) {
+    window.localStorage.setItem(LATEST_RUN_STORAGE_KEY, runId);
+  } else {
+    window.localStorage.removeItem(LATEST_RUN_STORAGE_KEY);
+  }
+}
 
 function clearRunSync() {
   if (typeof window === "undefined") {
@@ -597,12 +612,43 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
       set({ benchmarksLoading: false, runError: "Failed to load benchmark catalog." });
     }
   },
+  resumeRun: async (runId) => {
+    if (!runId || get().phase !== "idle" || get().currentRunId) {
+      return;
+    }
+
+    clearRunSync();
+    set({ quotaLoading: true, runError: null });
+
+    try {
+      const snapshot = await fetchRunSnapshot(runId);
+      applyRunSnapshot(snapshot, set);
+      setStoredLatestRunId(runId);
+      set({ quotaLoading: false });
+
+      if (typeof window !== "undefined" && !isTerminalStatus(snapshot.run.status)) {
+        startRunStream(runId, set, get);
+      } else {
+        set({ streamMode: "idle" });
+      }
+    } catch {
+      setStoredLatestRunId(null);
+      set({
+        quotaLoading: false,
+        runError: "Failed to resume the previous run.",
+        phase: "idle",
+        statusLine: "Failed to resume the previous run.",
+        streamMode: "idle",
+      });
+    }
+  },
   stopRun: () => {
     clearRunSync();
     set({ phase: "failed", statusLine: "Stopped", streamMode: "idle" });
   },
   reset: () => {
     clearRunSync();
+    setStoredLatestRunId(null);
     set((state) => ({
       ...initialState,
       quota: state.quota,
@@ -682,6 +728,8 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
         quota: result.quota ?? get().quota,
         quotaLoading: false,
       });
+
+      setStoredLatestRunId(result.run.id);
 
       if (typeof window !== "undefined") {
         startRunStream(result.run.id, set, get);


### PR DESCRIPTION
Persist the latest run id in localStorage and restore the playground state on page load so guests can continue watching an ongoing run after refreshing or revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)