### PR TITLE
fix(web): stable hook order when active run loads

### DIFF
--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -315,6 +315,10 @@ export function RunConnectionCard() {
   const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
+    setEventPage(0);
+  }, [timeline.length]);
+
+  useEffect(() => {
     if (!runId) {
       setPayload(null);
       setConnectError(null);
@@ -466,10 +470,6 @@ export function RunConnectionCard() {
     safeEventPage * eventsPerPage,
     (safeEventPage + 1) * eventsPerPage,
   );
-
-  useEffect(() => {
-    setEventPage(0);
-  }, [timeline.length]);
 
   return (
     <div className="mt-4 rounded-[1.6rem] border border-[#d7d0c4] bg-white p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">


### PR DESCRIPTION
Fixes a React hooks-order crash that happens when an ongoing run loads after refresh.\n\n- Moves the  that resets the Latest Events page before any conditional early return so the component calls the same number of hooks on every render.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)