### PR TITLE
fix(web): rank compatible patch releases together

### DIFF
--- a/apps/web/components/landing/Leaderboard.tsx
+++ b/apps/web/components/landing/Leaderboard.tsx
@@ -12,7 +12,7 @@ async function loadBoards(): Promise<LeaderboardBoard[]> {
     version: item.version,
     tag: item.tag,
     slug: item.slug,
-    entries: await listPublicLeaderboard(20, item.version, item.slug),
+    entries: await listPublicLeaderboard(20, item.versions, item.slug),
   })));
 }
 
@@ -38,7 +38,7 @@ export async function Leaderboard() {
             </h2>
           </div>
           <p className="max-w-xl text-base leading-7 text-[#66625a] lg:justify-self-end">
-            Finished scored runs are ranked within the same benchmark version. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
+            Finished scored runs are ranked within the same major.minor release line. Agent and model identities are self-reported; browser environment and completion time are captured by AgentBench.
           </p>
         </div>
 

--- a/apps/web/components/landing/LeaderboardRanking.tsx
+++ b/apps/web/components/landing/LeaderboardRanking.tsx
@@ -128,19 +128,26 @@ export function LeaderboardRanking({ boards }: { boards: LeaderboardBoard[] }) {
                   <span>{entry.baseModel}</span>
                   <span className="lg:hidden"> · {entry.browser ?? "Unknown browser"} / {entry.platform ?? "Unknown platform"}</span>
                 </div>
-                {entry.status === "completed" ? (
-                  <div className="mt-2 inline-flex rounded-full bg-[#d7ff00]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#d7ff00]">
-                    Finished
-                  </div>
-                ) : entry.status === "timeout" ? (
-                  <div className="mt-2 inline-flex rounded-full bg-[#ffb627]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ffc44d]">
-                    Timed out
-                  </div>
-                ) : entry.status === "failed" ? (
-                  <div className="mt-2 inline-flex rounded-full bg-[#ff8d7a]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ff9f90]">
-                    Failed run
-                  </div>
-                ) : null}
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                  {entry.status === "completed" ? (
+                    <div className="inline-flex rounded-full bg-[#d7ff00]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#d7ff00]">
+                      Finished
+                    </div>
+                  ) : entry.status === "timeout" ? (
+                    <div className="inline-flex rounded-full bg-[#ffb627]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ffc44d]">
+                      Timed out
+                    </div>
+                  ) : entry.status === "failed" ? (
+                    <div className="inline-flex rounded-full bg-[#ff8d7a]/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-[#ff9f90]">
+                      Failed run
+                    </div>
+                  ) : null}
+                  {entry.suiteVersion ? (
+                    <div className="inline-flex rounded-full border border-white/15 px-2 py-0.5 text-[9px] tracking-[0.12em] text-white/45">
+                      {entry.suiteVersion}
+                    </div>
+                  ) : null}
+                </div>
               </div>
               <div className="hidden min-w-0 lg:block">
                 <div className="truncate text-sm text-white/85">{entry.browser ?? "Unknown browser"}</div>

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -15,6 +15,7 @@ import { buildInitialRunMetadata, buildRunMetadataUpdate, parseBrowserEnvironmen
 import { completableRunStatuses, terminalRunStatuses } from "./run-lifecycle";
 import { hostedWebCatalogReleases } from "@agentbench/test-cases/release";
 import type { PublicConsistencyCheck } from "./public-result-consistency";
+import { groupLeaderboardVersions, type LeaderboardVersionCandidate } from "./leaderboard-versions";
 
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
 const DEVELOPMENT_GUEST_RUN_LIMIT = 10;
@@ -741,6 +742,7 @@ export async function getPublicBenchmarkResult(runId: string): Promise<PublicBen
 
 export type LeaderboardVersion = {
   version: string;
+  versions: string[];
   slug: string;
   tag: string;
 };
@@ -765,7 +767,7 @@ export async function listPublicLeaderboardVersions(): Promise<LeaderboardVersio
   const releaseByCaseId = new Map(releases.map((release) => [release.benchmarkCase.id, release]));
 
   const seen = new Set<string>();
-  const versions: LeaderboardVersion[] = [];
+  const versions: LeaderboardVersionCandidate[] = [];
   const tagBySuiteSlug = new Map<string, string>();
 
   for (const item of cases) {
@@ -822,23 +824,18 @@ export async function listPublicLeaderboardVersions(): Promise<LeaderboardVersio
     }
   }
 
-  return versions.sort((left, right) => {
-    if (left.tag !== right.tag) {
-      return right.tag.localeCompare(left.tag);
-    }
-    return right.version.localeCompare(left.version, undefined, { numeric: true, sensitivity: "base" });
-  });
+  return groupLeaderboardVersions(versions);
 }
 
-export async function listPublicLeaderboard(limit = 20, suiteVersion?: string, suiteSlug?: string): Promise<LeaderboardEntry[]> {
+export async function listPublicLeaderboard(limit = 20, suiteVersions?: string[], suiteSlug?: string): Promise<LeaderboardEntry[]> {
   const supabase = getSupabase();
 
   let versionRunIds: string[] | null = null;
-  if (suiteVersion) {
+  if (suiteVersions && suiteVersions.length > 0) {
     let versionAttemptsQuery = supabase
       .from("public_hosted_run_summaries")
       .select("run_id")
-      .eq("suite_version", suiteVersion)
+      .in("suite_version", suiteVersions)
       .limit(1000);
 
     if (suiteSlug) {

--- a/apps/web/lib/leaderboard-versions.ts
+++ b/apps/web/lib/leaderboard-versions.ts
@@ -1,0 +1,88 @@
+export type LeaderboardVersionCandidate = {
+  version: string;
+  slug: string;
+  tag: string;
+};
+
+export type LeaderboardVersionGroup = {
+  version: string;
+  versions: string[];
+  slug: string;
+  tag: string;
+};
+
+type ParsedSuiteVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+function parseSuiteVersion(version: string): ParsedSuiteVersion | null {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(version);
+  if (!match) return null;
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function versionFamily(version: string) {
+  const parsed = parseSuiteVersion(version);
+  if (!parsed) {
+    return { key: `exact:${version}`, label: version };
+  }
+
+  return {
+    key: `${parsed.major}.${parsed.minor}`,
+    label: `v${parsed.major}.${parsed.minor}.x`,
+  };
+}
+
+function compareVersions(left: string, right: string) {
+  const leftParsed = parseSuiteVersion(left);
+  const rightParsed = parseSuiteVersion(right);
+
+  if (leftParsed && rightParsed) {
+    return rightParsed.major - leftParsed.major
+      || rightParsed.minor - leftParsed.minor
+      || rightParsed.patch - leftParsed.patch
+      || right.localeCompare(left, undefined, { numeric: true, sensitivity: "base" });
+  }
+
+  return right.localeCompare(left, undefined, { numeric: true, sensitivity: "base" });
+}
+
+export function groupLeaderboardVersions(candidates: LeaderboardVersionCandidate[]): LeaderboardVersionGroup[] {
+  const groups = new Map<string, LeaderboardVersionGroup>();
+
+  for (const candidate of candidates) {
+    const family = versionFamily(candidate.version);
+    const key = `${candidate.slug}:${family.key}`;
+    const existing = groups.get(key);
+
+    if (existing) {
+      if (!existing.versions.includes(candidate.version)) {
+        existing.versions.push(candidate.version);
+      }
+      continue;
+    }
+
+    groups.set(key, {
+      version: family.label,
+      versions: [candidate.version],
+      slug: candidate.slug,
+      tag: candidate.tag,
+    });
+  }
+
+  return [...groups.values()]
+    .map((group) => ({ ...group, versions: group.versions.sort(compareVersions) }))
+    .sort((left, right) => {
+      if (left.tag !== right.tag) {
+        return right.tag.localeCompare(left.tag);
+      }
+      return compareVersions(left.versions[0] ?? left.version, right.versions[0] ?? right.version);
+    });
+}

--- a/apps/web/tests/unit/leaderboard-versions.test.ts
+++ b/apps/web/tests/unit/leaderboard-versions.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { groupLeaderboardVersions } from "../../lib/leaderboard-versions";
+
+test("groups patch releases from the same major and minor line", () => {
+  const groups = groupLeaderboardVersions([
+    { slug: "hosted-web-hard-suite", version: "v1.0.1", tag: "hard" },
+    { slug: "hosted-web-hard-suite", version: "1.0.3", tag: "hard" },
+    { slug: "hosted-web-hard-suite", version: "v1.0.5", tag: "hard" },
+  ]);
+
+  assert.deepEqual(groups, [{
+    slug: "hosted-web-hard-suite",
+    version: "v1.0.x",
+    versions: ["v1.0.5", "1.0.3", "v1.0.1"],
+    tag: "hard",
+  }]);
+});
+
+test("keeps different major or minor release lines on separate boards", () => {
+  const groups = groupLeaderboardVersions([
+    { slug: "hosted-web-hard-suite", version: "v1.0.5", tag: "hard" },
+    { slug: "hosted-web-hard-suite", version: "v1.1.0", tag: "hard" },
+    { slug: "hosted-web-hard-suite", version: "v2.0.0", tag: "hard" },
+  ]);
+
+  assert.deepEqual(groups.map((group) => group.version), ["v2.0.x", "v1.1.x", "v1.0.x"]);
+});
+
+test("keeps legacy and malformed versions exact instead of guessing compatibility", () => {
+  const groups = groupLeaderboardVersions([
+    { slug: "hosted-web-suite", version: "v1", tag: "easy" },
+    { slug: "hosted-web-suite", version: "1.03", tag: "easy" },
+    { slug: "hosted-web-suite", version: "v1", tag: "easy" },
+  ]);
+
+  assert.deepEqual(groups.map((group) => ({ version: group.version, versions: group.versions })), [
+    { version: "v1", versions: ["v1"] },
+    { version: "1.03", versions: ["1.03"] },
+  ]);
+});
+
+test("does not combine the same release line across different suite slugs", () => {
+  const groups = groupLeaderboardVersions([
+    { slug: "hosted-web-hard-suite", version: "v1.0.5", tag: "hard" },
+    { slug: "hosted-web-suite", version: "v1.0.4", tag: "easy" },
+  ]);
+
+  assert.equal(groups.length, 2);
+  assert.deepEqual(groups.map((group) => group.slug), ["hosted-web-hard-suite", "hosted-web-suite"]);
+});

--- a/docs/benchmark-spec.md
+++ b/docs/benchmark-spec.md
@@ -65,6 +65,8 @@ Changing seed data, success conditions, task wording that affects behavior, or a
 
 Hosted suite releases use `v<major>.<minor>.<patch>` for `suiteVersion` and mirror that value in the revision name, for example `hosted-web-suite-v3.0.1`.
 
+Public leaderboard comparability follows the suite slug and `major.minor` release line. Patch releases such as `v1.0.1`, `v1.0.3`, and `v1.0.5` share one ranking while each result retains its exact executed version. Different major or minor lines remain separate, and legacy versions that do not match the hosted suite version format are ranked only against the same exact version.
+
 - Increment the patch version for small compatible testcase additions, new app sessions, extra variants, wording clarifications that preserve semantics, and scorer fixes that do not redefine historical intent.
 - Increment the minor version only for large batch updates, broad suite composition changes, or material scoring/task semantics changes that still belong to the same major benchmark line.
 - Increment the major version only when the project owner explicitly requests a new major suite line.


### PR DESCRIPTION
## Summary

- group leaderboard results by suite slug and SemVer major.minor release line
- preserve and display each result exact patch version
- show release-family labels such as v1.0.x in the leaderboard selector
- keep different major/minor lines and malformed legacy versions isolated

## Root cause

The leaderboard selector and query filtered on the complete suite_version value, so compatible patch releases were split across separate rankings.

## Verification

- pnpm --filter web test (61/61)
- pnpm --filter web exec tsc --noEmit
- pnpm --filter web build
- pnpm --filter @agentbench/test-cases test
- pnpm catalog:check
- scoring, hosted-sites, and hosted-orchestrator builds
- desktop and 390x844 browser checks for version selection, patch labels, combined ranking, and pagination
- pnpm verify:ci completed repository static checks but could not run Docker-backed PostgreSQL/Redis integration because the local Docker daemon is unavailable

No issue: this is a bounded leaderboard compatibility fix.