### PR TITLE
fix(web): refresh progress panel after metadata submission

### DIFF
--- a/apps/web/components/landing/RunConnectionCard.tsx
+++ b/apps/web/components/landing/RunConnectionCard.tsx
@@ -15,6 +15,7 @@ import {
   applyHostedSessionProgress,
   deriveHostedSessionProgressFromEvents,
 } from "@/lib/hosted-progress";
+import { shouldRefreshHostedConnection } from "@/lib/run-connection-refresh";
 
 type RunConnectPayload = {
   runId: string;
@@ -352,6 +353,14 @@ export function RunConnectionCard() {
     if (progressSessions.length === 0) return;
     setPayload((current) => current ? applyHostedSessionProgress(current, progressSessions) : current);
   }, [progressSessions]);
+
+  useEffect(() => {
+    if (!payload || !shouldRefreshHostedConnection(payload.metadataRequired, runEvents)) {
+      return;
+    }
+
+    setRetryNonce((current) => current + 1);
+  }, [payload, runEvents]);
 
   if (!runId || executionMode !== "external-agent") {
     return null;

--- a/apps/web/lib/run-connection-refresh.ts
+++ b/apps/web/lib/run-connection-refresh.ts
@@ -1,0 +1,14 @@
+export type RunConnectionRefreshEvent = {
+  type: string;
+};
+
+export function shouldRefreshHostedConnection(
+  metadataRequired: boolean,
+  events: RunConnectionRefreshEvent[],
+) {
+  return metadataRequired && events.some((event) =>
+    event.type === "agent.connected" ||
+    event.type === "hosted.session.created" ||
+    event.type === "hosted.session.progress",
+  );
+}

--- a/apps/web/tests/unit/run-connection-refresh.test.ts
+++ b/apps/web/tests/unit/run-connection-refresh.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldRefreshHostedConnection } from "../../lib/run-connection-refresh";
+
+test("refreshes a metadata-gated connection after hosted allocation begins", () => {
+  assert.equal(shouldRefreshHostedConnection(true, [{ type: "agent.connected" }]), true);
+  assert.equal(shouldRefreshHostedConnection(true, [{ type: "hosted.session.created" }]), true);
+  assert.equal(shouldRefreshHostedConnection(true, [{ type: "hosted.session.progress" }]), true);
+});
+
+test("does not reload an already resolved connection for unrelated events", () => {
+  assert.equal(shouldRefreshHostedConnection(true, [{ type: "hosted.page.load" }]), false);
+  assert.equal(shouldRefreshHostedConnection(false, [{ type: "agent.connected" }]), false);
+});


### PR DESCRIPTION
## Summary
- reload the landing connection payload after metadata registration starts hosted allocation
- reveal the progress panel without a manual page refresh

## Verification
- `pnpm --filter web test`
- `pnpm --filter web build`
- Browser: `/#playground` at desktop and 390px; no console errors
- `pnpm verify:ci` reached Lifecycle Postgres integration; it could not run because the local Docker daemon is unavailable.