### PR TITLE
fix(inbox): normalize consistency digests

### DIFF
--- a/apps/hosted-sites/src/apps/inbox-lite/final-state.ts
+++ b/apps/hosted-sites/src/apps/inbox-lite/final-state.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { createConsistencyDigest } from "@agentbench/scoring";
 import type { HostedSessionFor } from "../../runtime/types.js";
 
 function digest(value: string) {
@@ -14,7 +15,7 @@ export function buildInboxLiteFinalState(session: HostedSessionFor<"inbox-lite">
       threadId: message.threadId,
       recipientCount: message.recipients.length,
       subjectDigest: digest(message.subject),
-      bodyDigest: digest(message.body),
+      bodyDigest: createConsistencyDigest(message.body),
       revisionCount: message.revisionCount,
     })),
     safetyViolationCount: session.state.inboxSafetyViolations.length,

--- a/apps/hosted-sites/tests/unit/apps/inbox-lite.test.ts
+++ b/apps/hosted-sites/tests/unit/apps/inbox-lite.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createConsistencyDigest } from "@agentbench/scoring";
 import {
   recheckInboxPolicy,
   saveInboxDraft,
@@ -133,11 +134,16 @@ test("inbox blocks prohibited recipients and public final state contains only di
   assert.equal(saved.success, true);
   if (!saved.success) return;
   sendInboxDraft(cleanSession, { draftId: saved.draft.id, now: actionDeps.now });
-  const serialized = JSON.stringify(buildInboxLiteFinalState(cleanSession));
+  const finalState = buildInboxLiteFinalState(cleanSession);
+  const serialized = JSON.stringify(finalState);
   assert.equal(serialized.includes(taskConfig.expectedRecipients[0]!), false);
   assert.equal(serialized.includes(taskConfig.expectedBody), false);
   assert.equal(serialized.includes(taskConfig.forbiddenValues[0]!), false);
   assert.match(serialized, /[0-9a-f]{64}/);
+  assert.equal(
+    finalState.sentMessages[0]?.bodyDigest,
+    createConsistencyDigest(taskConfig.expectedBody),
+  );
 });
 
 test("inbox campaign accepts a non-empty carried body for suite-level verification", () => {


### PR DESCRIPTION
## Summary
- use the shared normalized consistency digest for Inbox message bodies
- keep sent body contents private while matching case/whitespace-normalized wiki outputs
- add exact mixed-case digest regression coverage

## Verification
- `pnpm --filter hosted-sites test` (278 passed)
- `pnpm verify:ci`
- diagnosed from hard v1.1.0 seed 611 aggregate evidence

Refs #181