### PR TITLE
fix(web): reduce run stream database egress

### DIFF
--- a/apps/web/app/api/runs/[runId]/stream/route.ts
+++ b/apps/web/app/api/runs/[runId]/stream/route.ts
@@ -1,8 +1,8 @@
-import { getBenchmarkRun, listArtifacts, listRunEvents } from "@/lib/db";
+import { getBenchmarkRun, getRunStreamFingerprint, listArtifacts, listRunEvents } from "@/lib/db";
 
 const encoder = new TextEncoder();
 const STREAM_MAX_DURATION_MS = 25_000;
-const STREAM_POLL_MS = 750;
+const STREAM_POLL_MS = 5_000;
 const STREAM_HEARTBEAT_MS = 10_000;
 
 export const dynamic = "force-dynamic";
@@ -12,6 +12,8 @@ type RunStreamPayload = {
   events: Awaited<ReturnType<typeof listRunEvents>>;
   artifacts: Awaited<ReturnType<typeof listArtifacts>>;
 };
+
+type RunStreamFingerprint = Awaited<ReturnType<typeof getRunStreamFingerprint>>;
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -23,22 +25,24 @@ function toSseChunk(event: string, data: unknown) {
 
 function makeFingerprint(payload: RunStreamPayload) {
   return JSON.stringify({
-        run: payload.run
-          ? {
-              id: payload.run.id,
-              status: payload.run.status,
-              score: payload.run.score,
-              errorMessage: payload.run.errorMessage,
-              completedAt: payload.run.completedAt,
-              startedAt: payload.run.startedAt,
-              runnerId: payload.run.runnerId,
+    run: payload.run
+      ? {
+          id: payload.run.id,
+          status: payload.run.status,
+          score: payload.run.score,
+          errorMessage: payload.run.errorMessage,
+          completedAt: payload.run.completedAt,
+          startedAt: payload.run.startedAt,
+          runnerId: payload.run.runnerId,
         }
       : null,
     lastEventId: payload.events[payload.events.length - 1]?.id ?? null,
-    eventCount: payload.events.length,
     lastArtifactId: payload.artifacts[payload.artifacts.length - 1]?.id ?? null,
-    artifactCount: payload.artifacts.length,
   });
+}
+
+function stringifyFingerprint(fingerprint: RunStreamFingerprint) {
+  return JSON.stringify(fingerprint);
 }
 
 function isTerminal(status: string | null | undefined) {
@@ -70,6 +74,7 @@ export async function GET(
       },
     });
   }
+  const initialRun = initialSnapshot.run;
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -90,32 +95,47 @@ export async function GET(
       request.signal.addEventListener("abort", close);
 
       controller.enqueue(encoder.encode("retry: 2000\n\n"));
+      lastFingerprint = makeFingerprint(initialSnapshot);
+      controller.enqueue(toSseChunk("snapshot", initialSnapshot));
+
+      if (isTerminal(initialRun.status)) {
+        controller.enqueue(toSseChunk("terminal", { status: initialRun.status }));
+        close();
+        return;
+      }
 
       while (!closed) {
-        const snapshot = await loadSnapshot(runId);
+        await sleep(STREAM_POLL_MS);
 
-        if (!snapshot.run) {
+        const fingerprintSnapshot = await getRunStreamFingerprint(runId);
+        if (!fingerprintSnapshot.run) {
           controller.enqueue(toSseChunk("error", { message: "Run not found" }));
           close();
           break;
         }
 
-        const fingerprint = makeFingerprint(snapshot);
+        const fingerprint = stringifyFingerprint(fingerprintSnapshot);
         if (fingerprint !== lastFingerprint) {
+          const snapshot = await loadSnapshot(runId);
+          if (!snapshot.run) {
+            controller.enqueue(toSseChunk("error", { message: "Run not found" }));
+            close();
+            break;
+          }
           lastFingerprint = fingerprint;
           controller.enqueue(toSseChunk("snapshot", snapshot));
+
+          if (isTerminal(snapshot.run.status)) {
+            controller.enqueue(toSseChunk("terminal", { status: snapshot.run.status }));
+            close();
+            break;
+          }
         }
 
         const now = Date.now();
         if (now - lastHeartbeatAt >= STREAM_HEARTBEAT_MS) {
           controller.enqueue(toSseChunk("heartbeat", { ts: new Date(now).toISOString() }));
           lastHeartbeatAt = now;
-        }
-
-        if (isTerminal(snapshot.run.status)) {
-          controller.enqueue(toSseChunk("terminal", { status: snapshot.run.status }));
-          close();
-          break;
         }
 
         if (now - startedAt >= STREAM_MAX_DURATION_MS) {

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -408,6 +408,58 @@ export async function listArtifacts(runId: string): Promise<Artifact[]> {
   }));
 }
 
+export async function getRunStreamFingerprint(runId: string) {
+  const supabase = getSupabase();
+
+  const [runResult, eventResult, artifactResult] = await Promise.all([
+    supabase
+      .from("benchmark_runs")
+      .select("id, status, score, error_message, started_at, completed_at, runner_id")
+      .eq("id", runId)
+      .maybeSingle(),
+    supabase
+      .from("run_events")
+      .select("id")
+      .eq("run_id", runId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("artifacts")
+      .select("id")
+      .eq("run_id", runId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  if (runResult.error) {
+    throw runResult.error;
+  }
+  if (eventResult.error) {
+    throw eventResult.error;
+  }
+  if (artifactResult.error) {
+    throw artifactResult.error;
+  }
+
+  return {
+    run: runResult.data
+      ? {
+          id: runResult.data.id,
+          status: runResult.data.status,
+          score: runResult.data.score,
+          errorMessage: runResult.data.error_message,
+          completedAt: runResult.data.completed_at,
+          startedAt: runResult.data.started_at,
+          runnerId: runResult.data.runner_id,
+        }
+      : null,
+    lastEventId: eventResult.data?.id ?? null,
+    lastArtifactId: artifactResult.data?.id ?? null,
+  };
+}
+
 export async function appendRunEvent(runId: string, input: AppendRunEventInput) {
   const supabase = getSupabase();
 

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -498,6 +498,10 @@ function startFallbackPolling(
   set({ streamMode: "polling" });
 
   const tick = async () => {
+    if (typeof document !== "undefined" && document.hidden) {
+      return;
+    }
+
     const state = getState();
     if (state.currentRunId !== runId) {
       clearRunSync();
@@ -522,7 +526,7 @@ function startFallbackPolling(
     void tick().catch((error) => {
       console.error("[playground] polling refresh failed", error);
     });
-  }, 2000);
+  }, 5000);
 }
 
 function startRunStream(


### PR DESCRIPTION
## Summary
- reduce `/api/runs/[runId]/stream` Supabase egress by polling lightweight markers instead of full run events/artifacts
- only load the full run snapshot when the run status, latest event, or latest artifact changes
- lower fallback polling frequency and skip fallback polling for background tabs

## Root Cause
The run stream endpoint polled Supabase every 750ms and each poll fetched the full run, full run event payload list, and full artifact list. Long-lived playground/live tabs repeatedly transferred full PostgREST JSON even when nothing changed, which can quickly consume Supabase egress.

## Validation
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` from `apps/web`
- `node --import tsx --test $(find tests/unit -type f -name '*.test.ts' | sort)` from `apps/web`
- `./node_modules/.bin/next build` from `apps/web`
