### PR TITLE
fix(web): sync benchmark labels with main

### DIFF
--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -32,7 +32,7 @@ function SuiteLabel({ board }: { board: LeaderboardBoard }) {
   return (
     <span className="flex items-center gap-2">
       <SuiteTag tag={board.tag} compact />
-      <span className="truncate">agent benchmark [{board.tag}-{board.version}]</span>
+      <span className="truncate">benchmark [{board.tag}-{board.version}]</span>
     </span>
   );
 }

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -594,8 +594,8 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
       const benchmarks: BenchmarkOption[] = result.cases.map((item) => ({
         id: item.id,
         slug: item.slug,
-        label: `agent benchmark [${item.tag}-${item.version}]`,
-        description: `Run the ${item.tag} agent benchmark suite.`,
+        label: `benchmark [${item.tag}-${item.version}]`,
+        description: `Run the ${item.tag} benchmark suite.`,
         difficulty: item.difficulty,
         tag: item.tag,
         version: item.version,


### PR DESCRIPTION
Remove the stray "agent" prefix from playground and leaderboard benchmark labels so `develop` matches `main`.