### PR TITLE
fix(web): keep full hosted event history for live viewer URL

### DIFF
--- a/apps/web/components/run/LiveRunViewer.tsx
+++ b/apps/web/components/run/LiveRunViewer.tsx
@@ -181,7 +181,7 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
       setErrorMessage(payload.run?.errorMessage ?? initialErrorMessage);
       setFrameUrl(deriveLiveFrameUrl(payload));
       const nextHostedEvents = payload.events.filter((item) => item.type.startsWith("hosted."));
-      setHostedEvents(nextHostedEvents.slice(-8));
+      setHostedEvents(nextHostedEvents);
       setSuiteSessions(deriveHostedSuiteSessions(nextHostedEvents));
     });
 
@@ -383,9 +383,10 @@ function HostedEventFallback({ events, compact = false }: { events: StreamEvent[
     );
   }
 
+  const displayEvents = events.slice(-8);
   return (
     <div className="flex h-full flex-col justify-end gap-2 p-4">
-      {events.map((event, index) => (
+      {displayEvents.map((event, index) => (
         <div
           key={`${event.type}-${index}`}
           className="rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 text-left"


### PR DESCRIPTION
Fixes the live viewer falling back to the hosted-event list instead of showing the active session site.\n\nThe snapshot handler was slicing hosted events to the latest 8, which dropped older  events. When the active session advanced before issuing a new page load, the viewer no longer had the session's , so it rendered the fallback instead of the site.\n\nThe viewer now retains the full hosted event history for URL derivation and only caps the fallback UI to the latest 8 events.\n\nVerification:\n- `pnpm --filter web exec tsc --noEmit` ✅\n- `pnpm --filter web test` ✅ (41/41)