### PR TITLE
fix(benchmark): verify hard suite lifecycle sweeps

### DIFF
--- a/.github/workflows/hosted-variant-sweep.yml
+++ b/.github/workflows/hosted-variant-sweep.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Dispatch sweep from develop
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run hosted-variant-sweep.yml --ref develop
+        run: gh workflow run hosted-variant-sweep.yml --ref develop --repo "${GITHUB_REPOSITORY}"
 
   sweep-development:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop'
@@ -36,14 +36,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        benchmark_case_slug:
+          - hosted-web-suite
+          - hosted-web-hard-suite
         generation_seed:
-          - full-pool-0
-          - full-pool-1
-          - full-pool-2
-          - full-pool-18
-          - full-pool-59
-          - full-pool-152
-          - full-pool-197
+          - full-pool-164
+          - full-pool-268
+          - full-pool-327
+          - full-pool-548
+          - full-pool-819
+          - full-pool-843
+          - full-pool-853
     steps:
       - name: Checkout develop
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -55,6 +58,7 @@ jobs:
         env:
           START_LOCAL_SERVICES: "false"
           SMOKE_MODE: full-pass
+          BENCHMARK_CASE_SLUG: ${{ matrix.benchmark_case_slug }}
           GENERATION_SEED: ${{ matrix.generation_seed }}
           HOSTED_SITES_PUBLIC_URL: ${{ vars.HOSTED_SITES_PUBLIC_URL }}
           HOSTED_ORCHESTRATOR_PUBLIC_URL: ${{ vars.HOSTED_ORCHESTRATOR_PUBLIC_URL }}

--- a/apps/hosted-orchestrator/tests/unit/attempt-lifecycle.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/attempt-lifecycle.test.ts
@@ -756,7 +756,7 @@ test("complete-session passes the suite when the agent carries the value across 
   assert.equal(aggregate.breakdown.consistency?.[0]?.evidence?.matchedValue, "90 days");
 });
 
