### PR TITLE
fix(hosted): publish active viewer session

### DIFF
--- a/apps/hosted-orchestrator/src/server.ts
+++ b/apps/hosted-orchestrator/src/server.ts
@@ -486,6 +486,7 @@ function hostedSessionProgressPayload(params: {
   attemptId: string;
   activeSessionId: string | null;
   activeSequenceIndex: number | null;
+  viewerStartUrl: string | null;
   sessions: Array<{
     sessionId: string;
     app: string;
@@ -502,6 +503,7 @@ function hostedSessionProgressPayload(params: {
     attemptId: params.attemptId,
     activeSessionId: params.activeSessionId,
     activeSequenceIndex: params.activeSequenceIndex,
+    viewerStartUrl: params.viewerStartUrl,
     progress: {
       total: sessions.length,
       completed: sessions.filter((session) => session.status === "completed").length,
@@ -515,6 +517,7 @@ async function forwardSessionProgressForAttempt(runId: string | null, attemptId:
     return;
   }
   const readModel = await loadAttemptReadModel(attemptId);
+  const activeSession = readModel.sessions.find((session) => session.id === readModel.activeSessionId) ?? null;
   await forwardRunEventForRun(
     runId,
     "hosted.session.progress",
@@ -522,6 +525,10 @@ async function forwardSessionProgressForAttempt(runId: string | null, attemptId:
       attemptId,
       activeSessionId: readModel.activeSessionId,
       activeSequenceIndex: readModel.activeSequenceIndex,
+      viewerStartUrl:
+        activeSession?.startPath && activeSession.expiresAt
+          ? buildViewerStartUrl(activeSession.id, activeSession.startPath, activeSession.expiresAt)
+          : null,
       sessions: readModel.sessions.map((session) => ({
         sessionId: session.id,
         app: session.app,
@@ -974,6 +981,7 @@ async function initializeAttempt(params: InitializeAttemptParams) {
       attemptId: attemptRow.id,
       activeSessionId: firstSession?.sessionId ?? null,
       activeSequenceIndex: firstSession?.sequenceIndex ?? null,
+      viewerStartUrl: firstSession?.viewerStartUrl ?? null,
       sessions: sessions.map((session) => ({
         sessionId: session.sessionId,
         app: session.app,

--- a/apps/web/lib/hosted-viewer.ts
+++ b/apps/web/lib/hosted-viewer.ts
@@ -75,6 +75,22 @@ export function deriveActiveHostedViewerUrl(events: HostedViewerEvent[], activeS
   let activeUrl: string | null = null;
 
   for (const event of events) {
+    if (
+      event.type === "hosted.session.progress" &&
+      event.payload.activeSessionId === activeSessionId &&
+      typeof event.payload.viewerStartUrl === "string"
+    ) {
+      sessions.set(activeSessionId, {
+        url: event.payload.viewerStartUrl,
+        sequenceIndex:
+          typeof event.payload.activeSequenceIndex === "number" && Number.isFinite(event.payload.activeSequenceIndex)
+            ? event.payload.activeSequenceIndex
+            : sessions.size,
+      });
+      activeUrl = event.payload.viewerStartUrl;
+      continue;
+    }
+
     const sessionId = sessionIdFromEvent(event);
     if (sessionId !== activeSessionId) continue;
 

--- a/apps/web/tests/unit/hosted-viewer.test.ts
+++ b/apps/web/tests/unit/hosted-viewer.test.ts
@@ -117,6 +117,36 @@ test("hosted viewer follows the latest page load for the active session", () => 
   assert.equal(viewerUrl, "https://hosted.example/repository/merge-request/42?session=view-token-2");
 });
 
+test("hosted viewer switches to the active session URL from progress", () => {
+  const viewerUrl = deriveActiveHostedViewerUrl(
+    [
+      {
+        type: "hosted.session.created",
+        payload: {
+          sessionId: "session-1",
+          sequenceIndex: 0,
+          viewerStartUrl: "https://hosted.example/shopping?session=view-token-1",
+        },
+      },
+      {
+        type: "hosted.session.created",
+        payload: { sessionId: "session-2", sequenceIndex: 1 },
+      },
+      {
+        type: "hosted.session.progress",
+        payload: {
+          activeSessionId: "session-2",
+          activeSequenceIndex: 1,
+          viewerStartUrl: "https://hosted.example/forum?session=view-token-2",
+        },
+      },
+    ],
+    "session-2",
+  );
+
+  assert.equal(viewerUrl, "https://hosted.example/forum?session=view-token-2");
+});
+
 test("derive active hosted session id picks the first created session without a score", () => {
   const activeSessionId = deriveActiveHostedSessionId([
     {

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -51,7 +51,7 @@ flowchart TD
   Cache --> Handle
 ```
 
-Nginx may send each request to any hosted-sites replica. Redis is the first shared lookup for write-session tokens; the local Map is a non-authoritative hot copy. Hosted-sites has no database credential. Its authenticated recovery request is resolved by the orchestrator from the latest successfully persisted `metadata.appState` snapshot, which may lag state that had existed only in Redis.
+Nginx may send each request to any hosted-sites replica. Redis is the first shared lookup for write-session tokens; the local Map is a non-authoritative hot copy. Hosted-sites has no database credential. Its authenticated recovery request is resolved by the orchestrator from the latest successfully persisted `metadata.appState` snapshot, which may lag state that had existed only in Redis. Each durable `hosted.session.progress` event includes a short-lived viewer URL for its active session only, allowing the Web iframe to advance without exposing future write-session tokens.
 
 The current local-Map fallback can serve stale state after a Redis miss, and Redis session writes are not revision-checked. These are known horizontal-scaling gaps, not guarantees supplied by the diagram.
 


### PR DESCRIPTION
## Summary
- publish the current active session's short-lived read-only viewer URL with durable hosted progress
- switch the live iframe to that URL when a session advances
- cover session-advance viewer selection and document the viewer-token boundary

## Verification
- `pnpm --filter hosted-orchestrator test`
- `pnpm --filter web test`
- `pnpm --filter hosted-orchestrator build`
- `pnpm --filter web build`
- public test run reproduced the missing next-session viewer URL before this fix
- local `pnpm verify:ci` reached Lifecycle Postgres integration; Docker daemon unavailable