### PR TITLE
fix(benchmark): honor optional capability score

### DIFF
--- a/scripts/test-hosted-variant-sweep.sh
+++ b/scripts/test-hosted-variant-sweep.sh
@@ -36,6 +36,8 @@ require_text "${SMOKE}" 'BENCHMARK_CASE_SLUG="${BENCHMARK_CASE_SLUG:-hosted-web-
 require_text "${SMOKE}" 'slug: `eq.${benchmarkCaseSlug}`'
 require_text "${SMOKE}" 'redirect: "manual"'
 require_text "${SMOKE}" 'return checkedFetch(new URL(location, formUrl));'
+require_text "${SMOKE}" 'const minimumScore = minimumFullPassScore(revisionManifest);'
+require_text "${SMOKE}" 'aggregateScore < minimumScore'
 require_text "${WORKFLOW}" 'gh workflow run hosted-variant-sweep.yml --ref develop --repo "${GITHUB_REPOSITORY}"'
 require_text "${WORKFLOW}" 'benchmark_case_slug:'
 require_text "${WORKFLOW}" '          - hosted-web-suite'

--- a/tests/e2e/hosted-lifecycle-smoke.sh
+++ b/tests/e2e/hosted-lifecycle-smoke.sh
@@ -234,6 +234,23 @@ function normalizedSessions(benchmarkCase) {
   };
 }
 
+function minimumFullPassScore(manifest) {
+  if (!("capabilityMatrix" in manifest)) return 1;
+  const matrix = requireObject(manifest.capabilityMatrix, "capability matrix");
+  if (!Array.isArray(matrix.dimensions)) {
+    throw new Error("Capability matrix dimensions must be an array.");
+  }
+  const optionalWeight = matrix.dimensions.reduce((sum, value, index) => {
+    const dimension = requireObject(value, `capability dimension ${index}`);
+    if (dimension.required !== false) return sum;
+    if (typeof dimension.weight !== "number" || !Number.isFinite(dimension.weight)) {
+      throw new Error(`Capability dimension ${index} weight must be finite.`);
+    }
+    return sum + dimension.weight;
+  }, 0);
+  return Number((1 - optionalWeight).toFixed(4));
+}
+
 function generatedConfig(sessionRows, sequenceIndex) {
   const session = sessionRows.find((candidate) => candidate.sequence_index === sequenceIndex);
   const generation = requireObject(
@@ -467,8 +484,20 @@ async function main() {
   if (scoreRows.length !== 1) {
     throw new Error(`Expected one aggregate attempt score, got ${scoreRows.length}.`);
   }
-  if (smokeMode === "full-pass" && (scoreRows[0].status !== "passed" || Number(scoreRows[0].score) !== 1)) {
-    throw new Error(`Expected a passing aggregate score, got ${JSON.stringify(scoreRows[0])}.`);
+  const aggregateScore = Number(scoreRows[0].score);
+  const minimumScore = minimumFullPassScore(revisionManifest);
+  if (
+    smokeMode === "full-pass"
+    && (
+      scoreRows[0].status !== "passed"
+      || !Number.isFinite(aggregateScore)
+      || aggregateScore < minimumScore
+      || aggregateScore > 1
+    )
+  ) {
+    throw new Error(
+      `Expected a passing aggregate score in [${minimumScore}, 1], got ${JSON.stringify(scoreRows[0])}.`,
+    );
   }
 
   const selectedVariants = sessionRows


### PR DESCRIPTION
## Summary
- derive the full-pass score floor from non-gating capability dimensions
- retain strict passed status and normalized score bounds
- prevent the sweep from treating expected interaction-cost deductions as lifecycle failures

## Verification
- `pnpm verify:ci`
- `bash -n tests/e2e/hosted-lifecycle-smoke.sh`
- `bash scripts/test-hosted-variant-sweep.sh`
- hard v1.1.0 seed 919 completed with passed status and score 0.95

Refs #181