### PR TITLE
fix(hosted): mark scored partial runs finished

### DIFF
--- a/apps/hosted-orchestrator/src/attempt-lifecycle.ts
+++ b/apps/hosted-orchestrator/src/attempt-lifecycle.ts
@@ -258,7 +258,9 @@ export function createAttemptLifecycle(deps: AttemptLifecycleDeps) {
         passSummary: `All required hosted sessions for ${session.suiteSlug} passed.`,
         failSummary: `One or more required hosted sessions for ${session.suiteSlug} failed.`,
       });
-      attemptStatus = aggregate.status === "passed" ? "completed" : "failed";
+      // A scored suite has finished even when its evaluator evidence earns a
+      // partial score. Reserve the failed lifecycle state for scoring errors.
+      attemptStatus = aggregate.status === "error" ? "failed" : "completed";
       metadata = {
         ...existingAttemptMetadata,
         activeSessionId: null,

--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -154,7 +154,7 @@ function tokenFromStartUrl(startUrl: string) {
   }
 }
 
-const DEFAULT_SESSION_TIME_LIMIT_MINUTES = 360;
+const DEFAULT_SESSION_TIME_LIMIT_MINUTES = 10;
 
 function sessionExpiresAt(baseTime: string | number | Date, timeLimitMinutes?: number) {
   const minutes = typeof timeLimitMinutes === "number" && Number.isFinite(timeLimitMinutes) && timeLimitMinutes > 0
@@ -1432,7 +1432,7 @@ async function sweepExpiredSessions() {
         result: {
           status: "failed",
           score: 0,
-          summary: `Hosted session ${row.task_slug} timed out after ${row.metadata?.timeLimitMinutesPerTestcase ?? 360} minutes.`,
+          summary: `Hosted session ${row.task_slug} timed out after ${row.metadata?.timeLimitMinutesPerTestcase ?? DEFAULT_SESSION_TIME_LIMIT_MINUTES} minutes.`,
           evaluators: [],
         },
       });

--- a/apps/hosted-orchestrator/tests/unit/attempt-lifecycle.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/attempt-lifecycle.test.ts
@@ -756,7 +756,7 @@ test("complete-session passes the suite when the agent carries the value across 
   assert.equal(aggregate.breakdown.consistency?.[0]?.evidence?.matchedValue, "90 days");
 });
 
