### PR TITLE
fix(hosted): remove reflected fault-page input

### DIFF
--- a/apps/hosted-sites/src/runtime/deterministic-faults.ts
+++ b/apps/hosted-sites/src/runtime/deterministic-faults.ts
@@ -144,23 +144,15 @@ const faultCopy: Record<FaultKind, { status: number; title: string; message: str
   },
 };
 
-function escapeHtml(value: string) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
-
 export function renderRecoverableFault(
   response: ServerResponse,
   kind: FaultKind,
-  retryUrl: string,
 ) {
   const copy = faultCopy[kind];
   response.writeHead(copy.status, {
     "Content-Type": "text/html; charset=utf-8",
     "Cache-Control": "no-store",
+    "Content-Security-Policy": "default-src 'none'; base-uri 'none'; frame-ancestors 'none'",
     "Retry-After": "0",
   });
   response.end(`<!doctype html>
@@ -170,7 +162,7 @@ export function renderRecoverableFault(
     <main>
       <h1>${copy.title}</h1>
       <p>${copy.message}</p>
-      <a href="${escapeHtml(retryUrl)}">Retry</a>
+      <a href="">Retry</a>
     </main>
   </body>
 </html>`);

--- a/apps/hosted-sites/src/server.ts
+++ b/apps/hosted-sites/src/server.ts
@@ -267,7 +267,7 @@ const server = createServer(async (request, response) => {
             type: "scenario.fault_applied",
             kind: observation.injected.kind,
           });
-          renderRecoverableFault(response, observation.injected.kind, `${url.pathname}${url.search}`);
+          renderRecoverableFault(response, observation.injected.kind);
           return;
         }
         if (observation.recovered) {

--- a/apps/hosted-sites/tests/unit/runtime/deterministic-faults.test.ts
+++ b/apps/hosted-sites/tests/unit/runtime/deterministic-faults.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { observeDeterministicFault } from "../../../src/runtime/deterministic-faults.js";
+import type { ServerResponse } from "node:http";
+import {
+  observeDeterministicFault,
+  renderRecoverableFault,
+} from "../../../src/runtime/deterministic-faults.js";
 
 function metadata() {
   return {
@@ -85,4 +89,26 @@ test("leaves legacy and malformed schedules unchanged", () => {
   });
   assert.equal("scenarioFaultState" in legacy, false);
   assert.equal("scenarioFaultState" in malformed, false);
+});
+
+test("renders recoverable faults without request-derived HTML", () => {
+  let status = 0;
+  let headers: Record<string, string> = {};
+  let body = "";
+  const response = {
+    writeHead(nextStatus: number, nextHeaders: Record<string, string>) {
+      status = nextStatus;
+      headers = nextHeaders;
+    },
+    end(nextBody: string) {
+      body = nextBody;
+    },
+  } as unknown as ServerResponse;
+
+  renderRecoverableFault(response, "stale-view");
+
+  assert.equal(status, 409);
+  assert.equal(headers["Content-Security-Policy"], "default-src 'none'; base-uri 'none'; frame-ancestors 'none'");
+  assert.match(body, /<a href="">Retry<\/a>/);
+  assert.doesNotMatch(body, /<script|javascript:|onerror=/i);
 });


### PR DESCRIPTION
## Summary

- remove request-derived retry URLs from deterministic recoverable-fault HTML
- use a static empty relative link, which retries the browser current URL without interpolation
- add a restrictive CSP and response rendering regression coverage

## Verification

- `pnpm --filter hosted-sites test` (279 passed)
- `pnpm --filter hosted-sites build`
- release PR #202 CodeQL must pass after this merges

Closes #203
