### PR TITLE
fix(results): expose suite consistency breakdown

### DIFF
--- a/apps/web/app/results/[runId]/page.tsx
+++ b/apps/web/app/results/[runId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getPublicBenchmarkResult } from "@/lib/db";
+import { summarizePublicConsistencyChecks } from "@/lib/public-result-consistency";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +15,8 @@ export default async function PublicResultPage({ params }: { params: Promise<{ r
   const result = await getPublicBenchmarkResult(runId);
   if (!result) notFound();
 
-  const { run, benchmark, suite, tasks } = result;
+  const { run, benchmark, suite, tasks, consistencyChecks } = result;
+  const consistencySummary = summarizePublicConsistencyChecks(consistencyChecks);
   return (
     <main className="min-h-screen bg-[#111111] px-6 py-12 text-[#f7f2e7] md:px-10 md:py-20">
       <div className="mx-auto max-w-5xl">
@@ -79,6 +81,41 @@ export default async function PublicResultPage({ params }: { params: Promise<{ r
             ))}
           </div>
         </section>
+
+        {consistencySummary.total > 0 ? (
+          <section className="mt-12">
+            <div className="flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <div className="text-xs uppercase tracking-[0.2em] text-white/40">Suite consistency</div>
+                <h2 className="mt-2 text-2xl font-medium text-white">Cross-app checks</h2>
+              </div>
+              <div className="text-sm text-white/45">
+                {consistencySummary.requiredPassed}/{consistencySummary.requiredTotal} required checks passed
+              </div>
+            </div>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/55">
+              These checks verify that values the agent submitted in one task were carried into the required later task.
+            </p>
+            <div className="mt-6 divide-y divide-white/10 border-y border-white/10">
+              {consistencyChecks.map((check) => (
+                <article key={`${check.sourceTaskSlug}:${check.targetTaskSlug}:${check.name}`} className="grid gap-3 py-6 md:grid-cols-[48px_1fr_auto] md:items-center">
+                  <div className="text-xl text-white/30">C{String(check.sequenceIndex).padStart(2, "0")}</div>
+                  <div>
+                    <div className="text-lg font-medium text-white">{check.name}</div>
+                    <div className="mt-1 text-sm text-white/45">
+                      {check.status === "passed"
+                        ? "Required value was carried across tasks."
+                        : check.failureReason ?? "The required cross-app value did not match."}
+                    </div>
+                  </div>
+                  <div className={check.status === "passed" ? "text-2xl text-[#d7ff00]" : "text-2xl text-[#ff8d7a]"}>
+                    {Math.round(check.score * 100)}%
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : null}
       </div>
     </main>
   );

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -14,6 +14,7 @@ import { createSupabaseAdminClient } from "./supabase/admin";
 import { buildInitialRunMetadata, buildRunMetadataUpdate, parseBrowserEnvironment } from "./run-metadata";
 import { completableRunStatuses, terminalRunStatuses } from "./run-lifecycle";
 import { hostedWebCatalogReleases } from "@agentbench/test-cases/release";
+import type { PublicConsistencyCheck } from "./public-result-consistency";
 
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
 const DEVELOPMENT_GUEST_RUN_LIMIT = 10;
@@ -675,6 +676,7 @@ export type PublicBenchmarkResult = {
     score: number;
     summary: string;
   }>;
+  consistencyChecks: PublicConsistencyCheck[];
 };
 
 export async function getPublicBenchmarkResult(runId: string): Promise<PublicBenchmarkResult | null> {
@@ -691,13 +693,23 @@ export async function getPublicBenchmarkResult(runId: string): Promise<PublicBen
   if (!row) return null;
 
   const run = mapRunRow(row);
-  const [{ data: benchmark, error: benchmarkError }, { data: summary, error: summaryError }, { data: results, error: resultsError }] = await Promise.all([
+  const [
+    { data: benchmark, error: benchmarkError },
+    { data: summary, error: summaryError },
+    { data: results, error: resultsError },
+    { data: consistencyChecks, error: consistencyError },
+  ] = await Promise.all([
     supabase.from("benchmark_cases").select("title, description").eq("id", run.caseId).maybeSingle(),
     supabase.from("public_hosted_run_summaries").select("suite_slug, suite_version").eq("run_id", runId).maybeSingle(),
     supabase.from("public_hosted_run_tasks").select("app, task_slug, status, score, summary, created_at").eq("run_id", runId).order("created_at", { ascending: true }),
+    supabase
+      .from("public_hosted_run_consistency_checks")
+      .select("sequence_index, name, source_task_slug, target_task_slug, status, score, required, failure_reason")
+      .eq("run_id", runId)
+      .order("sequence_index", { ascending: true }),
   ]);
-  if (benchmarkError || summaryError || resultsError) {
-    throw benchmarkError ?? summaryError ?? resultsError;
+  if (benchmarkError || summaryError || resultsError || consistencyError) {
+    throw benchmarkError ?? summaryError ?? resultsError ?? consistencyError;
   }
   if (!benchmark) return null;
 
@@ -713,6 +725,16 @@ export async function getPublicBenchmarkResult(runId: string): Promise<PublicBen
       status: result.status!,
       score: result.score!,
       summary: result.summary!,
+    })),
+    consistencyChecks: (consistencyChecks ?? []).map((check) => ({
+      sequenceIndex: check.sequence_index ?? 0,
+      name: check.name ?? "Cross-app consistency check",
+      sourceTaskSlug: check.source_task_slug ?? "source task",
+      targetTaskSlug: check.target_task_slug ?? "target task",
+      status: check.status === "passed" ? "passed" : "failed",
+      score: check.score ?? 0,
+      required: check.required !== false,
+      failureReason: check.failure_reason,
     })),
   };
 }

--- a/apps/web/lib/public-result-consistency.ts
+++ b/apps/web/lib/public-result-consistency.ts
@@ -1,0 +1,19 @@
+export type PublicConsistencyCheck = {
+  sequenceIndex: number;
+  name: string;
+  sourceTaskSlug: string;
+  targetTaskSlug: string;
+  status: "passed" | "failed";
+  score: number;
+  required: boolean;
+  failureReason: string | null;
+};
+
+export function summarizePublicConsistencyChecks(checks: PublicConsistencyCheck[]) {
+  const required = checks.filter((check) => check.required);
+  return {
+    total: checks.length,
+    requiredTotal: required.length,
+    requiredPassed: required.filter((check) => check.status === "passed").length,
+  };
+}

--- a/apps/web/tests/unit/public-result-consistency.test.ts
+++ b/apps/web/tests/unit/public-result-consistency.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { summarizePublicConsistencyChecks } from "../../lib/public-result-consistency.js";
+
+test("summarizes required consistency checks separately from session tasks", () => {
+  const summary = summarizePublicConsistencyChecks([
+    {
+      sequenceIndex: 1,
+      name: "Wiki answer carried into note",
+      sourceTaskSlug: "wiki-hard",
+      targetTaskSlug: "notes-hard",
+      status: "passed",
+      score: 1,
+      required: true,
+      failureReason: null,
+    },
+    {
+      sequenceIndex: 2,
+      name: "Note title carried into calendar",
+      sourceTaskSlug: "notes-hard",
+      targetTaskSlug: "calendar-hard",
+      status: "failed",
+      score: 0,
+      required: true,
+      failureReason: "The required value was not carried consistently between tasks.",
+    },
+    {
+      sequenceIndex: 3,
+      name: "Optional display check",
+      sourceTaskSlug: "notes-hard",
+      targetTaskSlug: "calendar-hard",
+      status: "failed",
+      score: 0,
+      required: false,
+      failureReason: "The required value was not carried consistently between tasks.",
+    },
+  ]);
+
+  assert.deepEqual(summary, { total: 3, requiredTotal: 2, requiredPassed: 1 });
+});
+
+test("returns an empty summary for suites without cross-app checks", () => {
+  assert.deepEqual(summarizePublicConsistencyChecks([]), {
+    total: 0,
+    requiredTotal: 0,
+    requiredPassed: 0,
+  });
+});

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,6 +82,14 @@ rate-limited, and transient-error responses are never shared-cacheable.
 
 The connection lasts at most 25 seconds and clients reconnect using `retry: 2000`.
 
+### Public Result Pages
+
+`/results/:runId` renders terminal public hosted runs from filtered read-model
+views. In addition to per-task results, hard suites may expose a display-safe
+cross-app consistency breakdown. It contains check labels, task slugs, status,
+score, required flag, and generalized failure reasons only; evaluator evidence,
+generated task configuration, final state, and matched values remain private.
+
 ## Hosted-Sites API
 
 | Method | Path | Purpose |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -90,6 +90,13 @@ Per-session evaluation result:
 Aggregate suite result with score, status, summary, and a JSON breakdown of all required and optional sessions.
 Each attempt has at most one aggregate score. A concurrent writer recovers and uses the existing row.
 
+Public result pages read terminal hosted score details through filtered views, not
+the lifecycle tables. `public_hosted_run_consistency_checks` exposes only the
+safe display projection of cross-app checks: name, source/target task slugs,
+status, score, required flag, and a generalized failure reason. It deliberately
+excludes final state, generated configuration, evaluator evidence, and matched
+values.
+
 ### `hosted_web_access_logs`
 
 Operational audit records for session access and expiry. These records have a retention sweep and should not be treated as permanent benchmark evidence.

--- a/packages/shared/src/database.types.ts
+++ b/packages/shared/src/database.types.ts
@@ -707,6 +707,20 @@ export type Database = {
         };
         Relationships: [];
       };
+      public_hosted_run_consistency_checks: {
+        Row: {
+          failure_reason: string | null;
+          name: string | null;
+          required: boolean | null;
+          run_id: string | null;
+          score: number | null;
+          sequence_index: number | null;
+          source_task_slug: string | null;
+          status: "passed" | "failed" | null;
+          target_task_slug: string | null;
+        };
+        Relationships: [];
+      };
       public_hosted_run_tasks: {
         Row: {
           app: string | null;

--- a/scripts/test-hosted-read-models-postgres.sh
+++ b/scripts/test-hosted-read-models-postgres.sh
@@ -26,6 +26,7 @@ create table benchmark_runs (
   completed_at timestamptz
 );
 create table benchmark_attempts (id uuid primary key, run_id uuid not null, suite_slug text not null, suite_version text not null, status text not null);
+create table benchmark_attempt_scores (attempt_id uuid primary key, breakdown jsonb not null);
 create table hosted_web_sessions (run_id uuid not null, sequence_index int not null, first_seen_user_agent text);
 create table hosted_web_results (run_id uuid not null, app text, task_slug text, status text, score numeric, summary text, created_at timestamptz not null);
 
@@ -38,6 +39,10 @@ insert into benchmark_attempts values
   ('30000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001', 'suite', 'v2', 'completed'),
   ('30000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000002', 'suite', 'v2', 'completed'),
   ('30000000-0000-0000-0000-000000000003', '20000000-0000-0000-0000-000000000003', 'suite', 'v2', 'failed');
+insert into benchmark_attempt_scores values
+  ('30000000-0000-0000-0000-000000000001', '{"consistency":[{"name":"Wiki answer carried into note","sourceTaskSlug":"wiki-release-answer","targetTaskSlug":"notes-followup","status":"failed","score":0,"required":true,"errorMessage":"Output from wiki-release-answer was not carried."}],"evidence":"private"}'),
+  ('30000000-0000-0000-0000-000000000002', '{"consistency":[{"name":"Private check","status":"passed","score":1,"required":true}]}'),
+  ('30000000-0000-0000-0000-000000000003', '{"consistency":[]}');
 insert into hosted_web_sessions values
   ('20000000-0000-0000-0000-000000000001', 0, 'public-agent'),
   ('20000000-0000-0000-0000-000000000002', 0, 'private-agent'),
@@ -50,9 +55,13 @@ SQL
 
 "${PSQL[@]}" -v ON_ERROR_STOP=1 < "${ROOT_DIR}/supabase/migrations/20260622000022_hosted_public_read_models.sql" >/dev/null
 "${PSQL[@]}" -v ON_ERROR_STOP=1 < "${ROOT_DIR}/supabase/migrations/20260624000025_publish_failed_benchmark_results.sql" >/dev/null
+"${PSQL[@]}" -v ON_ERROR_STOP=1 < "${ROOT_DIR}/supabase/migrations/20260713000032_public_consistency_read_model.sql" >/dev/null
 
 [[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_summaries')" == "2" ]]
 [[ "$(${PSQL[@]} -Atqc "set role anon; select observed_user_agent from public_hosted_run_summaries where run_id = '20000000-0000-0000-0000-000000000003'")" == "failed-agent" ]]
 [[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_tasks')" == "2" ]]
+[[ "$(${PSQL[@]} -Atqc 'set role anon; select count(*) from public_hosted_run_consistency_checks')" == "1" ]]
+[[ "$(${PSQL[@]} -Atqc "set role anon; select failure_reason from public_hosted_run_consistency_checks where run_id = '20000000-0000-0000-0000-000000000001'")" == "The required value was not carried consistently between tasks." ]]
+[[ "$(${PSQL[@]} -Atqc "select count(*) from information_schema.columns where table_name = 'public_hosted_run_consistency_checks' and column_name in ('evidence', 'breakdown', 'error_message')")" == "0" ]]
 
 echo "hosted public read-model Postgres tests passed"

--- a/supabase/migrations/20260713000032_public_consistency_read_model.sql
+++ b/supabase/migrations/20260713000032_public_consistency_read_model.sql
@@ -4,18 +4,18 @@ as
 select
   runs.id as run_id,
   consistency.position as sequence_index,
-  consistency.check ->> 'name' as name,
-  consistency.check ->> 'sourceTaskSlug' as source_task_slug,
-  consistency.check ->> 'targetTaskSlug' as target_task_slug,
+  consistency.item ->> 'name' as name,
+  consistency.item ->> 'sourceTaskSlug' as source_task_slug,
+  consistency.item ->> 'targetTaskSlug' as target_task_slug,
   case
-    when consistency.check ->> 'status' in ('passed', 'failed') then consistency.check ->> 'status'
+    when consistency.item ->> 'status' in ('passed', 'failed') then consistency.item ->> 'status'
     else 'failed'
   end as status,
-  coalesce((consistency.check ->> 'score')::numeric, 0) as score,
-  coalesce((consistency.check ->> 'required')::boolean, true) as required,
+  coalesce((consistency.item ->> 'score')::numeric, 0) as score,
+  coalesce((consistency.item ->> 'required')::boolean, true) as required,
   case
-    when consistency.check ->> 'status' = 'passed' then null
-    when consistency.check ->> 'errorMessage' like 'Missing prior output%' then
+    when consistency.item ->> 'status' = 'passed' then null
+    when consistency.item ->> 'errorMessage' like 'Missing prior output%' then
       'Required output was unavailable for cross-app comparison.'
     else 'The required value was not carried consistently between tasks.'
   end as failure_reason
@@ -27,7 +27,7 @@ cross join lateral jsonb_array_elements(
     when jsonb_typeof(scores.breakdown -> 'consistency') = 'array' then scores.breakdown -> 'consistency'
     else '[]'::jsonb
   end
-) with ordinality as consistency(check, position)
+) with ordinality as consistency(item, position)
 where runs.status in ('completed', 'failed', 'timeout')
   and runs.is_public = true
   and attempts.status in ('completed', 'failed', 'timeout');

--- a/supabase/migrations/20260713000032_public_consistency_read_model.sql
+++ b/supabase/migrations/20260713000032_public_consistency_read_model.sql
@@ -1,0 +1,39 @@
+create or replace view public.public_hosted_run_consistency_checks
+with (security_barrier = true)
+as
+select
+  runs.id as run_id,
+  consistency.position as sequence_index,
+  consistency.check ->> 'name' as name,
+  consistency.check ->> 'sourceTaskSlug' as source_task_slug,
+  consistency.check ->> 'targetTaskSlug' as target_task_slug,
+  case
+    when consistency.check ->> 'status' in ('passed', 'failed') then consistency.check ->> 'status'
+    else 'failed'
+  end as status,
+  coalesce((consistency.check ->> 'score')::numeric, 0) as score,
+  coalesce((consistency.check ->> 'required')::boolean, true) as required,
+  case
+    when consistency.check ->> 'status' = 'passed' then null
+    when consistency.check ->> 'errorMessage' like 'Missing prior output%' then
+      'Required output was unavailable for cross-app comparison.'
+    else 'The required value was not carried consistently between tasks.'
+  end as failure_reason
+from public.benchmark_runs as runs
+join public.benchmark_attempts as attempts on attempts.run_id = runs.id
+join public.benchmark_attempt_scores as scores on scores.attempt_id = attempts.id
+cross join lateral jsonb_array_elements(
+  case
+    when jsonb_typeof(scores.breakdown -> 'consistency') = 'array' then scores.breakdown -> 'consistency'
+    else '[]'::jsonb
+  end
+) with ordinality as consistency(check, position)
+where runs.status in ('completed', 'failed', 'timeout')
+  and runs.is_public = true
+  and attempts.status in ('completed', 'failed', 'timeout');
+
+revoke all on table public.public_hosted_run_consistency_checks from public;
+grant select on table public.public_hosted_run_consistency_checks to anon, authenticated, service_role;
+
+comment on view public.public_hosted_run_consistency_checks is
+  'Public terminal scored-run cross-app consistency projection. Exposes only safe check labels, status, score, and generalized failure reasons; it never exposes evaluator evidence, generated task configuration, or final session state.';


### PR DESCRIPTION
Closes #177

## Summary

- add a filtered public read model for terminal hosted-suite consistency checks
- render cross-app check status separately from per-task scores on public result pages
- show generalized failure reasons without exposing evaluator evidence, final state, generated task configuration, or matched values
- keep check ordering stable through a persisted public sequence index

## Root cause

Hard-suite aggregate scores include required cross-app consistency checks, but the public result read model returned only task rows. A run could therefore show seven 100% tasks and an unexplained 80% aggregate.

## Verification

- `pnpm --filter web test` (57 passing)
- `pnpm --filter web exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter web build`
- `bash scripts/check-database-ownership.sh`
- browser verification against a local read-model stub: desktop and 390px viewport both rendered 7 passing tasks, 1/3 required cross-app checks, and two safe failure explanations
- `pnpm verify:ci` passed all checks before Lifecycle Postgres integration; that step could not run because this workstation has no Docker daemon

## Deployment

Apply `20260713000032_public_consistency_read_model.sql` before deploying the Web change.