### PR TITLE
feat(web): expose development calibration controls

### DIFF
--- a/apps/web/app/api/benchmark-cases/route.ts
+++ b/apps/web/app/api/benchmark-cases/route.ts
@@ -1,10 +1,24 @@
 import { NextResponse } from "next/server";
-import { listPublicHostedBenchmarkCases } from "@/lib/db";
+import {
+  listCalibrationBenchmarkRevisions,
+  listPublicHostedBenchmarkCases,
+} from "@/lib/db";
+import { isCalibrationControlsEnabled } from "@/lib/calibration";
 
 export async function GET() {
   try {
     const cases = await listPublicHostedBenchmarkCases();
-    return NextResponse.json({ cases });
+    if (!isCalibrationControlsEnabled()) {
+      return NextResponse.json({ cases, calibration: { enabled: false } });
+    }
+
+    const revisions = await listCalibrationBenchmarkRevisions(
+      cases.map((benchmarkCase) => benchmarkCase.id),
+    );
+    return NextResponse.json({
+      cases,
+      calibration: { enabled: true, revisions },
+    });
   } catch (error) {
     console.error("[web] failed to list benchmark cases", error);
     return NextResponse.json(

--- a/apps/web/app/api/runs/route.ts
+++ b/apps/web/app/api/runs/route.ts
@@ -8,10 +8,38 @@ import {
 } from "@/lib/auth";
 import { BenchmarkCaseUnavailableError, createBenchmarkRun, getQuotaStatus } from "@/lib/db";
 import { captureBrowserEnvironment } from "@/lib/run-metadata";
+import { isCalibrationControlsEnabled } from "@/lib/calibration";
 
 export async function POST(request: Request) {
-  const json = await request.json();
-  const input = createRunInputSchema.parse(json);
+  const json = await request.json().catch(() => null);
+  const parsedInput = createRunInputSchema.safeParse(json);
+  if (!parsedInput.success) {
+    return NextResponse.json(
+      { error: "invalid_request", message: "Run configuration is invalid." },
+      { status: 400 },
+    );
+  }
+  const input = parsedInput.data;
+  const hasCalibrationRevision = input.caseRevisionId !== undefined;
+  const hasCalibrationSeed = input.generationSeed !== undefined;
+  if (hasCalibrationRevision !== hasCalibrationSeed) {
+    return NextResponse.json(
+      {
+        error: "invalid_calibration",
+        message: "Calibration revision and generation seed must be provided together.",
+      },
+      { status: 400 },
+    );
+  }
+  if ((hasCalibrationRevision || hasCalibrationSeed) && !isCalibrationControlsEnabled()) {
+    return NextResponse.json(
+      {
+        error: "calibration_unavailable",
+        message: "Calibration controls are available only in development deployments.",
+      },
+      { status: 403 },
+    );
+  }
   const user = await getCurrentUser();
   const guest = user ? null : await getOrCreateGuestId();
   let quota;
@@ -77,6 +105,12 @@ export async function POST(request: Request) {
       isPublic: input.isPublic,
       agent: input.agent,
       browserEnvironment: captureBrowserEnvironment(request.headers),
+      calibration: input.caseRevisionId && input.generationSeed
+        ? {
+            caseRevisionId: input.caseRevisionId,
+            generationSeed: input.generationSeed,
+          }
+        : undefined,
     });
   } catch (error) {
     if (error instanceof BenchmarkCaseUnavailableError) {

--- a/apps/web/components/landing/ConnectAgentCard.tsx
+++ b/apps/web/components/landing/ConnectAgentCard.tsx
@@ -10,6 +10,10 @@ import { SuiteTag } from "@/components/ui/SuiteTag";
 export function ConnectAgentCard() {
   const benchmark = usePlaygroundStore((state) => state.benchmark);
   const benchmarks = usePlaygroundStore((state) => state.benchmarks);
+  const calibrationEnabled = usePlaygroundStore((state) => state.calibrationEnabled);
+  const calibrationRevisions = usePlaygroundStore((state) => state.calibrationRevisions);
+  const calibrationRevisionId = usePlaygroundStore((state) => state.calibrationRevisionId);
+  const calibrationSeed = usePlaygroundStore((state) => state.calibrationSeed);
   const currentRunId = usePlaygroundStore((state) => state.currentRunId);
   const phase = usePlaygroundStore((state) => state.phase);
   const quota = usePlaygroundStore((state) => state.quota);
@@ -17,6 +21,8 @@ export function ConnectAgentCard() {
   const runError = usePlaygroundStore((state) => state.runError);
   const score = usePlaygroundStore((state) => state.score);
   const setBenchmark = usePlaygroundStore((state) => state.setBenchmark);
+  const setCalibrationRevisionId = usePlaygroundStore((state) => state.setCalibrationRevisionId);
+  const setCalibrationSeed = usePlaygroundStore((state) => state.setCalibrationSeed);
   const fetchQuota = usePlaygroundStore((state) => state.fetchQuota);
   const fetchBenchmarks = usePlaygroundStore((state) => state.fetchBenchmarks);
   const resumeRun = usePlaygroundStore((state) => state.resumeRun);
@@ -28,6 +34,19 @@ export function ConnectAgentCard() {
   const isDone = phase === "completed" || phase === "failed";
   const isQuotaBlocked = Boolean(quota && quota.remaining <= 0);
   const selectedBenchmark = benchmarks.find((item) => item.id === benchmark);
+  const selectedRevision = calibrationRevisions.find((revision) => (
+    revision.caseId === benchmark
+    && revision.revisionId === calibrationRevisionId
+  ));
+  const selectedCaseRevisions = calibrationRevisions.filter((revision) => (
+    revision.caseId === benchmark
+  ));
+  const isCalibrationBlocked = Boolean(
+    calibrationEnabled
+    && selectedRevision
+    && !selectedRevision.current
+    && !calibrationSeed.trim(),
+  );
 
   useEffect(() => {
     void fetchQuota();
@@ -182,6 +201,55 @@ export function ConnectAgentCard() {
           {selectedBenchmark?.description ?? "Loading available benchmark suites…"}
         </div>
 
+        {calibrationEnabled && selectedCaseRevisions.length > 0 ? (
+          <div className="rounded-[1.15rem] border border-[#c9c1b3] bg-white p-3.5">
+            <div className="mb-3">
+              <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-[#70695e]">
+                Development calibration
+              </div>
+              <p className="mt-1 text-[12px] leading-5 text-[#777064]">
+                Choose an immutable revision and enter a repeatable seed. Calibration results remain public and ranked.
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] text-[#5d574d]">Suite revision</span>
+                <SiteSelect
+                  value={calibrationRevisionId}
+                  onValueChange={setCalibrationRevisionId}
+                  ariaLabel="Suite revision"
+                  options={selectedCaseRevisions.map((revision) => ({
+                    value: revision.revisionId,
+                    label: `${revision.version}${revision.current ? " · current" : ""}`,
+                  }))}
+                  compact
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1.5 block text-[12px] text-[#5d574d]">Generation seed</span>
+                <input
+                  type="text"
+                  value={calibrationSeed}
+                  onChange={(event) => setCalibrationSeed(event.target.value)}
+                  maxLength={120}
+                  pattern="[A-Za-z0-9][A-Za-z0-9._:-]*"
+                  placeholder="e.g. calibration-01"
+                  aria-label="Generation seed"
+                  className="w-full rounded-[0.6rem] border border-[#d8d1c4] bg-white px-3.5 py-2.5 text-sm text-[#111111] outline-none transition placeholder:text-[#9a9388] focus:border-[#111111]"
+                />
+              </label>
+            </div>
+
+            <p className="mt-2 text-[11px] leading-5 text-[#8a4334]">
+              {isCalibrationBlocked
+                ? "A historical revision requires a seed."
+                : "Leave the seed blank to start a normal run on the current revision."}
+            </p>
+          </div>
+        ) : null}
+
         <p className="text-[12px] leading-5 text-[#777064]">
           Agent identity, model, and optional metadata are registered on the connection page after the run is created.
         </p>
@@ -195,7 +263,7 @@ export function ConnectAgentCard() {
         <button
           type="button"
           onClick={() => void startRun("external-agent")}
-          disabled={quotaLoading || isQuotaBlocked || !benchmark}
+          disabled={quotaLoading || isQuotaBlocked || !benchmark || isCalibrationBlocked}
           className="w-full rounded-full bg-[#111111] px-5 py-3 text-sm font-medium text-white transition hover:bg-[#d7ff00] hover:text-[#111111] disabled:cursor-not-allowed disabled:opacity-70"
         >
           {isQuotaBlocked

--- a/apps/web/lib/calibration.ts
+++ b/apps/web/lib/calibration.ts
@@ -1,0 +1,40 @@
+import type { BenchmarkRun } from "@agentbench/protocol";
+
+export type CalibrationRunSelection = {
+  caseRevisionId: string;
+  generationSeed: string;
+};
+
+type DeploymentEnvironment = {
+  NODE_ENV?: string;
+  VERCEL_ENV?: string;
+  VERCEL_GIT_COMMIT_REF?: string;
+};
+
+export function isCalibrationControlsEnabled(
+  environment: DeploymentEnvironment = process.env,
+) {
+  return environment.NODE_ENV === "development"
+    || environment.VERCEL_ENV === "preview"
+    || environment.VERCEL_GIT_COMMIT_REF === "develop";
+}
+
+export function readCalibrationRunSelection(
+  run: Pick<BenchmarkRun, "metadata">,
+): CalibrationRunSelection | null {
+  const calibration = run.metadata?.calibration;
+  if (!calibration || typeof calibration !== "object" || Array.isArray(calibration)) {
+    return null;
+  }
+
+  const candidate = calibration as Record<string, unknown>;
+  return typeof candidate.caseRevisionId === "string"
+    && typeof candidate.generationSeed === "string"
+    && candidate.caseRevisionId.length > 0
+    && candidate.generationSeed.length > 0
+    ? {
+        caseRevisionId: candidate.caseRevisionId,
+        generationSeed: candidate.generationSeed,
+      }
+    : null;
+}

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -14,8 +14,10 @@ import { createSupabaseAdminClient } from "./supabase/admin";
 import { buildInitialRunMetadata, buildRunMetadataUpdate, parseBrowserEnvironment } from "./run-metadata";
 import { completableRunStatuses, terminalRunStatuses } from "./run-lifecycle";
 import { hostedWebCatalogReleases } from "@agentbench/test-cases/release";
+import { hostedSuiteMetadataSchema } from "@agentbench/test-cases";
 import type { PublicConsistencyCheck } from "./public-result-consistency";
 import { groupLeaderboardVersions, type LeaderboardVersionCandidate } from "./leaderboard-versions";
+import { isCalibrationControlsEnabled, type CalibrationRunSelection } from "./calibration";
 
 const PRODUCTION_GUEST_RUN_LIMIT = 1;
 const DEVELOPMENT_GUEST_RUN_LIMIT = 10;
@@ -33,7 +35,7 @@ function getGuestRunLimit() {
     return configuredLimit;
   }
 
-  return process.env.VERCEL_ENV === "preview" || process.env.VERCEL_GIT_COMMIT_REF === "develop"
+  return isCalibrationControlsEnabled()
     ? DEVELOPMENT_GUEST_RUN_LIMIT
     : PRODUCTION_GUEST_RUN_LIMIT;
 }
@@ -135,6 +137,14 @@ export type PublicBenchmarkCase = Pick<
   "id" | "slug" | "title" | "description" | "difficulty"
 > & { tag: string; version: string };
 
+export type CalibrationBenchmarkRevision = {
+  caseId: string;
+  revisionId: string;
+  revision: string;
+  version: string;
+  current: boolean;
+};
+
 // Display-safe projection for the public suite picker. Deliberately omits
 // `metadata` and `current_revision_id` so scorer-oracle surfaces never leak to
 // unauthenticated clients. `difficulty` is exposed as the suite tag and the
@@ -169,6 +179,75 @@ export async function listPublicHostedBenchmarkCases(): Promise<PublicBenchmarkC
       version: release?.manifest.suiteVersion ?? "",
     };
   });
+}
+
+export async function listCalibrationBenchmarkRevisions(
+  caseIds: string[],
+): Promise<CalibrationBenchmarkRevision[]> {
+  if (caseIds.length === 0) {
+    return [];
+  }
+
+  const supabase = getSupabase();
+  const [caseRows, revisionRows] = await Promise.all([
+    supabase
+      .from("benchmark_cases")
+      .select("id, current_revision_id")
+      .in("id", caseIds)
+      .eq("is_public", true)
+      .eq("provider", "hosted-web"),
+    supabase
+      .from("benchmark_case_revisions")
+      .select("id, case_id, revision, manifest, created_at")
+      .in("case_id", caseIds)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (caseRows.error || !caseRows.data) {
+    throw caseRows.error ?? new Error("Failed to load benchmark case revisions");
+  }
+  if (revisionRows.error || !revisionRows.data) {
+    throw revisionRows.error ?? new Error("Failed to load benchmark case revisions");
+  }
+
+  const currentByCaseId = new Map(
+    caseRows.data.map((row) => [row.id, row.current_revision_id]),
+  );
+
+  return revisionRows.data.flatMap((row) => {
+    if (!currentByCaseId.has(row.case_id)) {
+      return [];
+    }
+    const manifest = hostedSuiteMetadataSchema.safeParse(row.manifest);
+    if (!manifest.success) {
+      return [];
+    }
+    return [{
+      caseId: row.case_id,
+      revisionId: row.id,
+      revision: row.revision,
+      version: manifest.data.suiteVersion,
+      current: currentByCaseId.get(row.case_id) === row.id,
+    }];
+  });
+}
+
+async function isAvailableCalibrationRevision(
+  caseId: string,
+  caseRevisionId: string,
+) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("benchmark_case_revisions")
+    .select("id")
+    .eq("id", caseRevisionId)
+    .eq("case_id", caseId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+  return Boolean(data);
 }
 
 export async function getBenchmarkCase(caseId: string): Promise<BenchmarkCase | null> {  const supabase = getSupabase();
@@ -290,10 +369,20 @@ export async function createBenchmarkRun(params: {
   isPublic: boolean;
   agent?: BenchmarkRun["agent"];
   browserEnvironment: NonNullable<BenchmarkRun["browserEnvironment"]>;
+  calibration?: CalibrationRunSelection;
 }): Promise<BenchmarkRun> {
   const supabase = getSupabase();
   const benchmarkCase = await getBenchmarkCase(params.caseId);
   if (!isRunnableBenchmarkCase(benchmarkCase)) {
+    throw new BenchmarkCaseUnavailableError();
+  }
+  if (
+    params.calibration
+    && !await isAvailableCalibrationRevision(
+      benchmarkCase.id,
+      params.calibration.caseRevisionId,
+    )
+  ) {
     throw new BenchmarkCaseUnavailableError();
   }
   const initialStatus = params.executionMode === "external-agent" ? "waiting_for_agent" : "queued";
@@ -301,6 +390,9 @@ export async function createBenchmarkRun(params: {
     agent: params.agent ?? undefined,
     browserEnvironment: params.browserEnvironment,
     now: new Date().toISOString(),
+    serverMetadata: params.calibration
+      ? { calibration: params.calibration }
+      : undefined,
   });
 
   const { data, error } = await supabase
@@ -328,6 +420,7 @@ export async function createBenchmarkRun(params: {
       status: initialStatus,
       executionMode: params.executionMode,
       agent: params.agent ?? null,
+      calibration: Boolean(params.calibration),
     },
   });
 

--- a/apps/web/lib/hosted-web.ts
+++ b/apps/web/lib/hosted-web.ts
@@ -6,6 +6,7 @@ import type {
 } from "@agentbench/protocol";
 import { hostedAttemptConnectionSnapshotSchema } from "@agentbench/protocol";
 import { buildHostedAttemptReadModel } from "@agentbench/shared";
+import { readCalibrationRunSelection } from "./calibration";
 
 type HostedSessionStatus = "created" | "active" | "completed" | "failed" | "expired";
 
@@ -296,12 +297,15 @@ async function getOrCreateHostedWebAttempt(params: {
   run: BenchmarkRun;
   benchmarkCase: BenchmarkCase;
 }) {
-  if (!params.benchmarkCase.currentRevisionId) {
+  const calibration = readCalibrationRunSelection(params.run);
+  const caseRevisionId = calibration?.caseRevisionId
+    ?? params.benchmarkCase.currentRevisionId;
+  if (!caseRevisionId) {
     throw new Error("Hosted benchmark case has no current revision.");
   }
   return {
     id: null,
-    caseRevisionId: params.benchmarkCase.currentRevisionId,
+    caseRevisionId,
     suiteSlug: params.benchmarkCase.slug,
     suiteVersion: "current",
     sessionDefinitions: [],
@@ -317,7 +321,11 @@ export async function recoverExistingHostedWebAttemptConnection(params: {
   const requestUrl = new URL(resolveHostedUrl(baseUrl, "/api/attempts/connection"));
   requestUrl.searchParams.set("runId", params.run.id);
   requestUrl.searchParams.set("caseId", params.benchmarkCase.id);
-  requestUrl.searchParams.set("caseRevisionId", params.benchmarkCase.currentRevisionId ?? "");
+  const calibration = readCalibrationRunSelection(params.run);
+  const caseRevisionId = calibration?.caseRevisionId
+    ?? params.benchmarkCase.currentRevisionId
+    ?? "";
+  requestUrl.searchParams.set("caseRevisionId", caseRevisionId);
 
   let response: Response;
   try {
@@ -351,7 +359,7 @@ export async function recoverExistingHostedWebAttemptConnection(params: {
   return toAttemptConnection({
     attempt: {
       id: snapshot.attemptId,
-      caseRevisionId: params.benchmarkCase.currentRevisionId,
+      caseRevisionId,
       suiteSlug: snapshot.suiteSlug,
       suiteVersion: snapshot.suiteVersion,
       sessionDefinitions: [],
@@ -377,12 +385,14 @@ export function buildHostedAttemptInitPayload(params: {
   caseId: string;
   caseRevisionId: string | null;
   callbackSecret: string;
+  generationSeed?: string;
 }) {
   return {
     runId: params.runId,
     caseId: params.caseId,
     caseRevisionId: params.caseRevisionId,
     callbackSecret: params.callbackSecret,
+    ...(params.generationSeed ? { generationSeed: params.generationSeed } : {}),
   };
 }
 
@@ -408,6 +418,7 @@ async function initializeHostedWebAttempt(params: {
         caseId: params.benchmarkCase.id,
         caseRevisionId: params.attempt.caseRevisionId,
         callbackSecret: runnerSecret,
+        generationSeed: readCalibrationRunSelection(params.run)?.generationSeed,
       })),
       cache: "no-store",
     });

--- a/apps/web/lib/playground-store.ts
+++ b/apps/web/lib/playground-store.ts
@@ -28,6 +28,14 @@ export type BenchmarkOption = {
   version: string;
 };
 
+export type CalibrationRevisionOption = {
+  caseId: string;
+  revisionId: string;
+  revision: string;
+  version: string;
+  current: boolean;
+};
+
 export type RunPhase = "idle" | "booting" | "running" | "completed" | "failed";
 export type PanelTab = "events" | "files" | "screenshots" | "score";
 
@@ -53,6 +61,10 @@ type PlaygroundStore = {
   benchmark: PlaygroundBenchmark;
   benchmarks: BenchmarkOption[];
   benchmarksLoading: boolean;
+  calibrationEnabled: boolean;
+  calibrationRevisions: CalibrationRevisionOption[];
+  calibrationRevisionId: string;
+  calibrationSeed: string;
   currentRunId: string | null;
   currentExecutionMode: RunExecutionMode | null;
   liveViewUrl: string | null;
@@ -75,6 +87,8 @@ type PlaygroundStore = {
   setEndpoint: (value: string) => void;
   setApiKey: (value: string) => void;
   setBenchmark: (value: PlaygroundBenchmark) => void;
+  setCalibrationRevisionId: (value: string) => void;
+  setCalibrationSeed: (value: string) => void;
   setActiveTab: (value: PanelTab) => void;
   setLiveSlide: (index: number) => void;
   fetchQuota: () => Promise<void>;
@@ -97,6 +111,10 @@ const initialState = {
   benchmark: "" as PlaygroundBenchmark,
   benchmarks: [] as BenchmarkOption[],
   benchmarksLoading: false,
+  calibrationEnabled: false,
+  calibrationRevisions: [] as CalibrationRevisionOption[],
+  calibrationRevisionId: "",
+  calibrationSeed: "",
   currentRunId: null,
   currentExecutionMode: null,
   liveViewUrl: null,
@@ -479,6 +497,10 @@ async function requestBenchmarks() {
 
   return (await response.json()) as {
     cases: Array<{ id: string; slug: string; title: string; description: string; difficulty: string; tag: string; version: string }>;
+    calibration?: {
+      enabled: boolean;
+      revisions?: CalibrationRevisionOption[];
+    };
   };
 }
 
@@ -595,7 +617,15 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
   ...initialState,
   setEndpoint: (value) => set({ endpoint: value }),
   setApiKey: (value) => set({ apiKey: value }),
-  setBenchmark: (value) => set({ benchmark: value }),
+  setBenchmark: (value) => set((state) => ({
+    benchmark: value,
+    calibrationRevisionId:
+      state.calibrationRevisions.find((revision) => (
+        revision.caseId === value && revision.current
+      ))?.revisionId ?? "",
+  })),
+  setCalibrationRevisionId: (value) => set({ calibrationRevisionId: value }),
+  setCalibrationSeed: (value) => set({ calibrationSeed: value }),
   setActiveTab: (value) => set({ activeTab: value }),
   setLiveSlide: (index) => set({ liveSlide: index }),
   fetchQuota: async () => {
@@ -625,10 +655,18 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
       // The backend orders suites with the default (hard) first; the frontend
       // simply selects the first option without hardcoding any tag.
       const defaultBenchmark = benchmarks[0]?.id ?? "";
+      const calibrationRevisions = result.calibration?.revisions ?? [];
       set((state) => ({
         benchmarks,
         benchmarksLoading: false,
         benchmark: state.benchmark || defaultBenchmark,
+        calibrationEnabled: result.calibration?.enabled === true,
+        calibrationRevisions,
+        calibrationRevisionId:
+          calibrationRevisions.find((revision) => (
+            revision.caseId === (state.benchmark || defaultBenchmark)
+            && revision.current
+          ))?.revisionId ?? "",
       }));
     } catch {
       set({ benchmarksLoading: false, runError: "Failed to load benchmark catalog." });
@@ -700,6 +738,34 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
         });
         return;
       }
+      const calibrationRevision = state.calibrationRevisions.find((revision) => (
+        revision.caseId === benchmark
+        && revision.revisionId === state.calibrationRevisionId
+      ));
+      const calibrationSeed = state.calibrationSeed.trim();
+      if (
+        state.calibrationEnabled
+        && calibrationRevision
+        && !calibrationRevision.current
+        && !calibrationSeed
+      ) {
+        set({
+          quotaLoading: false,
+          runError: "Enter a seed to run a historical revision.",
+          phase: "idle",
+          statusLine: "Enter a seed to run a historical revision.",
+          streamMode: "idle",
+        });
+        return;
+      }
+      const calibrationInput = state.calibrationEnabled
+        && calibrationRevision
+        && calibrationSeed
+        ? {
+            caseRevisionId: calibrationRevision.revisionId,
+            generationSeed: calibrationSeed,
+          }
+        : {};
       const response = await fetch("/api/runs", {
         method: "POST",
         headers: {
@@ -710,6 +776,7 @@ export const usePlaygroundStore = create<PlaygroundStore>((set, get) => ({
           caseId: benchmark,
           executionMode: mode,
           isPublic: true,
+          ...calibrationInput,
         }),
       });
 

--- a/apps/web/lib/run-metadata.ts
+++ b/apps/web/lib/run-metadata.ts
@@ -62,6 +62,7 @@ export function buildRunMetadataUpdate(params: {
   browserEnvironment: Record<string, unknown>;
   now: string;
 }): Database["public"]["Tables"]["benchmark_runs"]["Update"] {
+  const { calibration: _ignoredCalibration, ...agentMetadata } = params.input.metadata;
   return {
     agent_name: params.input.name,
     agent_version: params.input.version,
@@ -69,7 +70,7 @@ export function buildRunMetadataUpdate(params: {
     browser_environment: params.browserEnvironment,
     metadata: {
       ...params.currentMetadata,
-      ...params.input.metadata,
+      ...agentMetadata,
       identityReportedAt: params.now,
       identitySource: "connection-page",
     },
@@ -93,10 +94,12 @@ export function buildInitialRunMetadata(params: {
   agent: AgentIdentity | undefined;
   browserEnvironment: BrowserEnvironment;
   now: string;
+  serverMetadata?: Record<string, unknown>;
 }): Database["public"]["Tables"]["benchmark_runs"]["Update"] {
   if (!params.agent) {
     return {
       browser_environment: params.browserEnvironment,
+      metadata: params.serverMetadata,
     };
   }
 
@@ -105,6 +108,10 @@ export function buildInitialRunMetadata(params: {
     agent_version: params.agent.version,
     base_model: params.agent.baseModel,
     browser_environment: params.browserEnvironment,
-    metadata: { identityReportedAt: params.now, identitySource: "run-creation" },
+    metadata: {
+      ...params.serverMetadata,
+      identityReportedAt: params.now,
+      identitySource: "run-creation",
+    },
   };
 }

--- a/apps/web/tests/unit/calibration.test.ts
+++ b/apps/web/tests/unit/calibration.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BenchmarkRun } from "@agentbench/protocol";
+import {
+  isCalibrationControlsEnabled,
+  readCalibrationRunSelection,
+} from "../../lib/calibration";
+
+test("enables calibration for local, preview, and develop deployments", () => {
+  assert.equal(isCalibrationControlsEnabled({ NODE_ENV: "development" }), true);
+  assert.equal(isCalibrationControlsEnabled({
+    NODE_ENV: "production",
+    VERCEL_ENV: "preview",
+    VERCEL_GIT_COMMIT_REF: "feature/test",
+  }), true);
+  assert.equal(isCalibrationControlsEnabled({
+    NODE_ENV: "production",
+    VERCEL_ENV: "production",
+    VERCEL_GIT_COMMIT_REF: "develop",
+  }), true);
+});
+
+test("keeps calibration disabled after develop is promoted to main", () => {
+  assert.equal(isCalibrationControlsEnabled({
+    NODE_ENV: "production",
+    VERCEL_ENV: "production",
+    VERCEL_GIT_COMMIT_REF: "main",
+  }), false);
+});
+
+test("reads only complete server-owned calibration metadata", () => {
+  assert.deepEqual(readCalibrationRunSelection({
+    metadata: {
+      calibration: {
+        caseRevisionId: "revision-105",
+        generationSeed: "calibration-01",
+      },
+    },
+  } as BenchmarkRun), {
+    caseRevisionId: "revision-105",
+    generationSeed: "calibration-01",
+  });
+
+  assert.equal(readCalibrationRunSelection({
+    metadata: { calibration: { caseRevisionId: "revision-105" } },
+  } as BenchmarkRun), null);
+});

--- a/apps/web/tests/unit/hosted-attempt-recovery.test.ts
+++ b/apps/web/tests/unit/hosted-attempt-recovery.test.ts
@@ -75,3 +75,33 @@ test("missing hosted attempts fall through to initialization", async () => {
     else process.env.RUNNER_SHARED_SECRET = previousSecret;
   }
 });
+
+test("recovers a calibration attempt using its pinned historical revision", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousSecret = process.env.RUNNER_SHARED_SECRET;
+  process.env.RUNNER_SHARED_SECRET = "shared-secret";
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    assert.equal(url.searchParams.get("caseRevisionId"), "revision-105");
+    return Response.json({ error: "attempt_not_found" }, { status: 404 });
+  };
+
+  try {
+    assert.equal(await recoverExistingHostedWebAttemptConnection({
+      run: {
+        ...run,
+        metadata: {
+          calibration: {
+            caseRevisionId: "revision-105",
+            generationSeed: "calibration-01",
+          },
+        },
+      },
+      benchmarkCase,
+    }), null);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousSecret === undefined) delete process.env.RUNNER_SHARED_SECRET;
+    else process.env.RUNNER_SHARED_SECRET = previousSecret;
+  }
+});

--- a/apps/web/tests/unit/hosted-web-revision.test.ts
+++ b/apps/web/tests/unit/hosted-web-revision.test.ts
@@ -19,3 +19,21 @@ test("hosted attempt initialization sends a revision reference without a private
   assert.equal("sessions" in payload, false);
   assert.equal("suiteSlug" in payload, false);
 });
+
+test("hosted attempt initialization forwards a deterministic calibration seed", () => {
+  const payload = buildHostedAttemptInitPayload({
+    runId: "run-1",
+    caseId: "case-1",
+    caseRevisionId: "revision-105",
+    callbackSecret: "secret",
+    generationSeed: "calibration-01",
+  });
+
+  assert.deepEqual(payload, {
+    runId: "run-1",
+    caseId: "case-1",
+    caseRevisionId: "revision-105",
+    callbackSecret: "secret",
+    generationSeed: "calibration-01",
+  });
+});

--- a/apps/web/tests/unit/run-metadata.test.ts
+++ b/apps/web/tests/unit/run-metadata.test.ts
@@ -77,6 +77,63 @@ test("repeated registration preserves the original start time", () => {
   assert.equal(patch.status, "running");
 });
 
+test("agent metadata cannot replace the server-owned calibration selection", () => {
+  const patch = buildRunMetadataUpdate({
+    currentMetadata: {
+      calibration: {
+        caseRevisionId: "revision-105",
+        generationSeed: "calibration-01",
+      },
+    },
+    currentStatus: "waiting_for_agent",
+    startedAt: null,
+    input: {
+      name: "Codex",
+      version: "1.2.3",
+      baseModel: "GPT-5",
+      metadata: {
+        calibration: {
+          caseRevisionId: "revision-current",
+          generationSeed: "replacement",
+        },
+      },
+    },
+    browserEnvironment: {},
+    now: "2026-06-19T12:00:00.000Z",
+  });
+
+  assert.deepEqual((patch.metadata as Record<string, unknown>).calibration, {
+    caseRevisionId: "revision-105",
+    generationSeed: "calibration-01",
+  });
+});
+
+test("run creation stores a server-owned calibration selection", () => {
+  const insert = buildInitialRunMetadata({
+    agent: undefined,
+    browserEnvironment: {
+      browser: "Chrome",
+      browserVersion: "126",
+      platform: "macOS",
+      mobile: false,
+    },
+    now: "2026-06-24T12:00:00.000Z",
+    serverMetadata: {
+      calibration: {
+        caseRevisionId: "revision-105",
+        generationSeed: "calibration-01",
+      },
+    },
+  });
+
+  assert.deepEqual(insert.metadata, {
+    calibration: {
+      caseRevisionId: "revision-105",
+      generationSeed: "calibration-01",
+    },
+  });
+});
+
 test("run creation persists selected identity without connecting the agent", () => {
   const insert = buildInitialRunMetadata({
     agent: { name: "Codex", version: "latest", baseModel: "GPT-5" },

--- a/docs/benchmark-testing.md
+++ b/docs/benchmark-testing.md
@@ -159,6 +159,17 @@ candidate pass-rate interval's upper bound is below the baseline interval's
 lower bound. This report is evidence tooling, not a substitute for actually
 running the representative agents.
 
+The Web launcher exposes immutable revision selection and an optional
+generation-seed input only for local development, Vercel previews, and the
+`develop` deployment. Selecting a historical revision requires a non-empty
+seed; selecting the current revision with an empty seed preserves the normal
+random-seed run flow. The run stores the server-validated revision and seed
+together and the orchestrator uses both when it creates or recovers the
+attempt. Calibration runs remain public and enter the normal version-grouped
+leaderboard. Production deployments from `main` omit the revision catalog and
+reject calibration fields at the run API even if a client submits them
+directly.
+
 The published v1.1.0 `inbox-lite` surface scores exact server-owned outbound message
 state and a separate required safety evaluator. Confidential canaries and
 prohibited recipients are rejected before a draft is persisted; only the
@@ -207,7 +218,13 @@ Tests and local Web data import the catalog directly. `supabase/seed.sql` is gen
 
 Publishing converts the validated catalog into an immutable `benchmark_case_revisions` row identified by a revision name and SHA-256 content hash. `pnpm catalog:publish` uses the service-role-only publication RPC; repeating the same revision or content is idempotent, while reusing an identity with different content is rejected.
 
-`benchmark_cases.current_revision_id` selects the release for new runs. The Web sends only this revision ID during attempt initialization. The orchestrator loads the private manifest directly, validates it again, generates the seeded question snapshot, and writes `benchmark_attempts.case_revision_id`. Updating the current release therefore does not change the manifest associated with an earlier attempt.
+`benchmark_cases.current_revision_id` selects the release for normal new runs.
+Development calibration runs may instead pin a server-validated historical
+revision. The Web sends only the selected revision ID during attempt
+initialization. The orchestrator loads the private manifest directly, validates
+it again, generates the seeded question snapshot, and writes
+`benchmark_attempts.case_revision_id`. Updating the current release therefore
+does not change the manifest associated with an earlier attempt.
 
 ## Commands And Scheduled Coverage
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -241,7 +241,11 @@ Revision and distractor outcomes require named persisted evaluator evidence;
 session completion metadata cannot claim either result. A deterministic
 calibration report harness now computes repeated-seed, per-family, per-track,
 time, and action-cost statistics with 95% confidence intervals; representative
-agent observations still need to be collected before production promotion. The
+agent observations still need to be collected before production promotion. A
+development-only launcher now exposes retained immutable revisions and
+repeatable generation seeds, while production omits the revision catalog and
+rejects calibration parameters; calibration results remain on the normal
+version-grouped leaderboard. The
 two development task surfaces now exist: `inbox-lite` enforces
 safe approval routing with canary/prohibited-recipient gates, while
 `sheets-lite` evaluates deterministic joins, filtering, formulas, and repair

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -212,6 +212,13 @@ export const createRunInputSchema = z.object({
   executionMode: runExecutionModeSchema.default("external-agent"),
   isPublic: z.boolean().default(true),
   agent: agentIdentitySchema.optional(),
+  caseRevisionId: z.string().uuid().optional(),
+  generationSeed: z.string()
+    .trim()
+    .min(1)
+    .max(120)
+    .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "Seed contains unsupported characters.")
+    .optional(),
 });
 
 export type CreateRunInput = z.infer<typeof createRunInputSchema>;


### PR DESCRIPTION
## Summary

- expose safe immutable revision choices and generation-seed input on local, preview, and `develop` deployments
- pin server-validated revision/seed metadata through hosted attempt initialization and recovery
- hide the revision catalog and reject calibration fields on `main` production deployments while keeping calibration results public and ranked
- document the calibration launch flow in the benchmark guide and roadmap

## Verification

- `pnpm verify:ci`
- `git push` pre-push verification (`pnpm verify:ci`)
- local development browser at 1440x1000 and 390x844: current v1.1.0 and historical v1.0.5 choices render; historical selection disables launch until a seed is entered
- production-mode browser at 1440x1000: no revision or seed controls render
- production-mode API: catalog returns no revision keys; direct calibration request returns HTTP 403
- all Agent Browser sessions and local Next.js processes closed after verification

Closes #181