### PR TITLE
fix(benchmark): verify redacted notes consistency

### DIFF
--- a/apps/hosted-orchestrator/tests/unit/attempt-lifecycle.test.ts
+++ b/apps/hosted-orchestrator/tests/unit/attempt-lifecycle.test.ts
@@ -7,7 +7,7 @@ import {
   type AttemptLifecycleAdvanceSession,
   type AttemptLifecycleSession,
 } from "../../src/attempt-lifecycle.js";
-import type { HostedWebScoreResult } from "@agentbench/scoring";
+import { createConsistencyDigest, type HostedWebScoreResult } from "@agentbench/scoring";
 
 function createLifecycle(overrides?: {
   getSupabaseAdmin?: () => SupabaseClient<Database> | null;
@@ -756,12 +756,13 @@ test("complete-session passes the suite when the agent carries the value across 
   assert.equal(aggregate.breakdown.consistency?.[0]?.evidence?.matchedValue, "90 days");
 });
 
-test("complete-session requires both hard v1.0.4 wiki answers in distinct note fields", async () => {
+test("complete-session requires both hard v1.0.5 wiki answers in distinct note fields", async () => {
   const bodyChain = {
     ...consistencyChain,
     name: "Wiki policy answer carried into note body",
     sourceTaskSlug: "wiki-policy-answer-hard",
-    targetPath: "notes[].body",
+    targetPath: "notes[].bodyDigest",
+    rule: "target-digest-matches-source",
   };
   const { supabase } = createConsistencySupabase({
     wikiFinalState: { app: "wiki-lite", latestAnswer: { answer: "30 days" } },
@@ -774,7 +775,7 @@ test("complete-session requires both hard v1.0.4 wiki answers in distinct note f
     type: "complete-session",
     session: makeNotesTargetSession({
       app: "notes-lite",
-      notes: [{ id: "n1", title: "30 days", body: "wrong value", tag: "release" }],
+      notes: [{ id: "n1", title: "30 days", bodyDigest: createConsistencyDigest("wrong value"), tag: "release" }],
     }),
     result: makeScoreResult(),
   });

--- a/apps/hosted-sites/src/apps/notes-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/notes-lite/final-state.ts
@@ -1,3 +1,4 @@
+import { createConsistencyDigest } from "@agentbench/scoring";
 import type { HostedSessionFor } from "../../runtime/types.js";
 
 export function buildNotesFinalState(session: HostedSessionFor<"notes-lite">) {
@@ -9,6 +10,7 @@ export function buildNotesFinalState(session: HostedSessionFor<"notes-lite">) {
       title: note.title,
       tag: note.tag,
       bodyLength: note.body.length,
+      bodyDigest: createConsistencyDigest(note.body),
     })),
   };
 }

--- a/apps/hosted-sites/tests/unit/app-registry.test.ts
+++ b/apps/hosted-sites/tests/unit/app-registry.test.ts
@@ -181,3 +181,22 @@ test("app registry dispatches evaluation and final state through definitions", (
     assert.equal((finalState as { app?: string }).app, app);
   }
 });
+
+test("notes final state retains a consistency digest without exposing note bodies", () => {
+  const session = makeSession("notes-lite");
+  session.state.notes = [{
+    id: "note-private",
+    title: "Release handoff",
+    body: "Private carried policy answer",
+    tag: "handoff",
+    createdAt: "2026-06-01T00:00:00.000Z",
+  }];
+
+  const finalState = buildFinalState(session) as {
+    notes: Array<Record<string, unknown>>;
+  };
+  assert.match(String(finalState.notes[0]?.bodyDigest), /^[0-9a-f]{64}$/);
+  assert.equal(finalState.notes[0]?.bodyLength, 29);
+  assert.equal("body" in finalState.notes[0]!, false);
+  assert.equal(JSON.stringify(finalState).includes("Private carried policy answer"), false);
+});

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -58,7 +58,7 @@ performed prerequisite actions out of order.
 
 ## Independent Suite Versioning
 
-The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.10` and `hosted-web-hard-suite-v1.0.4`). A change to a hard variant, the hard pool composition, a hard cross-app chain, or a testcase time limit bumps the affected suite's version and content hash.
+The easy and hard suites version independently. Each carries its own `suiteVersion` and is published as its own immutable revision (`hosted-web-suite-v3.0.10` and `hosted-web-hard-suite-v1.0.5`). A change to a hard variant, the hard pool composition, a hard cross-app chain, or a testcase time limit bumps the affected suite's version and content hash.
 
 This is enforced mechanically: new task-config fields used by hard variants are optional and only inspected when present, and `consistencyChecks` is an optional manifest key that is absent from the easy manifest. The easy catalog's "stable revision identity and content hash" test fails if a hard-suite change leaks into the easy manifest.
 
@@ -70,6 +70,10 @@ The hard suite declares a two-value cross-app chain: the release-lookup answer m
 - A check reads only the agents' own final states, never private `taskConfig`. The matching per-session evaluator stays lenient on the carried field so the carry is enforced only at suite level.
 - Source `sequenceIndex` must precede target; the manifest `superRefine` rejects out-of-order or unknown-task-slug checks.
 - Evidence surfaces only matched values, presence flags, and paths — never the corpus or the private answer contract.
+- Sensitive target fields use `target-digest-matches-source`: hosted-sites
+  persists only a SHA-256 digest of the normalized agent-authored value, and
+  scoring hashes the prior source value for comparison. The full Notes body is
+  never added to final-state evidence or aggregate output.
 
 Orchestrator unit coverage must include the chain succeeding, the carry mismatching, a missing prior output, and a chain-free suite that omits `consistencyChecks` entirely.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -156,16 +156,18 @@ Confidentiality is the gating constraint for the epic: scorer oracle surfaces (v
 | #113 Calendar hard pool | Complete | Conflict-avoidance, shared-window, timezone-overlap, and reschedule variants. |
 | #114 Repo hard pool | Complete | Coherent multi-edit / rename / rollout variants with required messages. |
 | #110 Shopping hard pool | Complete | Stock-aware, compatibility, and coupon constrained-checkout variants. |
-| #115 Cross-app chain | In Progress | Hard v1.0.4 requires the agent to carry two exact wiki answers into a later note's title and body; enforced only by suite-level consistency checks against the agent's own final states. |
+| #115 Cross-app chain | In Progress | Hard v1.0.5 requires the agent to carry two exact wiki answers into a later note's title and body; the body is checked through a normalized digest so final evidence stays redacted. |
 | #116 Verification matrix and docs | In Progress | Both suites swept independently by the generic matrix; independent semantic versioning, cross-app consistency, and scorer oracle policy documented. |
-| #140 Hard v1.0.4 scale expansion | In Progress | Expand all six hard pools, add a required workflow spanning at least three sessions, and complete deterministic, confidentiality, browser, and lifecycle verification before publishing v1.0.4. |
+| #140 Hard v1.0.5 lifecycle closure | In Progress | Validate all six expanded hard pools and the three-session workflow through deterministic dev sweeps; publish the digest-backed carry correction without exposing note bodies. |
 
 Each hard variant receives positive, negative, and presentation-invariant matrix coverage in `apps/hosted-sites/tests/unit/variant-matrix.test.ts`, which iterates every published suite. Per-session scoring stays deterministic; suite-level checks live solely in the scoring module (`evaluateSuiteConsistency`) and orchestrator aggregation. The easy and hard suites version and publish independently; a hard-suite change must not alter the easy manifest's content hash.
 
-Issue #140 is the umbrella work item for the unpublished `v1.0.4` revision. The
-revision remains `v1.0.4` while this scope is assembled; affected task and seed
-versions still advance whenever their semantics or fixtures change. Delivery is
-split into four increments:
+Issue #140 is the umbrella work item for the hard expansion. The immutable
+`v1.0.4` release exposed a dev-sweep-only evidence mismatch: Notes redacted the
+body from final state while the suite attempted to read that body directly.
+`v1.0.5` keeps the task semantics and adds digest-backed carry verification;
+affected task and seed versions still advance whenever their semantics or
+fixtures change. Delivery is split into four increments:
 
 1. Complete the two-value Wiki-to-Notes carry chain and its fail-closed
    aggregation coverage.
@@ -204,7 +206,7 @@ Exit criteria: the hard suite is published as its own immutable revision, every 
 
 Status: Planned ([#181](https://github.com/Kaiwen0418/agent-benchmark/issues/181))
 
-The current hard v1.0.4 suite is structurally medium-hard: it is strong at
+The current hard v1.0.5 suite is structurally medium-hard: it is strong at
 deterministic multi-step browser execution, exact backend-state scoring,
 ordered mutations, bounded constraint reasoning, and a three-session carry
 chain. Its principal blind spots are conflicting-evidence reconciliation,
@@ -214,7 +216,7 @@ task compositions. This 3/5 structural assessment is provisional until
 repeated representative-agent runs establish empirical pass rates and
 confidence intervals.
 
-P2.3 preserves the immutable v1.0.4 release and builds the next revision as a
+P2.3 preserves the immutable v1.0.5 release and builds the next revision as a
 capability-oriented testbench with independently reported tracks rather than a
 single longer scripted workflow:
 
@@ -230,7 +232,7 @@ single longer scripted workflow:
 
 Delivery is sequenced as follows:
 
-1. Establish the machine-readable capability matrix and calibrate v1.0.4 with
+1. Establish the machine-readable capability matrix and calibrate v1.0.5 with
    repeated runs from at least three representative agent families.
 2. Add generic private scenario-graph, deterministic fault-schedule, scoring,
    and per-capability result contracts before app-specific implementations.
@@ -251,7 +253,7 @@ Exit criteria: every scored capability maps to at least two independent
 variants; the suite includes at least four tracks, two new task surfaces, and
 one deterministic branching campaign; recoverable-failure and privacy canary
 tests pass without oracle leakage; representative-agent repeated-seed results
-show a statistically supported difficulty increase over v1.0.4; historical
+show a statistically supported difficulty increase over v1.0.5; historical
 easy and hard content hashes remain unchanged; and catalog checks, browser E2E,
 Docker-backed lifecycle smoke, and `pnpm verify:ci` are green.
 

--- a/packages/scoring/src/index.ts
+++ b/packages/scoring/src/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 
 export const hostedWebEvaluatorTypeSchema = z.enum([
@@ -51,7 +52,11 @@ export type HostedWebSuiteSessionScore = z.infer<typeof hostedWebSuiteSessionSco
 // own session final states (never private task config), so no hidden answer key
 // is involved — only "did the value the agent produced in session A reappear in
 // session B".
-export const suiteConsistencyRuleSchema = z.enum(["equal-normalized", "target-contains-source"]);
+export const suiteConsistencyRuleSchema = z.enum([
+  "equal-normalized",
+  "target-contains-source",
+  "target-digest-matches-source",
+]);
 
 export type SuiteConsistencyRule = z.infer<typeof suiteConsistencyRuleSchema>;
 
@@ -198,6 +203,10 @@ function normalizeConsistencyValue(value: string): string {
   return value.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
+export function createConsistencyDigest(value: string): string {
+  return createHash("sha256").update(normalizeConsistencyValue(value)).digest("hex");
+}
+
 // Resolve a dotted path against a session final state, returning every string
 // value reachable. A `[]` segment fans out across array elements, so a path
 // like `notes[].title` yields the title of every note. Non-string leaves are
@@ -284,9 +293,14 @@ export function evaluateSuiteConsistency(
     if (check.rule === "equal-normalized") {
       matched =
         sourceValues.find((_, index) => normalizedTargets.includes(normalizedSources[index]!)) ?? null;
-    } else {
+    } else if (check.rule === "target-contains-source") {
       const sourceIndex = normalizedSources.findIndex((source) =>
         normalizedTargets.some((target) => target.includes(source)),
+      );
+      matched = sourceIndex >= 0 ? sourceValues[sourceIndex]! : null;
+    } else {
+      const sourceIndex = sourceValues.findIndex((source) =>
+        normalizedTargets.includes(createConsistencyDigest(source)),
       );
       matched = sourceIndex >= 0 ? sourceValues[sourceIndex]! : null;
     }
@@ -296,7 +310,14 @@ export function evaluateSuiteConsistency(
       ...base,
       status: passed ? ("passed" as const) : ("failed" as const),
       score: passed ? 1 : 0,
-      evidence: { ...evidenceBase, matchedValue: matched },
+      evidence: {
+        ...evidenceBase,
+        // Digest-backed comparison proves carry without persisting or
+        // projecting the complete target note body.
+        ...(check.rule === "target-digest-matches-source"
+          ? { digestMatched: passed }
+          : { matchedValue: matched }),
+      },
       ...(passed
         ? {}
         : {

--- a/packages/scoring/tests/unit/index.test.ts
+++ b/packages/scoring/tests/unit/index.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   aggregateStrictScore,
   aggregateSuiteScore,
+  createConsistencyDigest,
   evaluateSuiteConsistency,
   failedEvaluator,
   passedEvaluator,
@@ -204,6 +205,30 @@ test("evaluateSuiteConsistency equal-normalized ignores case and surrounding whi
     states,
   );
   assert.equal(result!.status, "passed");
+});
+
+test("evaluateSuiteConsistency matches a source value to a redacted target digest", () => {
+  const sourceValue = "  Ninety   Days ";
+  const [result] = evaluateSuiteConsistency(
+    [
+      chain({
+        sourceTaskSlug: "wiki",
+        sourcePath: "answer",
+        targetTaskSlug: "notes",
+        targetPath: "notes[].bodyDigest",
+        rule: "target-digest-matches-source",
+      }),
+    ],
+    new Map<string, unknown>([
+      ["wiki", { answer: sourceValue }],
+      ["notes", { notes: [{ bodyDigest: createConsistencyDigest("ninety days") }] }],
+    ]),
+  );
+
+  assert.equal(result!.status, "passed");
+  assert.equal(result!.evidence?.digestMatched, true);
+  assert.equal("matchedValue" in (result!.evidence ?? {}), false);
+  assert.equal(JSON.stringify(result).includes(sourceValue), false);
 });
 
 test("aggregateSuiteScore folds a failed required consistency check into status and score", () => {

--- a/packages/test-cases/src/schemas.ts
+++ b/packages/test-cases/src/schemas.ts
@@ -13,7 +13,11 @@ export const hostedSuiteConsistencyCheckSchema = z.object({
   sourcePath: z.string().min(1),
   targetTaskSlug: z.string().min(1),
   targetPath: z.string().min(1),
-  rule: z.enum(["equal-normalized", "target-contains-source"]).default("equal-normalized"),
+  rule: z.enum([
+    "equal-normalized",
+    "target-contains-source",
+    "target-digest-matches-source",
+  ]).default("equal-normalized"),
   weight: z.number().nonnegative().default(1),
   required: z.boolean().default(true),
 });

--- a/packages/test-cases/src/suites/hosted-web-hard.ts
+++ b/packages/test-cases/src/suites/hosted-web-hard.ts
@@ -13,7 +13,7 @@ const calendarQuestionVariants = hostedTestcaseApps["calendar-lite"].variantPool
 
 export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   suiteSlug: "hosted-web-hard-suite-v1",
-  suiteVersion: "v1.0.4",
+  suiteVersion: "v1.0.5",
   timeLimitMinutesPerTestcase: 10,
   sessions: [
     {
@@ -126,8 +126,8 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
       sourceTaskSlug: "wiki-policy-answer-hard",
       sourcePath: "latestAnswer.answer",
       targetTaskSlug: "notes-followup-create-hard",
-      targetPath: "notes[].body",
-      rule: "equal-normalized",
+      targetPath: "notes[].bodyDigest",
+      rule: "target-digest-matches-source",
       weight: 1,
       required: true,
     },
@@ -144,7 +144,7 @@ export const hostedWebHardSuiteMetadata = hostedSuiteMetadataSchema.parse({
   ],
 });
 
-export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.4";
+export const hostedWebHardSuiteRevision = "hosted-web-hard-suite-v1.0.5";
 
 export const hostedWebHardSuiteCase = {
   id: "bb7e5cd4-f3ed-4aa0-9fcc-46fec39997eb",

--- a/packages/test-cases/tests/unit/catalog.test.ts
+++ b/packages/test-cases/tests/unit/catalog.test.ts
@@ -85,36 +85,40 @@ test("hard consistency checks reference real sessions with source before target"
   }
 });
 
-test("hard v1.0.4 requires both wiki answers to be carried into distinct note fields", () => {
+test("hard v1.0.5 requires both wiki answers to be carried into distinct note fields", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
-  assert.equal(suite.suiteVersion, "v1.0.4");
+  assert.equal(suite.suiteVersion, "v1.0.5");
   assert.deepEqual(
     suite.consistencyChecks?.map((check) => ({
       sourceTaskSlug: check.sourceTaskSlug,
-      targetPath: check.targetPath,
+        targetPath: check.targetPath,
+        rule: check.rule,
       required: check.required,
     })),
     [
       {
         sourceTaskSlug: "wiki-release-answer-hard",
         targetPath: "notes[].title",
+        rule: "equal-normalized",
         required: true,
       },
       {
         sourceTaskSlug: "wiki-policy-answer-hard",
-        targetPath: "notes[].body",
+        targetPath: "notes[].bodyDigest",
+        rule: "target-digest-matches-source",
         required: true,
       },
       {
         sourceTaskSlug: "notes-followup-create-hard",
         targetPath: "calendarEvents[].title",
+        rule: "equal-normalized",
         required: true,
       },
     ],
   );
 });
 
-test("hard v1.0.4 includes combined-constraint shopping variants on the v2 seed", () => {
+test("hard v1.0.5 includes combined-constraint shopping variants on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const shopping = suite.sessions.find((session) => session.app === "shopping-lite");
   assert.ok(shopping);
@@ -125,7 +129,7 @@ test("hard v1.0.4 includes combined-constraint shopping variants on the v2 seed"
   assert.ok(variantIds.includes("airlite-field-kit"));
 });
 
-test("hard v1.0.4 includes ordered forum escalation on the v2 seed", () => {
+test("hard v1.0.5 includes ordered forum escalation on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const forum = suite.sessions.find((session) => session.app === "forum-lite");
   assert.ok(forum);
@@ -136,7 +140,7 @@ test("hard v1.0.4 includes ordered forum escalation on the v2 seed", () => {
   );
 });
 
-test("hard v1.0.4 includes conflict-aware repo workflow on the v2 seed", () => {
+test("hard v1.0.5 includes conflict-aware repo workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const repo = suite.sessions.find((session) => session.app === "repo-lite");
   assert.ok(repo);
@@ -145,7 +149,7 @@ test("hard v1.0.4 includes conflict-aware repo workflow on the v2 seed", () => {
   assert.ok(repo.metadata.questionVariants.some((variant) => variant.id === "api-v3-conflict-rollout"));
 });
 
-test("hard v1.0.4 includes three-article wiki verification on the v2 seed", () => {
+test("hard v1.0.5 includes three-article wiki verification on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const wikiSessions = suite.sessions.filter((session) => session.app === "wiki-lite");
   assert.ok(wikiSessions.every((session) => session.seedVersion === "wiki-lite-hard-v2"));
@@ -156,7 +160,7 @@ test("hard v1.0.4 includes three-article wiki verification on the v2 seed", () =
   );
 });
 
-test("hard v1.0.4 includes a multi-record notes workflow with a carry handoff", () => {
+test("hard v1.0.5 includes a multi-record notes workflow with a carry handoff", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const notes = suite.sessions.find((session) => session.app === "notes-lite");
   assert.ok(notes);
@@ -168,7 +172,7 @@ test("hard v1.0.4 includes a multi-record notes workflow with a carry handoff", 
   assert.match(rollout.goal, /fourth handoff note/);
 });
 
-test("hard v1.0.4 includes recurring resource calendar workflow on the v2 seed", () => {
+test("hard v1.0.5 includes recurring resource calendar workflow on the v2 seed", () => {
   const suite = hostedSuiteMetadataSchema.parse(hostedWebHardSuiteMetadata);
   const calendar = suite.sessions.find((session) => session.app === "calendar-lite");
   assert.ok(calendar);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -608,10 +608,10 @@ select public.publish_benchmark_case_catalog(
   "metadata": {},
   "isPublic": true
 }$case$::jsonb,
-  'hosted-web-hard-suite-v1.0.4',
+  'hosted-web-hard-suite-v1.0.5',
   $catalog${
   "suiteSlug": "hosted-web-hard-suite-v1",
-  "suiteVersion": "v1.0.4",
+  "suiteVersion": "v1.0.5",
   "timeLimitMinutesPerTestcase": 10,
   "sessions": [
     {
@@ -1406,8 +1406,8 @@ select public.publish_benchmark_case_catalog(
       "sourceTaskSlug": "wiki-policy-answer-hard",
       "sourcePath": "latestAnswer.answer",
       "targetTaskSlug": "notes-followup-create-hard",
-      "targetPath": "notes[].body",
-      "rule": "equal-normalized",
+      "targetPath": "notes[].bodyDigest",
+      "rule": "target-digest-matches-source",
       "weight": 1,
       "required": true
     },
@@ -1423,7 +1423,7 @@ select public.publish_benchmark_case_catalog(
     }
   ]
 }$catalog$::jsonb,
-  'dc793b8caaff6183dc97a8afca5b24eac3fe4e9ff9cc0725b6953f5977095ef2'
+  '4d53f68938c5aaa3004c8ac317d515cf2fb5006698d7e69372b73bc00caea58b'
 );
 
 insert into public.runners (id, name, status, capacity, current_load, last_heartbeat)


### PR DESCRIPTION
## Summary

- add a normalized SHA-256 consistency digest for Notes bodies while keeping the complete body out of final-state evidence
- add a digest-backed cross-session consistency rule and publish the corrected immutable hard suite revision as v1.0.5
- cover digest normalization, redaction, lifecycle aggregation, catalog identity, and generated seed consistency
- update durable scoring and roadmap documentation

## Root cause

The first complete development hard-suite sweep exposed a contract mismatch after every individual session passed. Notes intentionally projected only `bodyLength`, but the suite-level policy carry check attempted to read `notes[].body`. The aggregate therefore failed at 0.9 even for a correct agent run.

This change compares the prior Wiki answer with `notes[].bodyDigest`. The digest is generated from the same normalized form used by scoring; the full Notes body remains absent from final state and public aggregate evidence.

## Verification

- `pnpm --filter @agentbench/scoring test` — 14 passed
- `pnpm --filter hosted-sites test` — 268 passed
- `pnpm --filter hosted-orchestrator test` — 60 passed, 5 Redis environment skips
- `pnpm --filter @agentbench/test-cases test` — 17 passed
- hosted-sites and hosted-orchestrator production builds — passed
- `pnpm catalog:check` — passed
- `pnpm verify:ci` — all static/topology/boundary/consistency stages passed; local Docker-backed Postgres stage could not run because the Docker socket is unavailable and is delegated to GitHub Actions
- development sweep run 29729462433 reproduced the pre-fix aggregate failure (all 7 sessions passed; only the redacted body carry check failed), then was cancelled after the universal root cause was confirmed; the complete 14-job sweep will be rerun after deployment

Closes #140