-test("complete-session requires both hard v1.0.2 wiki answers in distinct note fields", async () => {
+test("complete-session requires both hard v1.0.3 wiki answers in distinct note fields", async () => {
   const bodyChain = {
     ...consistencyChain,
     name: "Wiki policy answer carried into note body",
@@ -789,7 +789,7 @@ test("complete-session requires both hard v1.0.2 wiki answers in distinct note f
 });
 
 test("complete-session fails the suite on a cross-app consistency mismatch", async () => {
-  const { supabase } = createConsistencySupabase({
+  const { supabase, rpcCalls } = createConsistencySupabase({
     wikiFinalState: { app: "wiki-lite", latestAnswer: { answer: "90 days" } },
   });
   const lifecycle = createLifecycle({ getSupabaseAdmin: () => supabase });
@@ -809,6 +809,23 @@ test("complete-session fails the suite on a cross-app consistency mismatch", asy
   assert.equal(aggregate.status, "failed");
   assert.equal(aggregate.score, 0.6667);
   assert.equal(aggregate.breakdown.consistency?.[0]?.status, "failed");
+  assert.equal((rpcCalls[0]?.p_attempt_update as Record<string, unknown>).status, "completed");
+});
+
+test("complete-session reserves the failed lifecycle state for scoring errors", async () => {
+  const { supabase, rpcCalls } = createConsistencySupabase({
+    wikiFinalState: { app: "wiki-lite", latestAnswer: { answer: "90 days" } },
+  });
+  const lifecycle = createLifecycle({ getSupabaseAdmin: () => supabase });
+
+  const result = await lifecycle.executeCompleteSessionCommand({
+    type: "complete-session",
+    session: makeNotesTargetSession({ app: "notes-lite", notes: [{ id: "n1", title: "90 days", tag: "release" }] }),
+    result: makeScoreResult({ status: "error", score: 0, summary: "Evaluator unavailable" }),
+  });
+
+  assert.equal(result.attemptResult.aggregate?.status, "error");
+  assert.equal((rpcCalls[0]?.p_attempt_update as Record<string, unknown>).status, "failed");
 });
 
 test("complete-session reports missing prior output when the source final state is absent", async () => {

--- a/apps/hosted-orchestrator/tests/unit/lifecycle-migration.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/lifecycle-migration.test.ts
@@ -22,6 +22,18 @@ const boundedCommandDlqMigration = readFileSync(
   new URL("../../../../supabase/migrations/20260709000028_bound_command_dead_letters.sql", import.meta.url),
   "utf8",
 );
+const pendingSessionTimeLimitMigration = readFileSync(
+  new URL("../../../../supabase/migrations/20260710000029_set_pending_session_time_limit.sql", import.meta.url),
+  "utf8",
+);
+const tenMinuteFallbackMigration = readFileSync(
+  new URL("../../../../supabase/migrations/20260710000030_default_session_time_limit_ten_minutes.sql", import.meta.url),
+  "utf8",
+);
+const partialRunNormalizationMigration = readFileSync(
+  new URL("../../../../supabase/migrations/20260710000031_finish_scored_partial_runs.sql", import.meta.url),
+  "utf8",
+);
 
 test("attempt timeout migration keeps lifecycle writes under one row lock", () => {
   assert.match(migration, /for update;/i);
@@ -74,4 +86,26 @@ test("command DLQ migration redacts history and prunes in bounded batches", () =
   assert.match(boundedCommandDlqMigration, /status = 'dead' and created_at < p_dead_before/i);
   assert.match(boundedCommandDlqMigration, /status in \('replayed', 'resolved'\)/i);
   assert.match(boundedCommandDlqMigration, /grant execute .* to service_role/is);
+});
+
+test("pending sessions adopt the ten-minute limit without changing active deadlines", () => {
+  assert.match(pendingSessionTimeLimitMigration, /status = 'created'/i);
+  assert.match(pendingSessionTimeLimitMigration, /timeLimitMinutesPerTestcase/i);
+  assert.match(pendingSessionTimeLimitMigration, /'10'::jsonb/i);
+  assert.doesNotMatch(pendingSessionTimeLimitMigration, /status = 'active'/i);
+});
+
+test("session promotion falls back to ten minutes when legacy metadata has no limit", () => {
+  assert.match(tenMinuteFallbackMigration, /next_time_limit_minutes := coalesce\(/i);
+  assert.match(tenMinuteFallbackMigration, /\), 10\);/i);
+  assert.doesNotMatch(tenMinuteFallbackMigration, /\), 360\);/i);
+});
+
+test("historical partial scores normalize to completed runs without rewriting aggregate errors", () => {
+  assert.match(partialRunNormalizationMigration, /status = 'failed'/i);
+  assert.match(partialRunNormalizationMigration, /status = 'completed'/i);
+  assert.match(partialRunNormalizationMigration, /aggregate_score is not null/i);
+  assert.match(partialRunNormalizationMigration, /scoring_summary ->> 'status' = 'failed'/i);
+  assert.match(partialRunNormalizationMigration, /hosted_callback_outbox/i);
+  assert.doesNotMatch(partialRunNormalizationMigration, /scoring_summary ->> 'status' = 'error'/i);
 });

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -32,7 +32,7 @@ test("fresh database seed contains generated question pools without fixed sessio
 
 test("wiki question variants declare typed answer contracts", () => {
   const suite = readHostedSuiteSeed();
-  assert.equal(suite.suiteVersion, "v3.0.9");
+  assert.equal(suite.suiteVersion, "v3.0.10");
   const sessions = suite.sessions as Array<Record<string, unknown>>;
   const wiki = sessions.find((session) => session.app === "wiki-lite");
   assert.ok(wiki);

--- a/apps/web/app/results/[runId]/page.tsx
+++ b/apps/web/app/results/[runId]/page.tsx
@@ -22,9 +22,13 @@ export default async function PublicResultPage({ params }: { params: Promise<{ r
         <div className="mt-8 grid gap-8 border-b border-white/10 pb-10 lg:grid-cols-[1fr_auto] lg:items-end">
           <div>
             <div className="text-xs uppercase tracking-[0.2em] text-white/40">Public benchmark result</div>
-            {run.status === "failed" ? (
+            {run.status === "completed" ? (
+              <div className="mt-3 inline-flex rounded-full bg-[#d7ff00]/15 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#d7ff00]">
+                Finished
+              </div>
+            ) : run.status === "failed" ? (
               <div className="mt-3 inline-flex rounded-full bg-[#ff8d7a]/15 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#ff9f90]">
-                Failed run · partial score
+                Run error
               </div>
             ) : null}
             <h1 className="mt-3 text-4xl font-medium tracking-[-0.05em] text-white md:text-6xl">{benchmark.title}</h1>
@@ -33,7 +37,7 @@ export default async function PublicResultPage({ params }: { params: Promise<{ r
           <div className="text-left lg:text-right">
             <div className="text-7xl font-medium tracking-[-0.07em] text-[#d7ff00]">{Math.round((run.score ?? 0) * 100)}</div>
             <div className="text-xs uppercase tracking-[0.2em] text-white/40">
-              {run.status === "failed" ? "Partial aggregate score" : "Aggregate score"}
+              {run.status === "failed" ? "Aggregate score before error" : "Aggregate score"}
             </div>
           </div>
         </div>

--- a/apps/web/components/landing/Leaderboard.tsx
+++ b/apps/web/components/landing/Leaderboard.tsx
@@ -38,7 +38,7 @@ export async function Leaderboard() {
             </h2>
           </div>
           <p className="max-w-xl text-base leading-7 text-[#66625a] lg:justify-self-end">
-            Completed and failed scored runs are ranked within the same benchmark version. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
+            Finished scored runs are ranked within the same benchmark version. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
           </p>
         </div>
 

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -128,7 +128,11 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
                   <span>{entry.baseModel}</span>
                   <span className="lg:hidden"> · {entry.browser ?? "Unknown browser"} / {entry.platform ?? "Unknown platform"}</span>
                 </div>
-                {entry.status === "timeout" ? (
+                {entry.status === "completed" ? (
+                  <div className="mt-2 inline-flex rounded-full bg-[#d7ff00]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#d7ff00]">
+                    Finished
+                  </div>
+                ) : entry.status === "timeout" ? (
                   <div className="mt-2 inline-flex rounded-full bg-[#ffb627]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ffc44d]">
                     Timed out
                   </div>

--- a/apps/web/components/landing/LiveMacContainer.tsx
+++ b/apps/web/components/landing/LiveMacContainer.tsx
@@ -46,7 +46,7 @@ export function LiveMacScreenContent() {
 
     if (phase === "completed") {
       return {
-        title: "Run completed",
+        title: "Run finished",
         body: `Replay captured. Score ${score === null ? "--" : `${Math.round(score * 100)}%`}.`,
         accent: "completed",
       };

--- a/apps/web/components/landing/PlaygroundSection.tsx
+++ b/apps/web/components/landing/PlaygroundSection.tsx
@@ -34,7 +34,7 @@ export function PlaygroundSection({
             Each hosted run uses fixed task rules, structured events, and scorer checks so agent behavior can be compared across attempts.
           </p>
           <p className="mt-3 text-sm leading-6 text-[#7a7469]">
-            Completed and failed scored runs are published to the leaderboard. Agent and base-model identity is self-reported; browser environment and timing are captured by AgentBench.
+            Finished scored runs are published to the leaderboard. Agent and base-model identity is self-reported; browser environment and timing are captured by AgentBench.
           </p>
         </div>
 

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -204,7 +204,7 @@ function eventSummary(event: RunEvent) {
     case "score.updated":
       return `Score updated to ${String(event.payload.score ?? "--")}`;
     case "run.completed":
-      return "Run completed";
+      return "Run finished";
     case "run.failed":
       return "Run failed";
     default:

--- a/apps/web/tests/unit/hosted-attempt-recovery.test.ts
+++ b/apps/web/tests/unit/hosted-attempt-recovery.test.ts
@@ -28,7 +28,7 @@ test("recovers an existing hosted attempt through the orchestrator API", async (
       attemptId: "attempt-1",
       suiteSlug: "hosted-web-suite",
       suiteVersion: "v1",
-      metadata: { activeSessionId: "session-1", timeLimitMinutesPerTestcase: 30 },
+      metadata: { activeSessionId: "session-1", timeLimitMinutesPerTestcase: 10 },
       sessions: [{
         sessionId: "session-1",
         attemptId: "attempt-1",

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -58,7 +58,7 @@ performed prerequisite actions out of order.
 
 ## Independent Suite Versioning
 
-The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.9` and `hosted-web-hard-suite-v1.0.2`). A change to a hard variant, the hard pool composition, or a hard cross-app chain bumps only the hard suite's version and content hash; the easy suite's revision identity must stay byte-identical.
+The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.10` and `hosted-web-hard-suite-v1.0.3`). A change to a hard variant, the hard pool composition, a hard cross-app chain, or a testcase time limit bumps the affected suite's version and content hash.
 
 This is enforced mechanically: new task-config fields used by hard variants are optional and only inspected when present, and `consistencyChecks` is an optional manifest key that is absent from the easy manifest. The easy catalog's "stable revision identity and content hash" test fails if a hard-suite change leaks into the easy manifest.
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -47,6 +47,8 @@ Current hosted-web runs use `external-agent`. Some legacy enum values and column
 One execution of a hosted suite under a run.
 
 - status: `created | running | scoring | completed | failed | cancelled | timeout`
+- `completed` means the suite finished and has a durable aggregate score; it does not imply a perfect score. Aggregate evaluator status remains in `benchmark_attempt_scores` and `scoring_summary`.
+- `failed` is reserved for lifecycle or evaluator-engine errors. A non-passing evaluator result with a valid aggregate remains a completed attempt.
 - suite identity: `suite_slug`, `suite_version`
 - immutable definition: `case_revision_id`
 - `aggregate_score` and `scoring_summary`

--- a/docs/frontend-state-machine.md
+++ b/docs/frontend-state-machine.md
@@ -9,7 +9,7 @@ The landing-page playground is the only user-facing hosted-web run interface. Th
 | `idle` | Initial state or reset | Benchmark selector | Create run |
 | `booting` | `queued`, `waiting_for_agent`, `agent_connected`, `starting` | Connection guide, waiting events, viewer boot state | Stop run, open connection page |
 | `running` | Run is `running/scoring`, or hosted activity appears during boot | Active suite session, aggregate score, events, viewer | Stop run, complete active session |
-| `completed` | Run status is `completed` | Final score breakdown | Start again |
+| `completed` | Run status is `completed` | Finished score breakdown, including partial scores and evaluator deductions | Start again |
 | `failed` | `failed`, `cancelled`, `timeout` | Error summary and available score breakdown | Start again |
 
 State mapping belongs in `apps/web/lib/playground-store.ts` through `mapRunStatus` and `applyRunSnapshot`. Components must not invent run states from local UI events.
@@ -23,7 +23,7 @@ stateDiagram-v2
   booting --> running: run.running / scoring
   booting --> running: first hosted page/action/score event
   booting --> failed: failed / cancelled / timeout
-  running --> completed: run.completed
+  running --> completed: run.completed (Finished, any durable aggregate score)
   running --> failed: failed / cancelled / timeout
   completed --> idle: reset
   failed --> idle: reset

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -156,14 +156,14 @@ Confidentiality is the gating constraint for the epic: scorer oracle surfaces (v
 | #113 Calendar hard pool | Complete | Conflict-avoidance, shared-window, timezone-overlap, and reschedule variants. |
 | #114 Repo hard pool | Complete | Coherent multi-edit / rename / rollout variants with required messages. |
 | #110 Shopping hard pool | Complete | Stock-aware, compatibility, and coupon constrained-checkout variants. |
-| #115 Cross-app chain | In Progress | Hard v1.0.2 requires the agent to carry two exact wiki answers into a later note's title and body; enforced only by suite-level consistency checks against the agent's own final states. |
+| #115 Cross-app chain | In Progress | Hard v1.0.3 requires the agent to carry two exact wiki answers into a later note's title and body; enforced only by suite-level consistency checks against the agent's own final states. |
 | #116 Verification matrix and docs | In Progress | Both suites swept independently by the generic matrix; independent semantic versioning, cross-app consistency, and scorer oracle policy documented. |
-| #140 Hard v1.0.2 scale expansion | In Progress | Expand all six hard pools, add a required workflow spanning at least three sessions, and complete deterministic, confidentiality, browser, and lifecycle verification before publishing v1.0.2. |
+| #140 Hard v1.0.3 scale expansion | In Progress | Expand all six hard pools, add a required workflow spanning at least three sessions, and complete deterministic, confidentiality, browser, and lifecycle verification before publishing v1.0.3. |
 
 Each hard variant receives positive, negative, and presentation-invariant matrix coverage in `apps/hosted-sites/tests/unit/variant-matrix.test.ts`, which iterates every published suite. Per-session scoring stays deterministic; suite-level checks live solely in the scoring module (`evaluateSuiteConsistency`) and orchestrator aggregation. The easy and hard suites version and publish independently; a hard-suite change must not alter the easy manifest's content hash.
 
-Issue #140 is the umbrella work item for the unpublished `v1.0.2` revision. The
-revision remains `v1.0.2` while this scope is assembled; affected task and seed
+Issue #140 is the umbrella work item for the unpublished `v1.0.3` revision. The
+revision remains `v1.0.3` while this scope is assembled; affected task and seed
 versions still advance whenever their semantics or fixtures change. Delivery is
 split into four increments:
 

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -13,8 +13,8 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-hard-suite-v1",
-  suiteVersion: "v1.0.2",
-  timeLimitMinutesPerTestcase: 60,
+  suiteVersion: "v1.0.3",
+  timeLimitMinutesPerTestcase: 10,
   sessions: [
     {
       app: "shopping-lite",
@@ -38,7 +38,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 1,
       weight: 1,
       required: true,
-      timeLimitMinutes: 60,
+      timeLimitMinutes: 10,
       metadata: { questionVariants: forumQuestionVariants },
     },
     {
@@ -51,7 +51,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 2,
       weight: 1,
       required: true,
-      timeLimitMinutes: 60,
+      timeLimitMinutes: 10,
       metadata: { questionVariants: repoQuestionVariants },
     },
     {
@@ -64,7 +64,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 3,
       weight: 1,
       required: true,
-      timeLimitMinutes: 60,
+      timeLimitMinutes: 10,
       metadata: { questionVariants: wikiHardQuestionVariants },
     },
     {
@@ -77,7 +77,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 4,
       weight: 1,
       required: true,
-      timeLimitMinutes: 60,
+      timeLimitMinutes: 10,
       metadata: { questionVariants: wikiHardQuestionVariants },
     },
     {
@@ -90,7 +90,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 5,
       weight: 1,
       required: true,
-      timeLimitMinutes: 60,
+      timeLimitMinutes: 10,
       metadata: { questionVariants: notesQuestionVariants },
     },
     {
@@ -103,7 +103,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sequenceIndex: 6,
       weight: 1,
       required: true,
-      timeLimitMinutes: 60,
+      timeLimitMinutes: 10,
       metadata: { questionVariants: calendarQuestionVariants },
     },
   ],
@@ -144,7 +144,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.2";
+export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.3";
 
 export const hostedWebHardSuiteCase = {
   id: "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",

--- a/packages/test-cases/src/suites/hosted-web.ts
+++ b/packages/test-cases/src/suites/hosted-web.ts
@@ -11,8 +11,8 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-suite-v1",
-  suiteVersion: "v3.0.9",
-  timeLimitMinutesPerTestcase: 30,
+  suiteVersion: "v3.0.10",
+  timeLimitMinutesPerTestcase: 10,
   sessions: [
     { app: "shopping-lite", taskSlug: "shopping-constrained-checkout", title: "Shopping Checkout", taskVersion: "v2", seedVersion: "shopping-lite-v2", sequenceIndex: 0, weight: 1, required: true, metadata: { questionVariants: shoppingQuestionVariants } },
     { app: "forum-lite", taskSlug: "forum-battery-moderation", title: "Forum Moderation", startPath: "/forum", taskVersion: "v2", seedVersion: "forum-lite-v2", sequenceIndex: 1, weight: 1, required: true, metadata: { questionVariants: forumQuestionVariants } },
@@ -24,7 +24,7 @@ export const hostedWebSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.9";
+export const hostedWebSuiteRevision = "hosted-web-suite-v3.0.10";
 
 export const hostedWebSuiteCase = {
   id: "7e8a6df3-17c3-4ddb-9877-d0bd8a0f0005",

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -46,12 +46,10 @@ test("every hosted suite catalog release has a stable revision identity and cont
   }
 });
 
-test("every hosted suite declares a positive per-testcase time limit", () => {
+test("every hosted suite gives each testcase a ten-minute time limit", () => {
   for (const { case: benchmarkCase, metadata } of hostedWebSuites) {
-    assert.ok(
-      typeof metadata.timeLimitMinutesPerTestcase === "number" && metadata.timeLimitMinutesPerTestcase > 0,
-      `${benchmarkCase.slug} declares a positive timeLimitMinutesPerTestcase`,
-    );
+    assert.equal(metadata.timeLimitMinutesPerTestcase, 10, `${benchmarkCase.slug} default time limit`);
+    assert.ok(metadata.sessions.every((session) => session.timeLimitMinutes === undefined || session.timeLimitMinutes === 10));
   }
 });
 
@@ -87,9 +85,9 @@ test("hard consistency checks reference real sessions with source before target"
   }
 });
 
-test("hard v1.0.2 requires both wiki answers to be carried into distinct note fields", () => {
+test("hard v1.0.3 requires both wiki answers to be carried into distinct note fields", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
-  assert.equal(suite.suiteVersion, "v1.0.2");
+  assert.equal(suite.suiteVersion, "v1.0.3");
   assert.deepEqual(
     suite.consistencyChecks?.map((check) => ({
       sourceTaskSlug: check.sourceTaskSlug,
@@ -116,7 +114,7 @@ test("hard v1.0.2 requires both wiki answers to be carried into distinct note fi
   );
 });
 
-test("hard v1.0.2 includes combined-constraint shopping variants on the v2 seed", () => {
+test("hard v1.0.3 includes combined-constraint shopping variants on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const shopping = suite.sessions.find((session) => session.app === "shopping-lite");
   assert.ok(shopping);
@@ -127,7 +125,7 @@ test("hard v1.0.2 includes combined-constraint shopping variants on the v2 seed"
   assert.ok(variantIds.includes("airlite-field-kit"));
 });
 
-test("hard v1.0.2 includes ordered forum escalation on the v2 seed", () => {
+test("hard v1.0.3 includes ordered forum escalation on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const forum = suite.sessions.find((session) => session.app === "forum-lite");
   assert.ok(forum);
@@ -138,7 +136,7 @@ test("hard v1.0.2 includes ordered forum escalation on the v2 seed", () => {
   );
 });
 
-test("hard v1.0.2 includes conflict-aware repo workflow on the v2 seed", () => {
+test("hard v1.0.3 includes conflict-aware repo workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const repo = suite.sessions.find((session) => session.app === "repo-lite");
   assert.ok(repo);
@@ -147,7 +145,7 @@ test("hard v1.0.2 includes conflict-aware repo workflow on the v2 seed", () => {
   assert.ok(repo.metadata.questionVariants.some((variant) => variant.id === "api-v3-conflict-rollout"));
 });
 
-test("hard v1.0.2 includes three-article wiki verification on the v2 seed", () => {
+test("hard v1.0.3 includes three-article wiki verification on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const wikiSessions = suite.sessions.filter((session) => session.app === "wiki-lite");
   assert.ok(wikiSessions.every((session) => session.seedVersion === "wiki-lite-hard-v2"));
@@ -158,7 +156,7 @@ test("hard v1.0.2 includes three-article wiki verification on the v2 seed", () =
   );
 });
 
-test("hard v1.0.2 includes a multi-record notes workflow on the v2 seed", () => {
+test("hard v1.0.3 includes a multi-record notes workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const notes = suite.sessions.find((session) => session.app === "notes-lite");
   assert.ok(notes);
@@ -167,7 +165,7 @@ test("hard v1.0.2 includes a multi-record notes workflow on the v2 seed", () => 
   assert.ok(notes.metadata.questionVariants.some((variant) => variant.id === "release-rollout-note-set"));
 });
 
-test("hard v1.0.2 includes recurring resource calendar workflow on the v2 seed", () => {
+test("hard v1.0.3 includes recurring resource calendar workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const calendar = suite.sessions.find((session) => session.app === "calendar-lite");
   assert.ok(calendar);

--- a/supabase/migrations/20260710000029_set_pending_session_time_limit.sql
+++ b/supabase/migrations/20260710000029_set_pending_session_time_limit.sql
@@ -1,0 +1,11 @@
+-- Preserve the deadline already shown to an active agent, but ensure every
+-- session that has not started yet uses the new ten-minute contract.
+update public.hosted_web_sessions
+set metadata = jsonb_set(
+  coalesce(metadata, '{}'::jsonb),
+  '{timeLimitMinutesPerTestcase}',
+  '10'::jsonb,
+  true
+)
+where status = 'created'
+  and coalesce(metadata ->> 'timeLimitMinutesPerTestcase', '') is distinct from '10';

--- a/supabase/migrations/20260710000030_default_session_time_limit_ten_minutes.sql
+++ b/supabase/migrations/20260710000030_default_session_time_limit_ten_minutes.sql
@@ -1,0 +1,176 @@
+create or replace function public.complete_hosted_attempt_session(
+  p_attempt_id uuid,
+  p_session_id uuid,
+  p_completed_at timestamptz,
+  p_result jsonb,
+  p_attempt_update jsonb
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  attempt_row public.benchmark_attempts%rowtype;
+  session_row public.hosted_web_sessions%rowtype;
+  result_row public.hosted_web_results%rowtype;
+  score_row public.benchmark_attempt_scores%rowtype;
+  next_session_id uuid;
+  is_complete boolean := coalesce((p_attempt_update ->> 'complete')::boolean, false);
+  next_time_limit_minutes int;
+begin
+  select * into attempt_row
+  from public.benchmark_attempts attempts
+  where attempts.id = p_attempt_id
+  for update;
+
+  if not found then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'attempt_not_found');
+  end if;
+
+  select * into result_row
+  from public.hosted_web_results results
+  where results.session_id = p_session_id;
+
+  if found then
+    select * into score_row
+    from public.benchmark_attempt_scores scores
+    where scores.attempt_id = p_attempt_id;
+    return jsonb_build_object(
+      'transitioned', false,
+      'duplicate', true,
+      'conflict', null,
+      'result', jsonb_build_object(
+        'status', result_row.status,
+        'score', result_row.score,
+        'summary', result_row.summary,
+        'evaluators', result_row.evaluators
+      ),
+      'complete', score_row.id is not null,
+      'aggregate', case when score_row.id is null then null else jsonb_build_object(
+        'status', score_row.status,
+        'score', score_row.score,
+        'summary', score_row.summary,
+        'breakdown', score_row.breakdown
+      ) end
+    );
+  end if;
+
+  if attempt_row.status in ('completed', 'failed', 'cancelled', 'timeout') then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'attempt_terminal');
+  end if;
+
+  if nullif(attempt_row.metadata ->> 'activeSessionId', '') is distinct from p_session_id::text then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'session_not_active');
+  end if;
+
+  select * into session_row
+  from public.hosted_web_sessions sessions
+  where sessions.id = p_session_id
+    and sessions.attempt_id = p_attempt_id
+  for update;
+
+  if not found or session_row.status not in ('active', 'scoring') then
+    return jsonb_build_object('transitioned', false, 'duplicate', false, 'conflict', 'session_not_completable');
+  end if;
+
+  insert into public.hosted_web_results (
+    session_id, run_id, attempt_id, app, task_slug, weight,
+    status, score, summary, final_state, evaluators
+  ) values (
+    p_session_id,
+    attempt_row.run_id,
+    p_attempt_id,
+    session_row.app,
+    session_row.task_slug,
+    session_row.weight,
+    p_result ->> 'status',
+    (p_result ->> 'score')::numeric,
+    p_result ->> 'summary',
+    coalesce(p_result -> 'finalState', 'null'::jsonb),
+    coalesce(p_result -> 'evaluators', '[]'::jsonb)
+  )
+  returning * into result_row;
+
+  update public.hosted_web_sessions
+  set
+    status = case when result_row.status = 'passed' then 'completed' else 'failed' end,
+    completed_at = p_completed_at
+  where id = p_session_id;
+
+  if is_complete then
+    insert into public.benchmark_attempt_scores (
+      run_id, attempt_id, status, score, summary, breakdown
+    ) values (
+      attempt_row.run_id,
+      p_attempt_id,
+      p_attempt_update -> 'aggregate' ->> 'status',
+      (p_attempt_update -> 'aggregate' ->> 'score')::numeric,
+      p_attempt_update -> 'aggregate' ->> 'summary',
+      p_attempt_update -> 'aggregate' -> 'breakdown'
+    )
+    returning * into score_row;
+
+    update public.benchmark_attempts
+    set
+      status = p_attempt_update ->> 'status',
+      aggregate_score = score_row.score,
+      metadata = p_attempt_update -> 'metadata',
+      scoring_summary = p_attempt_update -> 'scoringSummary',
+      completed_at = p_completed_at
+    where id = p_attempt_id;
+  else
+    next_session_id := nullif(p_attempt_update ->> 'nextSessionId', '')::uuid;
+    next_time_limit_minutes := coalesce((
+      select (metadata ->> 'timeLimitMinutesPerTestcase')::int
+      from public.hosted_web_sessions
+      where id = next_session_id
+        and attempt_id = p_attempt_id
+    ), 10);
+
+    update public.hosted_web_sessions
+    set
+      status = 'active',
+      activated_at = coalesce(activated_at, p_completed_at),
+      expires_at = p_completed_at + (next_time_limit_minutes || ' minutes')::interval
+    where id = next_session_id
+      and attempt_id = p_attempt_id
+      and status = 'created';
+
+    if not found then
+      raise exception 'Next session % cannot be promoted for attempt %', next_session_id, p_attempt_id;
+    end if;
+
+    update public.benchmark_attempts
+    set
+      status = 'running',
+      metadata = p_attempt_update -> 'metadata',
+      scoring_summary = p_attempt_update -> 'scoringSummary'
+    where id = p_attempt_id;
+  end if;
+
+  return jsonb_build_object(
+    'transitioned', true,
+    'duplicate', false,
+    'conflict', null,
+    'result', jsonb_build_object(
+      'status', result_row.status,
+      'score', result_row.score,
+      'summary', result_row.summary,
+      'evaluators', result_row.evaluators
+    ),
+    'complete', is_complete,
+    'aggregate', case when is_complete then jsonb_build_object(
+      'status', score_row.status,
+      'score', score_row.score,
+      'summary', score_row.summary,
+      'breakdown', score_row.breakdown
+    ) else null end
+  );
+end;
+$$;
+
+revoke all on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) from public;
+revoke all on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) from anon;
+revoke all on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) from authenticated;
+grant execute on function public.complete_hosted_attempt_session(uuid, uuid, timestamptz, jsonb, jsonb) to service_role;

--- a/supabase/migrations/20260710000031_finish_scored_partial_runs.sql
+++ b/supabase/migrations/20260710000031_finish_scored_partial_runs.sql
@@ -1,0 +1,42 @@
+-- Older lifecycle code treated any non-passing aggregate as a failed run. A
+-- durable aggregate with evaluator status `failed` is a finished benchmark
+-- with deductions, not an execution failure. Do not rewrite aggregate errors.
+update public.benchmark_attempts
+set status = 'completed'
+where status = 'failed'
+  and aggregate_score is not null
+  and scoring_summary ->> 'status' = 'failed';
+
+update public.benchmark_runs runs
+set
+  status = 'completed',
+  error_message = null
+where runs.status = 'failed'
+  and exists (
+    select 1
+    from public.benchmark_attempts attempts
+    where attempts.run_id = runs.id
+      and attempts.status = 'completed'
+      and attempts.aggregate_score is not null
+      and attempts.scoring_summary ->> 'status' = 'failed'
+  );
+
+-- A pending outbox delivery must not restore the old failed lifecycle status
+-- after its attempt and run have been normalized.
+update public.hosted_callback_outbox outbox
+set
+  payload = jsonb_set(
+    jsonb_set(outbox.payload, '{status}', '"completed"'::jsonb, true),
+    '{errorMessage}', 'null'::jsonb,
+    true
+  ),
+  updated_at = now()
+where outbox.status in ('pending', 'delivering')
+  and exists (
+    select 1
+    from public.benchmark_attempts attempts
+    where attempts.id = outbox.attempt_id
+      and attempts.status = 'completed'
+      and attempts.aggregate_score is not null
+      and attempts.scoring_summary ->> 'status' = 'failed'
+  );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -11,11 +11,11 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-suite-v3.0.9',
+  'hosted-web-suite-v3.0.10',
   $catalog${
   "suiteSlug": "hosted-web-suite-v1",
-  "suiteVersion": "v3.0.9",
-  "timeLimitMinutesPerTestcase": 30,
+  "suiteVersion": "v3.0.10",
+  "timeLimitMinutesPerTestcase": 10,
   "sessions": [
     {
       "app": "shopping-lite",
@@ -593,7 +593,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '080899876b1c3b548a38bf4b94215ffc8c201c4fc28fcf3860e9f797c5a67b32'
+  'ba0f288878e756fd7f19fdfa589b3043a8ea66db734e947ec41bc9804f45b7fb'
 );
 
 select public.publish_benchmark_case_catalog(
@@ -608,11 +608,11 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-hard-suite-v1.0.2',
+  'hosted-web-hard-suite-v1.0.3',
   $catalog${
   "suiteSlug": "hosted-web-hard-suite-v1",
-  "suiteVersion": "v1.0.2",
-  "timeLimitMinutesPerTestcase": 60,
+  "suiteVersion": "v1.0.3",
+  "timeLimitMinutesPerTestcase": 10,
   "sessions": [
     {
       "app": "shopping-lite",
@@ -1423,7 +1423,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '2bdd486a2d9421ae0b1980d99cdd8ea768dd7127ebc3aaf3a2a9bd70cd37cdaa'
+  '423b56db70db3489bdbadc11d27094486f2293b400b79acaab1e55d988305ba0'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
## Summary
- treat completed partial-score runs as Finished while reserving Failed for lifecycle and scoring errors
- set all hosted task limits to 10 minutes and add backward-compatible data migrations
- update leaderboard, results, tests, catalog, and state documentation

## Verification
- `pnpm --filter hosted-orchestrator test`
- `pnpm --filter @agentbench/test-cases check-catalog`
- `pnpm --filter web test`
- `pnpm --filter web build`
- visual verification: leaderboard desktop and 390px narrow viewport
- `pnpm verify:ci` reached Lifecycle Postgres integration; local Docker daemon was unavailable