### PR TITLE
fix(web): sync live viewer with active session

### DIFF
--- a/apps/web/lib/hosted-viewer.ts
+++ b/apps/web/lib/hosted-viewer.ts
@@ -72,6 +72,7 @@ export function deriveActiveHostedViewerUrl(events: HostedViewerEvent[], activeS
   }
 
   const sessions = new Map<string, { url: string; sequenceIndex: number }>();
+  let activeUrl: string | null = null;
 
   for (const event of events) {
     const sessionId = sessionIdFromEvent(event);
@@ -91,23 +92,33 @@ export function deriveActiveHostedViewerUrl(events: HostedViewerEvent[], activeS
     if (event.type === "hosted.page.load" && typeof event.payload.url === "string") {
       const viewerSession = sessions.get(sessionId);
       if (!viewerSession) continue;
-      return applyNavigation(viewerSession.url, event.payload.url);
+      activeUrl = applyNavigation(viewerSession.url, event.payload.url);
     }
   }
 
-  return sessions.get(activeSessionId)?.url ?? deriveHostedViewerUrl(events);
+  return activeUrl ?? sessions.get(activeSessionId)?.url ?? deriveHostedViewerUrl(events);
 }
 
 export function deriveHostedViewerRevision(events: HostedViewerEvent[]) {
   return events.filter(
     (event) =>
       event.type === "hosted.page.load" ||
+      event.type === "hosted.session.progress" ||
       event.type === "hosted.task_signal" ||
       event.type === "hosted.score",
   ).length;
 }
 
 export function deriveActiveHostedSessionId(events: HostedViewerEvent[]) {
+  // The persisted progress projection is emitted before the score event and
+  // remains correct when a scorer event is delayed or absent from a replay.
+  const latestProgress = [...events]
+    .reverse()
+    .find((event) => event.type === "hosted.session.progress");
+  if (typeof latestProgress?.payload.activeSessionId === "string") {
+    return latestProgress.payload.activeSessionId;
+  }
+
   const sessions = new Map<string, { sequenceIndex: number }>();
 
   for (const event of events) {

--- a/apps/web/tests/unit/hosted-viewer.test.ts
+++ b/apps/web/tests/unit/hosted-viewer.test.ts
@@ -91,6 +91,32 @@ test("hosted viewer follows the first unscored session instead of stale page loa
   assert.equal(viewerUrl, "https://hosted.example/notes?session=view-token-2");
 });
 
+test("hosted viewer follows the latest page load for the active session", () => {
+  const viewerUrl = deriveActiveHostedViewerUrl(
+    [
+      {
+        type: "hosted.session.created",
+        payload: {
+          sessionId: "session-2",
+          sequenceIndex: 1,
+          viewerStartUrl: "https://hosted.example/repository?session=view-token-2",
+        },
+      },
+      {
+        type: "hosted.page.load",
+        payload: { sessionId: "session-2", url: "/repository/cart" },
+      },
+      {
+        type: "hosted.page.load",
+        payload: { sessionId: "session-2", url: "/repository/merge-request/42" },
+      },
+    ],
+    "session-2",
+  );
+
+  assert.equal(viewerUrl, "https://hosted.example/repository/merge-request/42?session=view-token-2");
+});
+
 test("derive active hosted session id picks the first created session without a score", () => {
   const activeSessionId = deriveActiveHostedSessionId([
     {
@@ -108,6 +134,25 @@ test("derive active hosted session id picks the first created session without a 
     {
       type: "hosted.score",
       payload: { sessionId: "session-1", score: 1 },
+    },
+  ]);
+
+  assert.equal(activeSessionId, "session-2");
+});
+
+test("derive active hosted session id prefers persisted session progress", () => {
+  const activeSessionId = deriveActiveHostedSessionId([
+    {
+      type: "hosted.session.created",
+      payload: { sessionId: "session-1", sequenceIndex: 0 },
+    },
+    {
+      type: "hosted.session.created",
+      payload: { sessionId: "session-2", sequenceIndex: 1 },
+    },
+    {
+      type: "hosted.session.progress",
+      payload: { activeSessionId: "session-2", sessions: [] },
     },
   ]);
 
@@ -134,9 +179,10 @@ test("hosted viewer revision advances only for state-bearing events", () => {
     deriveHostedViewerRevision([
       { type: "hosted.action", payload: { type: "click" } },
       { type: "hosted.page.load", payload: {} },
+      { type: "hosted.session.progress", payload: {} },
       { type: "hosted.task_signal", payload: {} },
       { type: "hosted.score", payload: {} },
     ]),
-    3,
+    4,
   );
 });

--- a/docs/frontend-state-machine.md
+++ b/docs/frontend-state-machine.md
@@ -41,8 +41,9 @@ stateDiagram-v2
 ## Data Priority
 
 1. Terminal status and final score from the run API.
-2. `hosted.score` events for the current attempt and their session weights.
-3. Generic `score.updated` events.
-4. Show `--` when no valid score exists; never present one evaluator score as the suite score.
+2. `hosted.session.progress.activeSessionId` selects the iframe's current hosted session; use its matching `hosted.page.load` events for the latest route.
+3. `hosted.score` events for the current attempt and their session weights.
+4. Generic `score.updated` events.
+5. Show `--` when no valid score exists; never present one evaluator score as the suite score.
 
 All hosted scores are isolated by `attemptId`. Events from old or superseded attempts must not affect the current aggregate.


### PR DESCRIPTION
## Summary
- select the iframe session from the persisted hosted session-progress projection
- follow the latest page load in the active session instead of retaining the first route
- document the viewer data priority and cover both regressions

## Verification
- `pnpm --filter web test`
- `pnpm --filter web build`
- browser: embedded viewer loading at desktop and 390px; no console errors
- local `pnpm verify:ci` reached Lifecycle Postgres integration; Docker daemon unavailable