### PR TITLE
feat(web/orchestrator/sites): time limit in prompt + countdowns + card polish

### DIFF
--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -656,6 +656,9 @@ async function initializeAttempt(params: InitializeAttemptParams) {
     activeSessionId: null,
     activeSequenceIndex: 0,
     completedSessionIds: [],
+    // Carry the suite's per-testcase time limit onto attempt metadata so the
+    // connection prompt and frontends can show the same deadline.
+    timeLimitMinutesPerTestcase: revision.timeLimitMinutesPerTestcase,
     // Carry the suite's cross-app consistency checks onto attempt metadata so
     // completion-time aggregation can evaluate them without re-reading the
     // manifest. Absent for suites without a chain.

--- a/apps/hosted-sites/src/templates.ts
+++ b/apps/hosted-sites/src/templates.ts
@@ -40,6 +40,40 @@ export function layout(params: {
   const taskHomePath = params.session.startPath ?? params.defaultStartPathForApp(params.session.app);
   const taskHomeSeparator = taskHomePath.includes("?") ? "&" : "?";
   const appNav = `<a href="${escapeHtml(taskHomePath)}${taskHomeSeparator}session=${encodeURIComponent(params.session.token)}">Task home</a>`;
+  const timeLimitMinutes =
+    typeof params.session.metadata.timeLimitMinutesPerTestcase === "number" &&
+    Number.isFinite(params.session.metadata.timeLimitMinutesPerTestcase)
+      ? params.session.metadata.timeLimitMinutesPerTestcase
+      : null;
+  const showCountdown = !isViewer && !isTerminal && params.session.expiresAt;
+  const countdownBanner = showCountdown
+    ? `<div class="countdown-banner" data-expires-at="${escapeHtml(params.session.expiresAt ?? "")}">
+        <span class="countdown-label">Time remaining</span>
+        <span class="countdown-value">--:--</span>
+        ${timeLimitMinutes ? `<span class="countdown-limit">/ ${timeLimitMinutes} min</span>` : ""}
+       </div>
+       <script>
+         (function () {
+           var banner = document.currentScript.previousElementSibling;
+           var valueEl = banner.querySelector('.countdown-value');
+           var expiresAt = new Date(banner.getAttribute('data-expires-at')).getTime();
+           function update() {
+             var remaining = expiresAt - Date.now();
+             if (remaining <= 0) {
+               valueEl.textContent = 'Timed out';
+               banner.classList.add('urgent');
+               return;
+             }
+             var minutes = Math.floor(remaining / 60000);
+             var seconds = Math.floor((remaining % 60000) / 1000);
+             valueEl.textContent = minutes + ':' + (seconds < 10 ? '0' : '') + seconds;
+             if (remaining < 60000) banner.classList.add('urgent');
+           }
+           update();
+           setInterval(update, 1000);
+         })();
+       </script>`
+    : "";
   const telemetry = isViewer || isTerminal ? "" : `
     <script>
       window.AgentBenchHostedSession = ${JSON.stringify({
@@ -169,6 +203,12 @@ export function layout(params: {
       .score { white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
       .layout-badge { display: inline-block; margin-bottom: 8px; color: var(--muted); font-size: 11px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
       .viewer-banner { margin: 0 24px; padding: 10px 14px; border: 1px solid var(--line); background: var(--accent-soft); color: var(--ink); font-size: 12px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+      .countdown-banner { margin: 0 24px; padding: 8px 14px; border: 1px solid var(--line); background: var(--panel); color: var(--ink); font-size: 12px; font-weight: 700; display: flex; align-items: center; gap: 8px; }
+      .countdown-banner.urgent { background: #fff1ed; color: #8a2d1f; border-color: #e6b3a9; }
+      .countdown-label { text-transform: uppercase; letter-spacing: .08em; font-size: 10px; color: var(--muted); }
+      .countdown-banner.urgent .countdown-label { color: #b45b4a; }
+      .countdown-value { font-variant-numeric: tabular-nums; }
+      .countdown-limit { color: var(--muted); font-size: 11px; margin-left: auto; }
       .viewer-readonly form, .viewer-readonly a { pointer-events: none; }
       .terminal-readonly form { pointer-events: none; opacity: .58; }
       .terminal-readonly button, .terminal-readonly input, .terminal-readonly textarea, .terminal-readonly select { cursor: not-allowed; }
@@ -335,6 +375,7 @@ export function layout(params: {
     <div class="shell">
     ${isViewer ? '<div class="viewer-banner">Live read-only session view</div>' : ""}
     ${isTerminal ? `<div class="viewer-banner">Case ${escapeHtml(params.session.status)} · return to the AgentBench Connection Page to continue${connectionUrl ? ` · <a href="${escapeHtml(connectionUrl)}">Return to Connection Page</a>` : ""}</div>` : ""}
+    ${countdownBanner}
     <header>
       <div class="heading">
         <span class="layout-badge">${escapeHtml(params.session.app)} · ${uiVariant} · ${uiTheme}</span>

--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import type { HostedSessionBreakdown } from "@/lib/hosted-scoring";
 import { usePlaygroundStore } from "@/lib/playground-store";
 import { ServiceUnavailableDialog } from "./ServiceUnavailableDialog";
+import type { HostedSessionDeadline } from "@/lib/db";
 
 type RunConnectPayload = {
   runId: string;
@@ -25,6 +26,7 @@ type RunConnectPayload = {
     attemptId: string | null;
     suiteSlug: string | null;
     suiteVersion: string | null;
+    timeLimitMinutes: number | null;
     orchestratorUrl: string | null;
     advanceUrl: string | null;
     activeSessionId: string | null;
@@ -56,6 +58,59 @@ type RunConnectError = {
   hostedSitesUrl?: string;
 };
 
+function useNow(intervalMs = 1000) {
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+function formatCountdown(durationMs: number) {
+  const totalSeconds = Math.max(0, Math.ceil(durationMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function useActiveSessionDeadline(runId: string | null) {
+  const [deadline, setDeadline] = useState<HostedSessionDeadline | null>(null);
+
+  useEffect(() => {
+    if (!runId) {
+      setDeadline(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const response = await fetch(`/api/runs/${runId}/hosted-sessions`, {
+          cache: "no-store",
+        });
+        if (!response.ok) return;
+        const result = (await response.json()) as { sessions: HostedSessionDeadline[] };
+        if (cancelled) return;
+        const active = result.sessions.find((session) => session.status === "active") ?? null;
+        setDeadline(active);
+      } catch (error) {
+        console.error("[run-connection-card] failed to refresh deadlines", error);
+      }
+    }
+
+    void load();
+    const interval = window.setInterval(load, 5000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [runId]);
+
+  return deadline;
+}
+
 function statusBadgeTone(status: string) {
   if (status === "completed") {
     return "bg-[#e8f7ec] text-[#1f6b35]";
@@ -64,7 +119,7 @@ function statusBadgeTone(status: string) {
     return "bg-[#fff1ed] text-[#8a2d1f]";
   }
   if (status === "active" || status === "running") {
-    return "bg-[#eef6ff] text-[#245a8a]";
+    return "bg-[#d7ff00] text-[#111111]";
   }
   return "bg-[#efede6] text-[#4d483f]";
 }
@@ -144,38 +199,37 @@ function SessionStepper({
   const sorted = [...sessions].sort((left, right) => left.sequenceIndex - right.sequenceIndex);
 
   return (
-    <div className="relative">
-      <div className="flex items-start justify-between gap-1 overflow-x-auto pb-2">
-        {sorted.map((session, index) => {
-          const isCompleted = index < completed;
-          const isCurrent = index === currentIndex;
-          return (
-            <div key={session.sessionId} className="flex min-w-[3.2rem] flex-col items-center gap-1.5">
-              <div
-                className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold ${
-                  isCompleted
-                    ? "bg-[#4da66a] text-white"
-                    : isCurrent
-                      ? "bg-[#d7ff00] text-[#111111] ring-2 ring-[#d7ff00]/30"
-                      : "border border-[#d8d1c4] bg-white text-[#6a655c]"
-                }`}
-              >
-                {isCompleted ? <CheckIcon /> : index + 1}
-              </div>
-              <span className="text-[9px] uppercase tracking-wider text-[#6a655c]">
-                Session {index + 1}
-              </span>
+    <div className="flex flex-wrap items-start gap-2">
+      {sorted.map((session, index) => {
+        const isCompleted = index < completed;
+        const isCurrent = index === currentIndex;
+        return (
+          <div
+            key={session.sessionId}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold"
+            title={`Session ${index + 1}`}
+          >
+            <div
+              className={`flex h-full w-full items-center justify-center rounded-full ${
+                isCompleted
+                  ? "bg-[#4da66a] text-white"
+                  : isCurrent
+                    ? "bg-[#d7ff00] text-[#111111] ring-2 ring-[#d7ff00]/30"
+                    : "border border-[#d8d1c4] bg-white text-[#6a655c]"
+              }`}
+            >
+              {isCompleted ? <CheckIcon /> : index + 1}
             </div>
-          );
-        })}
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 function ScoreCheck({ session }: { session: HostedSessionBreakdown }) {
   return (
-    <div className="rounded-[0.9rem] border border-[#e2ddd3] bg-white px-3 py-3">
+    <div className="group rounded-[0.9rem] border border-[#e2ddd3] bg-white px-3 py-3 transition hover:border-[#111111]">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="truncate text-sm font-medium text-[#111111]">{session.taskSlug}</div>
@@ -190,7 +244,7 @@ function ScoreCheck({ session }: { session: HostedSessionBreakdown }) {
         </div>
       </div>
       {session.evaluators.length > 0 ? (
-        <div className="mt-3 space-y-1.5">
+        <div className="mt-3 hidden space-y-1.5 group-hover:block">
           {session.evaluators.map((evaluator) => (
             <div key={`${evaluator.type}:${evaluator.name}`} className="flex items-start gap-2 text-xs leading-5">
               <span
@@ -232,6 +286,8 @@ export function RunConnectionCard() {
   const scoringSessions = usePlaygroundStore((state) => state.scoringSessions);
   const timeline = usePlaygroundStore((state) => state.timeline);
   const streamMode = usePlaygroundStore((state) => state.streamMode);
+  const activeDeadline = useActiveSessionDeadline(runId);
+  const now = useNow();
   const connectionRefreshKey = usePlaygroundStore(
     (state) =>
       state.timeline.filter(
@@ -371,6 +427,16 @@ export function RunConnectionCard() {
     (left, right) => left.sequenceIndex - right.sequenceIndex,
   );
 
+  const countdownText = (() => {
+    if (!activeDeadline?.expiresAt) return null;
+    const remaining = new Date(activeDeadline.expiresAt).getTime() - now;
+    if (remaining <= 0) return "Timed out";
+    return `Time left: ${formatCountdown(remaining)}`;
+  })();
+  const countdownUrgent = Boolean(
+    activeDeadline?.expiresAt && new Date(activeDeadline.expiresAt).getTime() - now < 60_000,
+  );
+
   const displayedEvents = showAllEvents
     ? [...timeline].reverse()
     : [...timeline].slice(-5).reverse();
@@ -380,43 +446,25 @@ export function RunConnectionCard() {
       <button
         type="button"
         onClick={() => setCollapsed((current) => !current)}
-        className="flex w-full flex-wrap items-center justify-between gap-3 text-left"
+        className="flex w-full items-center justify-between gap-3 text-left"
       >
-        <div>
-          <div className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Status</div>
-          <h3 className="mt-1.5 text-[1.2rem] font-medium text-[#111111]">
-            {isTerminalRun
-              ? statusLabel(payload.status)
-              : isActive
-                ? "Running"
-                : "Run created"}
-          </h3>
-        </div>
         <div className="flex items-center gap-3">
-          {payload.hostedWeb.available ? (
-            <div className="hidden items-center gap-3 text-xs text-[#6a655c] sm:flex">
-              {payload.hostedWeb.progress.currentIndex !== null ? (
-                <span>Session {payload.hostedWeb.progress.currentIndex + 1} / {payload.hostedWeb.progress.total}</span>
-              ) : null}
-              <span className="flex items-center gap-1 font-medium text-[#1f6b35]">
-                <CheckIcon className="h-3.5 w-3.5" />
-                {score === null ? "--" : `${Math.round(score * 100)}%`}
-              </span>
-            </div>
-          ) : null}
-          <div className={`rounded-full px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] ${statusBadgeTone(payload.status)}`}>
-            {isTerminalRun ? statusLabel(payload.status) : isActive ? "Run active" : "Run created"}
-          </div>
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            className={`shrink-0 transition-transform duration-200 ${collapsed ? "-rotate-90" : ""}`}
+          <span className="text-xs uppercase tracking-[0.2em] text-[#70695e]">Run Status</span>
+          <div
+            className={`rounded-full px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] ${statusBadgeTone(payload.status)}`}
           >
-            <path d="M2 4l4 4 4-4" stroke="#70695e" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
+            {isTerminalRun ? statusLabel(payload.status) : isActive ? "Running" : "Run created"}
+          </div>
         </div>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          className={`shrink-0 transition-transform duration-200 ${collapsed ? "-rotate-90" : ""}`}
+        >
+          <path d="M2 4l4 4 4-4" stroke="#70695e" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
       </button>
 
       {!collapsed && (
@@ -470,12 +518,23 @@ export function RunConnectionCard() {
                     <div className="text-sm font-semibold text-[#111111]">
                       {activeHostedSession.title ?? activeHostedSession.taskSlug}
                     </div>
-                    <p className="mt-1 text-sm leading-7 text-[#585248]">{activeHostedSession.goal}</p>
+                    <p className="max-h-28 overflow-y-auto pr-1 text-sm leading-7 text-[#585248] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[#d8d1c4]">
+                      {activeHostedSession.goal}
+                    </p>
                     <div className="mt-2 flex items-center gap-2 text-[10px] uppercase tracking-wider text-[#8f897e]">
                       <span>{activeHostedSession.app}</span>
                       <span>·</span>
                       <span>Session {activeHostedSession.sequenceIndex + 1}</span>
                     </div>
+                    {countdownText ? (
+                      <div
+                        className={`mt-2 text-[10px] font-semibold uppercase tracking-wider ${
+                          countdownUrgent ? "text-[#d45b45]" : "text-[#6a655c]"
+                        }`}
+                      >
+                        {countdownText}
+                      </div>
+                    ) : null}
                   </div>
                 ) : (
                   <div className="rounded-[1rem] border border-dashed border-[#d8d1c4] bg-white/60 px-4 py-3 text-sm text-[#7a7469]">
@@ -505,23 +564,15 @@ export function RunConnectionCard() {
 
               <hr className="border-[#e8e4da]" />
 
-              <section>
-                <SectionTitle
-                  icon={<CircleCheckIcon />}
-                  title={`Completed Checks (${scoringSessions.reduce((total, session) => total + session.evaluators.length, 0)})`}
-                />
-                <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
-                  {scoringSessions.length > 0 ? (
-                    [...scoringSessions].reverse().map((session) => <ScoreCheck key={session.sessionId} session={session} />)
-                  ) : (
-                    <div className="rounded-[0.9rem] border border-dashed border-[#d8d1c4] bg-white/60 px-3 py-4 text-xs leading-5 text-[#7a7469]">
-                      Completed evaluator checks will appear here as sessions are scored.
-                    </div>
-                  )}
-                </div>
-              </section>
+              {scoringSessions.length > 0 ? (
+                <section className="max-h-56 space-y-2 overflow-y-auto pr-1">
+                  {[...scoringSessions].reverse().map((session) => (
+                    <ScoreCheck key={session.sessionId} session={session} />
+                  ))}
+                </section>
+              ) : null}
 
-              <hr className="border-[#e8e4da]" />
+              {scoringSessions.length > 0 ? <hr className="border-[#e8e4da]" /> : null}
 
               <section>
                 <SectionTitle

--- a/apps/web/lib/hosted-web.ts
+++ b/apps/web/lib/hosted-web.ts
@@ -27,6 +27,7 @@ export type HostedWebAttemptConnection = {
   attemptId: string | null;
   suiteSlug: string;
   suiteVersion: string;
+  timeLimitMinutes: number | null;
   orchestratorUrl: string | null;
   advanceUrl: string | null;
   activeSessionId: string | null;
@@ -110,6 +111,11 @@ function toAttemptConnection(params: {
     attemptId: params.attempt.id ?? null,
     suiteSlug: params.attempt.suiteSlug,
     suiteVersion: params.attempt.suiteVersion,
+    timeLimitMinutes:
+      typeof params.attempt.metadata.timeLimitMinutesPerTestcase === "number" &&
+      Number.isFinite(params.attempt.metadata.timeLimitMinutesPerTestcase)
+        ? params.attempt.metadata.timeLimitMinutesPerTestcase
+        : null,
     orchestratorUrl: activeSession?.startUrl ?? null,
     advanceUrl:
       activeSession?.token

--- a/apps/web/lib/run-connect.ts
+++ b/apps/web/lib/run-connect.ts
@@ -26,13 +26,18 @@ export async function buildRunConnectPayload(params: {
   const metadataUrl = `${origin}/api/runs/${run.id}/metadata`;
   const goal = getGoal(benchmarkCase);
   const title = benchmarkCase?.title ?? "AgentBench Run";
+  const timeLimitMinutes = hostedWeb?.timeLimitMinutes ?? null;
+  const timeLimitSentence = timeLimitMinutes
+    ? `You have ${timeLimitMinutes} minute${timeLimitMinutes === 1 ? "" : "s"} to complete each hosted task.`
+    : "";
   const prompt = [
     "Open the AgentBench connection page below.",
     "Register the agent identity in the form, then open the active hosted benchmark and complete the current objective.",
     "Follow the ordered suite instructions and stop when the active task is completed or clearly blocked.",
+    timeLimitSentence,
     "",
     connectUrl,
-  ].join("\n");
+  ].filter(Boolean).join("\n");
 
   return {
     runId: run.id,
@@ -50,12 +55,13 @@ export async function buildRunConnectPayload(params: {
       ? [
           `Open the hosted benchmark site for run ${run.id}.`,
           `This suite contains ${hostedWeb.sessions.length} hosted session${hostedWeb.sessions.length === 1 ? "" : "s"}.`,
+          timeLimitSentence,
           "Register the agent name, version, base model, and optional metadata in the form on this page.",
           "Open only the active hosted case shown on this page.",
           "After each case completes, return here and proceed to the next active case.",
           "Use only the session URLs allocated for this run.",
           "Stop after the active objective is completed or clearly blocked.",
-        ]
+        ].filter(Boolean)
       : [
           `Open the connection page for run ${run.id}.`,
           "Register the agent name, version, base model, and optional metadata in the form on this page.",
@@ -84,6 +90,7 @@ export async function buildRunConnectPayload(params: {
           attemptId: hostedWeb.attemptId,
           suiteSlug: hostedWeb.suiteSlug,
           suiteVersion: hostedWeb.suiteVersion,
+          timeLimitMinutes: hostedWeb.timeLimitMinutes,
           orchestratorUrl: hostedWeb.orchestratorUrl,
           advanceUrl: hostedWeb.advanceUrl,
           activeSessionId: hostedWeb.activeSessionId,


### PR DESCRIPTION
- Adds the suite time limit to the agent prompt and instructions.\n- Shows a live countdown in the RunConnectionCard Current Task section and on hosted-site pages.\n- Polishes the connection card header, stepper, and completed-check cards per design feedback.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)