### PR TITLE
fix(deploy): include protocol in orchestrator image

### DIFF
--- a/apps/hosted-orchestrator/package.json
+++ b/apps/hosted-orchestrator/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/apps/hosted-orchestrator/src/server.js"
   },
   "dependencies": {
+    "@agentbench/protocol": "workspace:*",
     "@agentbench/scoring": "workspace:*",
     "@agentbench/shared": "workspace:*",
     "@agentbench/test-cases": "workspace:*",

--- a/infra/docker/hosted-orchestrator.Dockerfile
+++ b/infra/docker/hosted-orchestrator.Dockerfile
@@ -7,6 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.js
 COPY scripts ./scripts
 COPY apps/hosted-orchestrator ./apps/hosted-orchestrator
 COPY apps/hosted-sites ./apps/hosted-sites
+COPY packages/protocol ./packages/protocol
 COPY packages/scoring ./packages/scoring
 COPY packages/shared ./packages/shared
 COPY packages/test-cases ./packages/test-cases
@@ -24,6 +25,7 @@ RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.json ./
 COPY scripts ./scripts
 COPY apps/hosted-orchestrator ./apps/hosted-orchestrator
+COPY packages/protocol ./packages/protocol
 COPY packages/scoring ./packages/scoring
 COPY packages/shared ./packages/shared
 COPY packages/test-cases ./packages/test-cases

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/hosted-orchestrator:
     dependencies:
+      '@agentbench/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
       '@agentbench/scoring':
         specifier: workspace:*
         version: link:../../packages/scoring


### PR DESCRIPTION
## Summary
- declare the protocol workspace dependency used by hosted-orchestrator
- copy protocol into both hosted-orchestrator image stages
- unblock hosted development deployment for session progress and viewer updates

## Verification
- `pnpm --filter hosted-orchestrator test`
- `pnpm --filter hosted-orchestrator build`
- Docker build deferred to GitHub Actions because local Docker daemon is unavailable