### PR TITLE
fix(web): derive live viewer active session from run events

### DIFF
--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -315,6 +315,10 @@ export function RunConnectionCard() {
   const [retryNonce, setRetryNonce] = useState(0);
 
   useEffect(() => {
+    setEventPage(0);
+  }, [timeline.length]);
+
+  useEffect(() => {
     if (!runId) {
       setPayload(null);
       setConnectError(null);
@@ -466,10 +470,6 @@ export function RunConnectionCard() {
     safeEventPage * eventsPerPage,
     (safeEventPage + 1) * eventsPerPage,
   );
-
-  useEffect(() => {
-    setEventPage(0);
-  }, [timeline.length]);
 
   return (
     <div className="mt-4 rounded-[1.6rem] border border-[#d7d0c4] bg-white p-5 shadow-[0_14px_40px_rgba(17,17,17,0.05)]">

--- a/apps/web/components/run/LiveRunViewer.tsx
+++ b/apps/web/components/run/LiveRunViewer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import {
+  deriveActiveHostedSessionId,
   deriveActiveHostedViewerUrl,
   deriveHostedViewerRevision,
 } from "@/lib/hosted-viewer";
@@ -168,7 +169,6 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
   const [hostedEvents, setHostedEvents] = useState<StreamEvent[]>([]);
   const [suiteSessions, setSuiteSessions] = useState<HostedSuiteSession[]>([]);
   const [sessionDeadlines, setSessionDeadlines] = useState<Map<string, HostedSessionDeadline>>(new Map());
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const now = useNow();
 
   useEffect(() => {
@@ -212,7 +212,6 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
         if (!response.ok) return;
         const result = (await response.json()) as { sessions: HostedSessionDeadline[] };
         setSessionDeadlines(new Map(result.sessions.map((session) => [session.sessionId, session])));
-        setActiveSessionId(result.sessions.find((session) => session.status === "active")?.sessionId ?? null);
       } catch (error) {
         console.error("[live-viewer] failed to refresh session deadlines", error);
       }
@@ -224,9 +223,10 @@ export function LiveRunViewer(props: LiveRunViewerProps) {
   }, [runId]);
 
   useEffect(() => {
+    const activeSessionId = deriveActiveHostedSessionId(hostedEvents);
     setViewerUrl(deriveActiveHostedViewerUrl(hostedEvents, activeSessionId));
     setViewerRevision(deriveHostedViewerRevision(hostedEvents));
-  }, [hostedEvents, activeSessionId]);
+  }, [hostedEvents]);
 
   const terminalSummary =
     status === "timeout"

--- a/apps/web/lib/hosted-viewer.ts
+++ b/apps/web/lib/hosted-viewer.ts
@@ -106,3 +106,37 @@ export function deriveHostedViewerRevision(events: HostedViewerEvent[]) {
       event.type === "hosted.score",
   ).length;
 }
+
+export function deriveActiveHostedSessionId(events: HostedViewerEvent[]) {
+  const sessions = new Map<string, { sequenceIndex: number }>();
+
+  for (const event of events) {
+    if (event.type !== "hosted.session.created") continue;
+
+    const sessionId = sessionIdFromEvent(event);
+    if (!sessionId) continue;
+
+    const sequenceIndex =
+      typeof event.payload.sequenceIndex === "number" && Number.isFinite(event.payload.sequenceIndex)
+        ? event.payload.sequenceIndex
+        : sessions.size;
+
+    sessions.set(sessionId, { sequenceIndex });
+  }
+
+  const scoredSessionIds = new Set<string>();
+  for (const event of events) {
+    if (event.type !== "hosted.score") continue;
+
+    const sessionId = sessionIdFromEvent(event);
+    if (sessionId) {
+      scoredSessionIds.add(sessionId);
+    }
+  }
+
+  const activeEntry = [...sessions.entries()]
+    .filter(([sessionId]) => !scoredSessionIds.has(sessionId))
+    .sort((left, right) => left[1].sequenceIndex - right[1].sequenceIndex)[0];
+
+  return activeEntry?.[0] ?? null;
+}

--- a/apps/web/tests/unit/hosted-viewer.test.ts
+++ b/apps/web/tests/unit/hosted-viewer.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { deriveHostedViewerRevision, deriveHostedViewerUrl } from "../../lib/hosted-viewer";
+import {
+  deriveActiveHostedSessionId,
+  deriveActiveHostedViewerUrl,
+  deriveHostedViewerRevision,
+  deriveHostedViewerUrl,
+} from "../../lib/hosted-viewer";
 
 test("hosted viewer follows matching page loads while preserving its token", () => {
   const viewerUrl = deriveHostedViewerUrl([
@@ -44,6 +49,84 @@ test("hosted viewer ignores navigation outside the session app root", () => {
   ]);
 
   assert.equal(viewerUrl, "https://hosted.example/forum?session=view-token");
+});
+
+test("hosted viewer follows the first unscored session instead of stale page loads", () => {
+  const viewerUrl = deriveActiveHostedViewerUrl(
+    [
+      {
+        type: "hosted.session.created",
+        payload: {
+          sessionId: "session-1",
+          sequenceIndex: 0,
+          viewerStartUrl: "https://hosted.example/shopping?session=view-token-1",
+        },
+      },
+      {
+        type: "hosted.page.load",
+        payload: {
+          sessionId: "session-1",
+          url: "/shopping/cart?filter=active",
+        },
+      },
+      {
+        type: "hosted.session.created",
+        payload: {
+          sessionId: "session-2",
+          sequenceIndex: 1,
+          viewerStartUrl: "https://hosted.example/notes?session=view-token-2",
+        },
+      },
+      {
+        type: "hosted.score",
+        payload: {
+          sessionId: "session-1",
+          score: 1,
+        },
+      },
+    ],
+    "session-2",
+  );
+
+  assert.equal(viewerUrl, "https://hosted.example/notes?session=view-token-2");
+});
+
+test("derive active hosted session id picks the first created session without a score", () => {
+  const activeSessionId = deriveActiveHostedSessionId([
+    {
+      type: "hosted.session.created",
+      payload: { sessionId: "session-1", sequenceIndex: 0 },
+    },
+    {
+      type: "hosted.session.created",
+      payload: { sessionId: "session-2", sequenceIndex: 1 },
+    },
+    {
+      type: "hosted.session.created",
+      payload: { sessionId: "session-3", sequenceIndex: 2 },
+    },
+    {
+      type: "hosted.score",
+      payload: { sessionId: "session-1", score: 1 },
+    },
+  ]);
+
+  assert.equal(activeSessionId, "session-2");
+});
+
+test("derive active hosted session id returns null when all created sessions are scored", () => {
+  const activeSessionId = deriveActiveHostedSessionId([
+    {
+      type: "hosted.session.created",
+      payload: { sessionId: "session-1", sequenceIndex: 0 },
+    },
+    {
+      type: "hosted.score",
+      payload: { sessionId: "session-1", score: 0 },
+    },
+  ]);
+
+  assert.equal(activeSessionId, null);
 });
 
 test("hosted viewer revision advances only for state-bearing events", () => {


### PR DESCRIPTION
Fixes the embedded live viewer staying on an older session when the active hosted session advances.\n\n- The viewer was reading activeSessionId from /api/runs/[runId]/hosted-sessions, whose DB status can lag behind the orchestrator metadata used by the connection card.\n- Derive activeSessionId directly from the streamed run events: the first created session (by sequenceIndex) that has not yet received a hosted.score event is the active one.\n- Keep the hosted-sessions poll only for countdown/deadline data.\n- Add deriveActiveHostedSessionId and unit tests.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)