### PR TITLE
docs: link complementary live-web benchmark

### DIFF
--- a/docs/hosted-web-benchmark.md
+++ b/docs/hosted-web-benchmark.md
@@ -71,3 +71,12 @@ See [Hosted Site App Authoring](./hosted-site-app-authoring.md) for implementati
 - arbitrary public internet tasks
 - scoring based only on screenshots or free-form final answers
 - sharing mutable state between benchmark sessions
+
+## Complementary live-web benchmarks
+
+AgentBench intentionally evaluates deterministic, hosted web suites. For a
+complementary benchmark focused on multi-step tasks across live third-party
+websites, see [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) and its
+[project site](https://claw-bench.com/). ClawBench is an independent project;
+this link does not imply compatibility or shared scores between the two
+benchmarks.


### PR DESCRIPTION
This documentation-only change adds a clearly labeled complementary benchmark note to the hosted web benchmark guide.

It distinguishes AgentBench’s deterministic hosted suites from ClawBench’s live third-party website tasks, links the canonical repository and project site, and explicitly states that the projects do not share scores or imply compatibility.

Submitted by reacher-z (mtrxcop@gmail.com).