-test("complete-session requires both hard v1.0.3 wiki answers in distinct note fields", async () => {
+test("complete-session requires both hard v1.0.4 wiki answers in distinct note fields", async () => {
   const bodyChain = {
     ...consistencyChain,
     name: "Wiki policy answer carried into note body",

--- a/apps/hosted-orchestrator/tests/unit/question-data.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/question-data.test.ts
@@ -1,10 +1,24 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
-import { hostedWebSuiteMetadata } from "@agentbench/test-cases";
+import { hostedWebHardSuiteMetadata, hostedWebSuiteMetadata } from "@agentbench/test-cases";
 import { generateAttemptQuestions } from "../../src/question-generation.js";
 
 function readHostedSuiteSeed() {
   return hostedWebSuiteMetadata;
+}
+
+function readScheduledSweepSeeds() {
+  const workflow = fs.readFileSync(
+    path.resolve(import.meta.dirname, "../../../../.github/workflows/hosted-variant-sweep.yml"),
+    "utf8",
+  );
+  const block = workflow.match(/generation_seed:\n((?:\s+- full-pool-\d+\n)+)/)?.[1];
+  assert.ok(block, "hosted variant sweep must declare generation seeds");
+  const seeds = [...block.matchAll(/- (full-pool-\d+)/g)].map((match) => match[1]!);
+  assert.equal(seeds.length, 7, "hosted variant sweep should retain seven covering seeds");
+  return seeds;
 }
 
 test("fresh database seed contains generated question pools without fixed session goals", () => {
@@ -52,31 +66,32 @@ test("wiki question variants declare typed answer contracts", () => {
   }
 });
 
-test("scheduled development seeds cover every declared variant", () => {
-  const suite = readHostedSuiteSeed();
-  const sessions = suite.sessions as Array<Record<string, unknown>>;
-  const selectedBySession = new Map<string, Set<string>>();
-  for (const seed of ["full-pool-0", "full-pool-1", "full-pool-2", "full-pool-18", "full-pool-59", "full-pool-152", "full-pool-197"]) {
-    const generated = generateAttemptQuestions(
-      sessions as Parameters<typeof generateAttemptQuestions>[0],
-      seed,
-    );
-    for (const session of generated.sessions) {
-      const generation = session.metadata.questionGeneration as Record<string, unknown>;
-      const key = `${session.app}/${session.taskSlug}`;
-      const selected = selectedBySession.get(key) ?? new Set<string>();
-      selected.add(String(generation.variantId));
-      selectedBySession.set(key, selected);
+for (const suite of [hostedWebSuiteMetadata, hostedWebHardSuiteMetadata]) {
+  test(`${suite.suiteSlug} scheduled development seeds cover every declared variant`, () => {
+    const sessions = suite.sessions as Array<Record<string, unknown>>;
+    const selectedBySession = new Map<string, Set<string>>();
+    for (const seed of readScheduledSweepSeeds()) {
+      const generated = generateAttemptQuestions(
+        sessions as Parameters<typeof generateAttemptQuestions>[0],
+        seed,
+      );
+      for (const session of generated.sessions) {
+        const generation = session.metadata.questionGeneration as Record<string, unknown>;
+        const key = `${session.app}/${session.taskSlug}`;
+        const selected = selectedBySession.get(key) ?? new Set<string>();
+        selected.add(String(generation.variantId));
+        selectedBySession.set(key, selected);
+      }
     }
-  }
 
-  for (const session of sessions) {
-    const variants = (session.metadata as Record<string, unknown>).questionVariants as Array<Record<string, unknown>>;
-    const key = `${String(session.app)}/${String(session.taskSlug)}`;
-    assert.deepEqual(
-      selectedBySession.get(key),
-      new Set(variants.map((variant) => String(variant.id))),
-      key,
-    );
-  }
-});
+    for (const session of sessions) {
+      const variants = (session.metadata as Record<string, unknown>).questionVariants as Array<Record<string, unknown>>;
+      const key = `${String(session.app)}/${String(session.taskSlug)}`;
+      assert.deepEqual(
+        selectedBySession.get(key),
+        new Set(variants.map((variant) => String(variant.id))),
+        key,
+      );
+    }
+  });
+}

--- a/apps/hosted-sites/src/apps/calendar-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/calendar-lite/test-driver.mjs
@@ -1,6 +1,10 @@
-export async function complete({ session, config, postForm, requireString }) {
+export async function complete({ session, config, context = {}, postForm, requireString }) {
   const payload = {
-    title: typeof config.expectedTitle === "string" ? config.expectedTitle : "carried-value",
+    title: typeof config.expectedTitle === "string"
+      ? config.expectedTitle
+      : typeof context.noteTitle === "string"
+        ? context.noteTitle
+        : "carried-value",
     date: requireString(config.expectedDate, "calendar-lite expectedDate"),
     startTime: requireString(config.expectedStartTime, "calendar-lite expectedStartTime"),
     durationMinutes: String(config.expectedDurationMinutes),

--- a/apps/hosted-sites/src/apps/notes-lite/evaluate.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/evaluate.ts
@@ -26,13 +26,13 @@ export function evaluateNotes(session: NotesEvaluationSession): HostedWebScoreRe
   const expectedNotes = readExpectedNotes(config);
   const backend =
     expectedNotes.length > 0
-      ? evaluateExpectedNoteSet(session.state.notes, expectedNotes)
+      ? evaluateExpectedNoteSet(session.state.notes, expectedNotes, expectedTag)
       : evaluateNotesBackendState(session.state.notes, expectedTitle, expectedBody, expectedTag, targetNoteId);
 
   return aggregateStrictScore({
     evaluators: [backend],
     passSummary: expectedNotes.length > 0
-      ? "Agent created the complete generated note set with exact titles, bodies, and tags."
+      ? "Agent created the complete generated note set and the carried handoff note."
       : targetNoteId
       ? expectedTitle && expectedBody
         ? "Agent updated the requested seeded note to the exact generated title, body, and tag."
@@ -60,7 +60,11 @@ function readExpectedNotes(config: Record<string, unknown>): ExpectedNote[] {
   );
 }
 
-function evaluateExpectedNoteSet(notes: Note[], expectedNotes: ExpectedNote[]): HostedWebEvaluatorResult {
+function evaluateExpectedNoteSet(
+  notes: Note[],
+  expectedNotes: ExpectedNote[],
+  expectedCarryTag: string,
+): HostedWebEvaluatorResult {
   const matched = expectedNotes.map((expected) =>
     notes.some(
       (note) =>
@@ -69,14 +73,25 @@ function evaluateExpectedNoteSet(notes: Note[], expectedNotes: ExpectedNote[]): 
         note.tag.trim() === expected.tag,
     ),
   );
-  const passed = matched.every(Boolean);
-  const evidence = { requiredNoteCount: expectedNotes.length, matchedNoteCount: matched.filter(Boolean).length };
+  const carryNote = notes.find(
+    (note) =>
+      note.tag.trim() === expectedCarryTag &&
+      note.title.trim().length > 0 &&
+      note.body.trim().length > 0,
+  );
+  const passed = matched.every(Boolean) && carryNote !== undefined;
+  const evidence = {
+    requiredNoteCount: expectedNotes.length,
+    matchedNoteCount: matched.filter(Boolean).length,
+    expectedCarryTag,
+    carryNoteId: carryNote?.id ?? null,
+  };
   return passed
     ? passedEvaluator({ type: "backend_state", name: "generated note set exists", evidence })
     : failedEvaluator({
         type: "backend_state",
         name: "generated note set exists",
-        errorMessage: "One or more required notes are missing or do not exactly match.",
+        errorMessage: "One or more required notes are missing, do not exactly match, or the carried handoff note is absent.",
         evidence,
       });
 }

--- a/apps/hosted-sites/src/apps/notes-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/notes-lite/test-driver.mjs
@@ -1,4 +1,14 @@
-export async function complete({ session, config, hostedBaseUrl, checkedFetch, postForm, requireString }) {
+export async function complete({ session, config, context = {}, hostedBaseUrl, checkedFetch, postForm, requireString }) {
+  const title = typeof config.expectedTitle === "string"
+    ? config.expectedTitle
+    : typeof context.wikiReleaseAnswer === "string"
+      ? context.wikiReleaseAnswer
+      : "carried-value";
+  const body = typeof config.expectedBody === "string"
+    ? config.expectedBody
+    : typeof context.wikiPolicyAnswer === "string"
+      ? context.wikiPolicyAnswer
+      : "second-carried-value";
   if (Array.isArray(config.expectedNotes)) {
     for (const note of config.expectedNotes) {
       await postForm("/notes/create", session.token, {
@@ -7,10 +17,14 @@ export async function complete({ session, config, hostedBaseUrl, checkedFetch, p
         tag: requireString(note.tag, "notes set tag"),
       });
     }
+    await postForm("/notes/create", session.token, {
+      title,
+      body,
+      tag: requireString(config.expectedTag, "notes carry tag"),
+    });
+    context.noteTitle = title;
     return;
   }
-  const title = typeof config.expectedTitle === "string" ? config.expectedTitle : "carried-value";
-  const body = typeof config.expectedBody === "string" ? config.expectedBody : "second-carried-value";
   const tag = requireString(config.expectedTag, "notes expectedTag");
   if (config.targetNoteId) {
     await checkedFetch(`${hostedBaseUrl}/notes/${encodeURIComponent(config.targetNoteId)}/edit?session=${encodeURIComponent(session.token)}`);
@@ -18,4 +32,5 @@ export async function complete({ session, config, hostedBaseUrl, checkedFetch, p
   } else {
     await postForm("/notes/create", session.token, { title, body, tag });
   }
+  context.noteTitle = title;
 }

--- a/apps/hosted-sites/src/apps/notes-lite/test-support.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/test-support.ts
@@ -19,6 +19,13 @@ export const notesLiteTestSupport: HostedAppTestSupport<"notes-lite"> = {
           createdAt: "2026-06-23T00:00:00.000Z",
         });
       });
+      session.state.notes.push({
+        id: "note-set-carry",
+        title: "carried-value",
+        body: "second-carried-value",
+        tag: configString(config, "expectedTag"),
+        createdAt: "2026-06-23T00:00:00.000Z",
+      });
       return;
     }
     const targetNoteId = configStringOrNull(config, "targetNoteId");

--- a/apps/hosted-sites/src/apps/wiki-lite/test-driver.mjs
+++ b/apps/hosted-sites/src/apps/wiki-lite/test-driver.mjs
@@ -1,4 +1,4 @@
-export async function complete({ session, config, hostedBaseUrl, checkedFetch, postForm, requireString, requireObject }) {
+export async function complete({ session, config, context = {}, hostedBaseUrl, checkedFetch, postForm, requireString, requireObject }) {
   const articleSlug = requireString(config.targetArticleSlug, "wiki targetArticleSlug");
   const answerContract = requireObject(config.answerContract, "wiki answerContract");
   const secondaryArticleSlug = config.secondaryArticleSlug;
@@ -11,7 +11,8 @@ export async function complete({ session, config, hostedBaseUrl, checkedFetch, p
     }
   }
   await checkedFetch(`${hostedBaseUrl}/wiki/article/${encodeURIComponent(articleSlug)}?session=${encodeURIComponent(session.token)}`);
-  await postForm("/wiki/answer", session.token, {
-    answer: requireString(answerContract.canonicalValue, "wiki canonicalValue"),
-  });
+  const answer = requireString(answerContract.canonicalValue, "wiki canonicalValue");
+  await postForm("/wiki/answer", session.token, { answer });
+  if (session.taskSlug === "wiki-release-answer-hard") context.wikiReleaseAnswer = answer;
+  if (session.taskSlug === "wiki-policy-answer-hard") context.wikiPolicyAnswer = answer;
 }

--- a/apps/hosted-sites/tests/unit/evaluation.test.ts
+++ b/apps/hosted-sites/tests/unit/evaluation.test.ts
@@ -1798,6 +1798,55 @@ test("evaluateNotes dual-carry variant fails when the carried body is empty", ()
   assert.equal(result.score, 0);
 });
 
+const rolloutNotes = [
+  { title: "API v3 implementation", body: "Track implementation.", tag: "implementation" },
+  { title: "API v3 verification", body: "Record verification.", tag: "verification" },
+];
+
+test("evaluateNotes multi-record carry variant requires the fixed set and a handoff note", () => {
+  const result = evaluateNotes(
+    makeNotesSession(
+      {
+        notes: [
+          ...rolloutNotes.map((note, index) => ({
+            id: `note_rollout_${index}`,
+            ...note,
+            createdAt: "2026-06-23T00:00:00.000Z",
+          })),
+          {
+            id: "note_handoff",
+            title: "30 days",
+            body: "90 days",
+            tag: "handoff",
+            createdAt: "2026-06-23T00:00:00.000Z",
+          },
+        ],
+      },
+      generatedTaskConfig({ expectedTag: "handoff", expectedNotes: rolloutNotes }),
+    ),
+  );
+  assert.equal(result.status, "passed");
+  assert.equal(result.evaluators[0]?.evidence?.carryNoteId, "note_handoff");
+});
+
+test("evaluateNotes multi-record carry variant fails without the handoff note", () => {
+  const result = evaluateNotes(
+    makeNotesSession(
+      {
+        notes: rolloutNotes.map((note, index) => ({
+          id: `note_rollout_${index}`,
+          ...note,
+          createdAt: "2026-06-23T00:00:00.000Z",
+        })),
+      },
+      generatedTaskConfig({ expectedTag: "handoff", expectedNotes: rolloutNotes }),
+    ),
+  );
+  assert.equal(result.status, "failed");
+  assert.equal(result.evaluators[0]?.evidence?.matchedNoteCount, rolloutNotes.length);
+  assert.equal(result.evaluators[0]?.evidence?.carryNoteId, null);
+});
+
 test("generated shopping config changes the accepted category and shipping method", () => {
   const session = makeShoppingSession({
     products: [{ id: "prod-cable", name: "USB-C Cable", category: "cable", price: 9.99 }],

--- a/apps/hosted-sites/tests/unit/test-drivers.test.ts
+++ b/apps/hosted-sites/tests/unit/test-drivers.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type Driver = {
+  complete(params: Record<string, unknown>): Promise<void>;
+};
+
+function requireString(value: unknown, label: string) {
+  assert.equal(typeof value, "string", `${label} must be a string`);
+  assert.ok((value as string).length > 0, `${label} must not be empty`);
+  return value as string;
+}
+
+function requireObject(value: unknown, label: string) {
+  assert.ok(value && typeof value === "object" && !Array.isArray(value), `${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+test("hard smoke drivers carry Wiki answers through Notes into Calendar", async () => {
+  const wiki = (await import("../../src/apps/wiki-lite/test-driver.mjs")) as Driver;
+  const notes = (await import("../../src/apps/notes-lite/test-driver.mjs")) as Driver;
+  const calendar = (await import("../../src/apps/calendar-lite/test-driver.mjs")) as Driver;
+  const context: Record<string, string> = {};
+  const formPosts: Array<{ path: string; values: Record<string, string> }> = [];
+  const common = {
+    context,
+    hostedBaseUrl: "https://hosted.example.test",
+    checkedFetch: async () => undefined,
+    postForm: async (path: string, _token: string, values: Record<string, string>) => {
+      formPosts.push({ path, values });
+    },
+    requireString,
+    requireObject,
+  };
+
+  await wiki.complete({
+    ...common,
+    session: { token: "wiki-release", taskSlug: "wiki-release-answer-hard" },
+    config: {
+      targetArticleSlug: "returns-policy",
+      answerContract: { canonicalValue: "30 days" },
+    },
+  });
+  await wiki.complete({
+    ...common,
+    session: { token: "wiki-policy", taskSlug: "wiki-policy-answer-hard" },
+    config: {
+      targetArticleSlug: "retention-policy",
+      answerContract: { canonicalValue: "90 days" },
+    },
+  });
+  await notes.complete({
+    ...common,
+    session: { token: "notes", taskSlug: "notes-followup-create-hard" },
+    config: {
+      expectedTag: "handoff",
+      expectedNotes: [
+        { title: "Implementation", body: "Track it.", tag: "implementation" },
+        { title: "Verification", body: "Verify it.", tag: "verification" },
+      ],
+    },
+  });
+  await calendar.complete({
+    ...common,
+    session: { token: "calendar", taskSlug: "calendar-event-create-hard" },
+    config: {
+      expectedDate: "2026-07-20",
+      expectedStartTime: "15:00",
+      expectedDurationMinutes: 30,
+      expectedAttendeeEmail: "mira@example.com",
+    },
+  });
+
+  assert.deepEqual(context, {
+    wikiReleaseAnswer: "30 days",
+    wikiPolicyAnswer: "90 days",
+    noteTitle: "30 days",
+  });
+  assert.deepEqual(formPosts.at(-2), {
+    path: "/notes/create",
+    values: { title: "30 days", body: "90 days", tag: "handoff" },
+  });
+  assert.deepEqual(formPosts.at(-1), {
+    path: "/calendar/events",
+    values: {
+      title: "30 days",
+      date: "2026-07-20",
+      startTime: "15:00",
+      durationMinutes: "30",
+      attendeeEmail: "mira@example.com",
+    },
+  });
+});

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -58,7 +58,7 @@ performed prerequisite actions out of order.
 
 ## Independent Suite Versioning
 
-The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.10` and `hosted-web-hard-suite-v1.0.3`). A change to a hard variant, the hard pool composition, a hard cross-app chain, or a testcase time limit bumps the affected suite's version and content hash.
+The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.10` and `hosted-web-hard-suite-v1.0.4`). A change to a hard variant, the hard pool composition, a hard cross-app chain, or a testcase time limit bumps the affected suite's version and content hash.
 
 This is enforced mechanically: new task-config fields used by hard variants are optional and only inspected when present, and `consistencyChecks` is an optional manifest key that is absent from the easy manifest. The easy catalog's "stable revision identity and content hash" test fails if a hard-suite change leaks into the easy manifest.
 
@@ -100,7 +100,7 @@ Publishing converts the validated catalog into an immutable `benchmark_case_revi
 - `pnpm --filter hosted-sites test` imports the canonical catalog, executes positive and negative scoring for every declared variant across both published suites, and repeats each passing state across all layouts and themes.
 - `pnpm catalog:publish` validates and publishes the current catalog release with service-role credentials.
 - `pnpm verify:ci` runs the complete repository gate, including Redis command tests, PostgreSQL lifecycle races, local hosted smoke, and production builds.
-- `Hosted Variant Sweep` runs seven deterministic full-pass attempts against the development environment every Monday and on demand. The default-branch schedule dispatches the workflow from `develop` before it requests the protected `development` Environment. Seeds `full-pool-0`, `full-pool-1`, `full-pool-2`, `full-pool-18`, `full-pool-59`, `full-pool-152`, and `full-pool-197` cover every current variant without using Web guest quota. The hard suite is swept independently from the easy suite and ranked separately on public result and leaderboard surfaces.
+- `Hosted Variant Sweep` runs seven deterministic full-pass attempts per suite against the development environment every Monday and on demand. The default-branch schedule dispatches the workflow from `develop` before it requests the protected `development` Environment. The workflow matrix passes `BENCHMARK_CASE_SLUG` explicitly for both `hosted-web-suite` and `hosted-web-hard-suite`. Seeds `full-pool-164`, `full-pool-268`, `full-pool-327`, `full-pool-548`, `full-pool-819`, `full-pool-843`, and `full-pool-853` cover every current variant without using Web guest quota; an orchestrator test reads this list directly from the workflow and fails if either suite loses coverage. The hard suite is swept independently from the easy suite and ranked separately on public result and leaderboard surfaces.
 - Each lifecycle smoke logs selected variant IDs and requires one unique `hosted_web_results` row per suite session plus one `benchmark_attempt_scores` row.
 
 The seed list is versioned with the suite. Recompute it whenever variant IDs, session order, app slug, or task slug changes; CI remains the immediate guard against an uncovered variant.

--- a/docs/hosted-site-app-authoring.md
+++ b/docs/hosted-site-app-authoring.md
@@ -267,4 +267,12 @@ HOSTED_SITES_PORT=4011 HOSTED_ORCHESTRATOR_PORT=5011 \
   bash tests/e2e/hosted-lifecycle-full-pass.sh
 ```
 
+The smoke defaults to `hosted-web-suite`. Select another published case
+explicitly when verifying an independent suite:
+
+```bash
+BENCHMARK_CASE_SLUG=hosted-web-hard-suite \
+  bash tests/e2e/hosted-lifecycle-full-pass.sh
+```
+
 Acceptance requires registered typed state, evaluator breakdowns, at least one required `backend_state` unless purely informational, redacted final evidence, no app-specific tables, no server browser, and successful initialization/operation/scoring as an orchestrated session.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -156,14 +156,14 @@ Confidentiality is the gating constraint for the epic: scorer oracle surfaces (v
 | #113 Calendar hard pool | Complete | Conflict-avoidance, shared-window, timezone-overlap, and reschedule variants. |
 | #114 Repo hard pool | Complete | Coherent multi-edit / rename / rollout variants with required messages. |
 | #110 Shopping hard pool | Complete | Stock-aware, compatibility, and coupon constrained-checkout variants. |
-| #115 Cross-app chain | In Progress | Hard v1.0.3 requires the agent to carry two exact wiki answers into a later note's title and body; enforced only by suite-level consistency checks against the agent's own final states. |
+| #115 Cross-app chain | In Progress | Hard v1.0.4 requires the agent to carry two exact wiki answers into a later note's title and body; enforced only by suite-level consistency checks against the agent's own final states. |
 | #116 Verification matrix and docs | In Progress | Both suites swept independently by the generic matrix; independent semantic versioning, cross-app consistency, and scorer oracle policy documented. |
-| #140 Hard v1.0.3 scale expansion | In Progress | Expand all six hard pools, add a required workflow spanning at least three sessions, and complete deterministic, confidentiality, browser, and lifecycle verification before publishing v1.0.3. |
+| #140 Hard v1.0.4 scale expansion | In Progress | Expand all six hard pools, add a required workflow spanning at least three sessions, and complete deterministic, confidentiality, browser, and lifecycle verification before publishing v1.0.4. |
 
 Each hard variant receives positive, negative, and presentation-invariant matrix coverage in `apps/hosted-sites/tests/unit/variant-matrix.test.ts`, which iterates every published suite. Per-session scoring stays deterministic; suite-level checks live solely in the scoring module (`evaluateSuiteConsistency`) and orchestrator aggregation. The easy and hard suites version and publish independently; a hard-suite change must not alter the easy manifest's content hash.
 
-Issue #140 is the umbrella work item for the unpublished `v1.0.3` revision. The
-revision remains `v1.0.3` while this scope is assembled; affected task and seed
+Issue #140 is the umbrella work item for the unpublished `v1.0.4` revision. The
+revision remains `v1.0.4` while this scope is assembled; affected task and seed
 versions still advance whenever their semantics or fixtures change. Delivery is
 split into four increments:
 
@@ -192,12 +192,68 @@ simulated conflict-resolution requirements to coherent multi-file changes.
 The Wiki increment adds required article sets so a hard retrieval can require
 triangulation across three or more pages before the typed answer is submitted.
 The Notes increment supports multi-record tasks whose intermediate saves remain
-non-terminal until the complete exact note set exists in backend state.
+non-terminal until the complete exact note set and a Wiki-derived handoff note
+exist in backend state.
 The Calendar increment adds recurring occurrence and resource requirements.
 Every hard Calendar task also carries the preceding Notes title, completing a
 required Wiki-to-Notes-to-Calendar chain across three ordered sessions.
 
 Exit criteria: the hard suite is published as its own immutable revision, every hard variant and the cross-app carry checks pass unit and E2E checks, public surfaces rank the hard suite separately without exposing oracle data, and `pnpm verify:ci` remains green.
+
+### P2.3 Capability-Complete Hard Testbench
+
+Status: Planned ([#181](https://github.com/Kaiwen0418/agent-benchmark/issues/181))
+
+The current hard v1.0.4 suite is structurally medium-hard: it is strong at
+deterministic multi-step browser execution, exact backend-state scoring,
+ordered mutations, bounded constraint reasoning, and a three-session carry
+chain. Its principal blind spots are conflicting-evidence reconciliation,
+branching long-horizon plans, deterministic failure recovery, asynchronous
+multi-actor state, privacy judgment, efficiency, and generalization to unseen
+task compositions. This 3/5 structural assessment is provisional until
+repeated representative-agent runs establish empirical pass rates and
+confidence intervals.
+
+P2.3 preserves the immutable v1.0.4 release and builds the next revision as a
+capability-oriented testbench with independently reported tracks rather than a
+single longer scripted workflow:
+
+| Capability track | Milestone scope |
+| --- | --- |
+| Research and evidence reconciliation | Resolve authoritative, stale, contradictory, and irrelevant sources and retain compact source evidence. |
+| Transaction and quantitative reasoning | Combine shopping decisions with deterministic table, formula, validation, and verification work. |
+| Software change and verification | Diagnose a seeded failing check, make dependency-aware repository changes, resolve review or conflict state, and record verification. |
+| Communication, policy, and privacy | Triage deterministic inbox-style work, route approvals, and prevent canary-secret or prohibited-recipient disclosure. |
+| Scheduling and multi-actor coordination | React to deterministic delayed approvals and availability changes by polling, rechecking, and revising a schedule. |
+| Recovery and self-correction | Recover from seeded stale views, rejected mutations, version conflicts, and interrupted navigation without duplicate side effects. |
+| Long-horizon campaign | Execute a private branch-and-merge dependency graph across at least six sessions and four apps, including one required revision after new evidence. |
+
+Delivery is sequenced as follows:
+
+1. Establish the machine-readable capability matrix and calibrate v1.0.4 with
+   repeated runs from at least three representative agent families.
+2. Add generic private scenario-graph, deterministic fault-schedule, scoring,
+   and per-capability result contracts before app-specific implementations.
+3. Add at least two deterministic task surfaces, provisionally `inbox-lite`
+   and `sheets-lite`, and implement at least four independently runnable
+   capability tracks with two materially distinct variants each.
+4. Complete presentation, recovery, confidentiality, anti-forgery, browser,
+   lifecycle, seed-sweep, and production-like capacity verification before
+   publishing a new immutable hard-suite revision.
+
+The proposed score reports final-state correctness, cross-task consistency,
+evidence and verification, recovery and safety, and normalized interaction
+cost separately. Required final states and safety remain pass gates; wall-clock
+time remains diagnostic so infrastructure variance does not decide correctness.
+Weights and compatibility behavior must be frozen before publication.
+
+Exit criteria: every scored capability maps to at least two independent
+variants; the suite includes at least four tracks, two new task surfaces, and
+one deterministic branching campaign; recoverable-failure and privacy canary
+tests pass without oracle leakage; representative-agent repeated-seed results
+show a statistically supported difficulty increase over v1.0.4; historical
+easy and hard content hashes remain unchanged; and catalog checks, browser E2E,
+Docker-backed lifecycle smoke, and `pnpm verify:ci` are green.
 
 ## Explicit Non-Goals
 

--- a/packages/test-cases/src/apps/notes-lite/definition.ts
+++ b/packages/test-cases/src/apps/notes-lite/definition.ts
@@ -11,6 +11,8 @@ export const notesLiteTestcaseDefinition = defineHostedTestcaseApp({
     // Hard cross-app carry variants leave both title and body unpinned. Their
     // values are verified against prior session final states at suite level.
     expectedBody: z.string().min(1).optional(),
+    // For multi-record variants this identifies the additional unpinned carry
+    // note; suite consistency checks verify its title and body values.
     expectedTag: z.string().min(1),
     targetNoteId: z.string().min(1).optional(),
     expectedNotes: z
@@ -106,9 +108,9 @@ export const notesLiteTestcaseDefinition = defineHostedTestcaseApp({
       },
       {
         id: "release-rollout-note-set",
-        goal: "Create and organize all three rollout notes: (1) title 'API v3 implementation', body 'Track the implementation branch and conflict resolution.', tag 'implementation'; (2) title 'API v3 verification', body 'Record CI, reviewer, and compatibility evidence.', tag 'verification'; and (3) title 'API v3 release', body 'Schedule publication after verification passes.', tag 'release'. Create exactly these required notes.",
+        goal: "Create and organize all three rollout notes: (1) title 'API v3 implementation', body 'Track the implementation branch and conflict resolution.', tag 'implementation'; (2) title 'API v3 verification', body 'Record CI, reviewer, and compatibility evidence.', tag 'verification'; and (3) title 'API v3 release', body 'Schedule publication after verification passes.', tag 'release'. Then create a fourth handoff note whose title is exactly the answer you submitted in the earlier wiki release-lookup task, whose body is exactly the answer you submitted in the later wiki policy-lookup task, and whose tag is 'handoff'.",
         taskConfig: {
-          expectedTag: "project",
+          expectedTag: "handoff",
           expectedNotes: [
             { title: "API v3 implementation", body: "Track the implementation branch and conflict resolution.", tag: "implementation" },
             { title: "API v3 verification", body: "Record CI, reviewer, and compatibility evidence.", tag: "verification" },

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -13,7 +13,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-hard-suite-v1",
-  suiteVersion: "v1.0.3",
+  suiteVersion: "v1.0.4",
   timeLimitMinutesPerTestcase: 10,
   sessions: [
     {
@@ -85,8 +85,8 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       taskSlug: "notes-followup-create-hard",
       title: "Notes Follow-up (Hard)",
       startPath: "/notes",
-      taskVersion: "v3",
-      seedVersion: "notes-lite-hard-v2",
+      taskVersion: "v4",
+      seedVersion: "notes-lite-hard-v3",
       sequenceIndex: 5,
       weight: 1,
       required: true,
@@ -144,7 +144,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.3";
+export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.4";
 
 export const hostedWebHardSuiteCase = {
   id: "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -85,9 +85,9 @@ test("hard consistency checks reference real sessions with source before target"
   }
 });
 
-test("hard v1.0.3 requires both wiki answers to be carried into distinct note fields", () => {
+test("hard v1.0.4 requires both wiki answers to be carried into distinct note fields", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
-  assert.equal(suite.suiteVersion, "v1.0.3");
+  assert.equal(suite.suiteVersion, "v1.0.4");
   assert.deepEqual(
     suite.consistencyChecks?.map((check) => ({
       sourceTaskSlug: check.sourceTaskSlug,
@@ -114,7 +114,7 @@ test("hard v1.0.3 requires both wiki answers to be carried into distinct note fi
   );
 });
 
-test("hard v1.0.3 includes combined-constraint shopping variants on the v2 seed", () => {
+test("hard v1.0.4 includes combined-constraint shopping variants on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const shopping = suite.sessions.find((session) => session.app === "shopping-lite");
   assert.ok(shopping);
@@ -125,7 +125,7 @@ test("hard v1.0.3 includes combined-constraint shopping variants on the v2 seed"
   assert.ok(variantIds.includes("airlite-field-kit"));
 });
 
-test("hard v1.0.3 includes ordered forum escalation on the v2 seed", () => {
+test("hard v1.0.4 includes ordered forum escalation on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const forum = suite.sessions.find((session) => session.app === "forum-lite");
   assert.ok(forum);
@@ -136,7 +136,7 @@ test("hard v1.0.3 includes ordered forum escalation on the v2 seed", () => {
   );
 });
 
-test("hard v1.0.3 includes conflict-aware repo workflow on the v2 seed", () => {
+test("hard v1.0.4 includes conflict-aware repo workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const repo = suite.sessions.find((session) => session.app === "repo-lite");
   assert.ok(repo);
@@ -145,7 +145,7 @@ test("hard v1.0.3 includes conflict-aware repo workflow on the v2 seed", () => {
   assert.ok(repo.metadata.questionVariants.some((variant) => variant.id === "api-v3-conflict-rollout"));
 });
 
-test("hard v1.0.3 includes three-article wiki verification on the v2 seed", () => {
+test("hard v1.0.4 includes three-article wiki verification on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const wikiSessions = suite.sessions.filter((session) => session.app === "wiki-lite");
   assert.ok(wikiSessions.every((session) => session.seedVersion === "wiki-lite-hard-v2"));
@@ -156,16 +156,19 @@ test("hard v1.0.3 includes three-article wiki verification on the v2 seed", () =
   );
 });
 
-test("hard v1.0.3 includes a multi-record notes workflow on the v2 seed", () => {
+test("hard v1.0.4 includes a multi-record notes workflow with a carry handoff", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const notes = suite.sessions.find((session) => session.app === "notes-lite");
   assert.ok(notes);
-  assert.equal(notes.taskVersion, "v3");
-  assert.equal(notes.seedVersion, "notes-lite-hard-v2");
-  assert.ok(notes.metadata.questionVariants.some((variant) => variant.id === "release-rollout-note-set"));
+  assert.equal(notes.taskVersion, "v4");
+  assert.equal(notes.seedVersion, "notes-lite-hard-v3");
+  const rollout = notes.metadata.questionVariants.find((variant) => variant.id === "release-rollout-note-set");
+  assert.ok(rollout);
+  assert.equal(rollout.taskConfig.expectedTag, "handoff");
+  assert.match(rollout.goal, /fourth handoff note/);
 });
 
-test("hard v1.0.3 includes recurring resource calendar workflow on the v2 seed", () => {
+test("hard v1.0.4 includes recurring resource calendar workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const calendar = suite.sessions.find((session) => session.app === "calendar-lite");
   assert.ok(calendar);

--- a/scripts/test-hosted-variant-sweep.sh
+++ b/scripts/test-hosted-variant-sweep.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/hosted-variant-sweep.yml"
+SMOKE="${ROOT_DIR}/tests/e2e/hosted-lifecycle-smoke.sh"
+
+require_text() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file}"; then
+    printf 'expected %s to contain: %s\n' "${file}" "${expected}" >&2
+    exit 1
+  fi
+}
+
+bash -n "${SMOKE}"
+
+set +e
+invalid_output="$({
+  BENCHMARK_CASE_SLUG="Invalid slug" \
+    SUPABASE_URL="https://example.invalid" \
+    SUPABASE_SERVICE_ROLE_KEY="test-only" \
+    RUNNER_SHARED_SECRET="test-only" \
+    START_LOCAL_SERVICES="false" \
+    bash "${SMOKE}"
+} 2>&1)"
+invalid_status=$?
+set -e
+if [[ "${invalid_status}" -ne 2 || "${invalid_output}" != *"BENCHMARK_CASE_SLUG must be a lowercase hyphenated slug."* ]]; then
+  echo "invalid benchmark case slug was not rejected before smoke startup" >&2
+  exit 1
+fi
+
+require_text "${SMOKE}" 'BENCHMARK_CASE_SLUG="${BENCHMARK_CASE_SLUG:-hosted-web-suite}"'
+require_text "${SMOKE}" 'slug: `eq.${benchmarkCaseSlug}`'
+require_text "${WORKFLOW}" 'gh workflow run hosted-variant-sweep.yml --ref develop --repo "${GITHUB_REPOSITORY}"'
+require_text "${WORKFLOW}" 'benchmark_case_slug:'
+require_text "${WORKFLOW}" '          - hosted-web-suite'
+require_text "${WORKFLOW}" '          - hosted-web-hard-suite'
+require_text "${WORKFLOW}" 'BENCHMARK_CASE_SLUG: ${{ matrix.benchmark_case_slug }}'
+
+echo "hosted variant sweep workflow tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
+echo "== Hosted variant sweep workflow =="
+bash scripts/test-hosted-variant-sweep.sh
+
 echo "== Deployment classifier =="
 bash scripts/test-deploy-classifier.sh
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -608,10 +608,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-hard-suite-v1.0.3',
+  'hosted-web-hard-suite-v1.0.4',
   $catalog${
   "suiteSlug": "hosted-web-hard-suite-v1",
-  "suiteVersion": "v1.0.3",
+  "suiteVersion": "v1.0.4",
   "timeLimitMinutesPerTestcase": 10,
   "sessions": [
     {
@@ -1150,8 +1150,8 @@ select public.publish_benchmark_case_catalog(
       "taskSlug": "notes-followup-create-hard",
       "title": "Notes Follow-up (Hard)",
       "startPath": "/notes",
-      "taskVersion": "v3",
-      "seedVersion": "notes-lite-hard-v2",
+      "taskVersion": "v4",
+      "seedVersion": "notes-lite-hard-v3",
       "sequenceIndex": 5,
       "weight": 1,
       "required": true,
@@ -1174,9 +1174,9 @@ select public.publish_benchmark_case_catalog(
           },
           {
             "id": "release-rollout-note-set",
-            "goal": "Create and organize all three rollout notes: (1) title 'API v3 implementation', body 'Track the implementation branch and conflict resolution.', tag 'implementation'; (2) title 'API v3 verification', body 'Record CI, reviewer, and compatibility evidence.', tag 'verification'; and (3) title 'API v3 release', body 'Schedule publication after verification passes.', tag 'release'. Create exactly these required notes.",
+            "goal": "Create and organize all three rollout notes: (1) title 'API v3 implementation', body 'Track the implementation branch and conflict resolution.', tag 'implementation'; (2) title 'API v3 verification', body 'Record CI, reviewer, and compatibility evidence.', tag 'verification'; and (3) title 'API v3 release', body 'Schedule publication after verification passes.', tag 'release'. Then create a fourth handoff note whose title is exactly the answer you submitted in the earlier wiki release-lookup task, whose body is exactly the answer you submitted in the later wiki policy-lookup task, and whose tag is 'handoff'.",
             "taskConfig": {
-              "expectedTag": "project",
+              "expectedTag": "handoff",
               "expectedNotes": [
                 {
                   "title": "API v3 implementation",
@@ -1423,7 +1423,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  '423b56db70db3489bdbadc11d27094486f2293b400b79acaab1e55d988305ba0'
+  'dc793b8caaff6183dc97a8afca5b24eac3fe4e9ff9cc0725b6953f5977095ef2'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)

--- a/tests/e2e/hosted-lifecycle-smoke.sh
+++ b/tests/e2e/hosted-lifecycle-smoke.sh
@@ -11,6 +11,7 @@ WEB_URL="${AGENTBENCH_WEB_URL:-http://127.0.0.1:3999}"
 SMOKE_MODE="${SMOKE_MODE:-timeout}"
 START_LOCAL_SERVICES="${START_LOCAL_SERVICES:-true}"
 GENERATION_SEED="${GENERATION_SEED:-}"
+BENCHMARK_CASE_SLUG="${BENCHMARK_CASE_SLUG:-hosted-web-suite}"
 
 if [[ -f "${ENV_FILE}" && -z "${SUPABASE_URL:-}" && -z "${SUPABASE_SERVICE_ROLE_KEY:-}" && -z "${RUNNER_SHARED_SECRET:-}" ]]; then
   set -a
@@ -28,6 +29,10 @@ if [[ "${SMOKE_MODE}" != "full-pass" && "${SMOKE_MODE}" != "timeout" ]]; then
 fi
 if [[ "${START_LOCAL_SERVICES}" != "true" && "${START_LOCAL_SERVICES}" != "false" ]]; then
   echo "START_LOCAL_SERVICES must be true or false." >&2
+  exit 2
+fi
+if [[ ! "${BENCHMARK_CASE_SLUG}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "BENCHMARK_CASE_SLUG must be a lowercase hyphenated slug." >&2
   exit 2
 fi
 
@@ -87,6 +92,7 @@ curl -fsS "${ORCHESTRATOR_BASE_URL}/health" >/dev/null
 set +e
 SMOKE_MODE="${SMOKE_MODE}" \
 GENERATION_SEED="${GENERATION_SEED}" \
+BENCHMARK_CASE_SLUG="${BENCHMARK_CASE_SLUG}" \
 ROOT_DIR="${ROOT_DIR}" \
 HOSTED_BASE_URL="${HOSTED_BASE_URL}" \
 ORCHESTRATOR_BASE_URL="${ORCHESTRATOR_BASE_URL}" \
@@ -96,6 +102,7 @@ const { pathToFileURL } = await import("node:url");
 
 const smokeMode = process.env.SMOKE_MODE;
 const generationSeed = process.env.GENERATION_SEED || undefined;
+const benchmarkCaseSlug = process.env.BENCHMARK_CASE_SLUG || "hosted-web-suite";
 const rootDir = process.env.ROOT_DIR;
 const hostedBaseUrl = process.env.HOSTED_BASE_URL;
 const orchestratorBaseUrl = process.env.ORCHESTRATOR_BASE_URL;
@@ -216,6 +223,7 @@ function generatedConfig(sessionRows, sequenceIndex) {
 }
 
 const appCompletion = new Map();
+const completionContext = {};
 
 async function loadAppDriver(app) {
   if (appCompletion.has(app)) {
@@ -238,6 +246,7 @@ async function completeAndVerifySession(session, config) {
   await completeApp({
     session,
     config,
+    context: completionContext,
     hostedBaseUrl,
     checkedFetch,
     postForm,
@@ -269,11 +278,11 @@ async function loadAttemptState(attemptId) {
 async function main() {
   const benchmarkCases = await selectRows("benchmark_cases", {
     select: "id,slug,title,description,current_revision_id",
-    slug: "eq.hosted-web-suite",
+    slug: `eq.${benchmarkCaseSlug}`,
     limit: "1",
   });
   if (!Array.isArray(benchmarkCases) || benchmarkCases.length !== 1) {
-    throw new Error("benchmark case not found");
+    throw new Error(`benchmark case not found: ${benchmarkCaseSlug}`);
   }
   const benchmarkCase = benchmarkCases[0];
   const caseRevisionId = requireString(benchmarkCase.current_revision_id, "current benchmark revision");
@@ -428,11 +437,14 @@ async function main() {
   }
 
   const scoreRows = await selectRows("benchmark_attempt_scores", {
-    select: "id",
+    select: "id,status,score",
     attempt_id: `eq.${initialized.attemptId}`,
   });
   if (scoreRows.length !== 1) {
     throw new Error(`Expected one aggregate attempt score, got ${scoreRows.length}.`);
+  }
+  if (smokeMode === "full-pass" && (scoreRows[0].status !== "passed" || Number(scoreRows[0].score) !== 1)) {
+    throw new Error(`Expected a passing aggregate score, got ${JSON.stringify(scoreRows[0])}.`);
   }
 
   const selectedVariants = sessionRows
@@ -446,7 +458,7 @@ async function main() {
     })
     .join(",");
   console.log(
-    `orchestrator smoke (${smokeMode}) passed: run=${run.id} attempt=${initialized.attemptId} sessions=${sessions.length} variants=${selectedVariants}`,
+    `orchestrator smoke (${smokeMode}) passed: case=${benchmarkCaseSlug} suite=${suite.suiteSlug}@${suite.suiteVersion} run=${run.id} attempt=${initialized.attemptId} sessions=${sessions.length} variants=${selectedVariants}`,
   );
 }
 


### PR DESCRIPTION
## Summary

- run the hosted lifecycle smoke against an explicit benchmark case and include both easy and hard suites in the 7-seed variant sweep
- repair scheduled dispatch repository targeting and add static workflow/coverage contract tests
- require successful aggregate score evidence for a full-pass lifecycle run
- make the hard Notes handoff variant satisfiable while preserving cross-app consistency, publishing the immutable hard suite baseline as v1.0.4
- refresh generated seed data and durable benchmark/roadmap documentation

## Root cause

Issue #140 could not be closed because the lifecycle smoke and manual variant sweep exercised only the easy suite, scheduled dispatch had no explicit repository context, and the previous seeds did not cover hard-suite variants. Enabling the hard sweep also exposed an impossible Notes variant: the fixed note set could not carry both Wiki answers required by the global consistency evaluator.

## Verification

- `pnpm --filter @agentbench/test-cases test` — 17 passed
- `pnpm --filter hosted-sites test` — 267 passed
- `pnpm --filter hosted-orchestrator test` — 60 passed, 5 environment/Redis skips
- `pnpm --filter @agentbench/scoring test` — 13 passed
- `pnpm catalog:check` — passed
- hosted-sites, hosted-orchestrator, and web production builds — passed
- web tests — 55 passed
- workflow YAML parse and `git diff --check` — passed
- `pnpm verify:ci` passes the workflow, topology, boundary, layout, and hosted-app consistency stages locally; the Docker-backed Postgres lifecycle stage could not run because the local Docker socket is unavailable and is delegated to GitHub Actions

Closes #140