### PR TITLE
fix(web): gate readiness on PostgreSQL availability

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,8 +1,21 @@
 import { NextResponse } from "next/server";
+import { checkWebDatabaseReadiness } from "@/lib/database";
 
-export function GET() {
-  return NextResponse.json(
-    { status: "ok", service: "web" },
-    { headers: { "Cache-Control": "no-store" } },
-  );
+export async function GET() {
+  try {
+    await checkWebDatabaseReadiness();
+    return NextResponse.json(
+      { status: "ok", service: "web" },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    console.error("[web] database readiness check failed", error);
+    return NextResponse.json(
+      { status: "unavailable", service: "web" },
+      {
+        status: 503,
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  }
 }

--- a/apps/web/lib/database.ts
+++ b/apps/web/lib/database.ts
@@ -61,6 +61,12 @@ export function getWebDatabaseClient() {
   return client;
 }
 
+export async function checkWebDatabaseReadiness(
+  client: Pick<DatabaseClient, "ping"> = getWebDatabaseClient(),
+) {
+  await client.ping();
+}
+
 export function getWebModelCatalogRepository(): ModelCatalogReadRepository {
   return createModelCatalogReadRepository(getWebDatabaseClient().db);
 }

--- a/apps/web/tests/unit/database.test.ts
+++ b/apps/web/tests/unit/database.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  checkWebDatabaseReadiness,
   DatabaseServiceUnavailableError,
   getWebDatabaseClient,
 } from "../../lib/database";
@@ -18,4 +19,25 @@ test("missing PostgreSQL configuration fails closed instead of creating a local 
     if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
     else process.env.DATABASE_URL = previousDatabaseUrl;
   }
+});
+
+test("database readiness resolves after a successful ping", async () => {
+  let pinged = false;
+  await checkWebDatabaseReadiness({
+    ping: async () => {
+      pinged = true;
+    },
+  });
+  assert.equal(pinged, true);
+});
+
+test("database readiness propagates ping failures", async () => {
+  await assert.rejects(
+    checkWebDatabaseReadiness({
+      ping: async () => {
+        throw new Error("database unavailable");
+      },
+    }),
+    /database unavailable/,
+  );
 });

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -6,6 +6,7 @@ export type AgentBenchDatabase = NodePgDatabase<typeof schema>;
 
 export type DatabaseClient = {
   db: AgentBenchDatabase;
+  ping: () => Promise<void>;
   close: () => Promise<void>;
 };
 
@@ -55,6 +56,9 @@ export function createDatabaseClient(options: {
 
   return {
     db: drizzle(pool, { schema }),
+    ping: async () => {
+      await pool.query("select 1");
+    },
     close: () => pool.end(),
   };
 }


### PR DESCRIPTION
## Summary
- report Web readiness only when PostgreSQL is reachable
- keep liveness independent from database readiness
- return a controlled 503 instead of accepting traffic without persistence

## Verification
- `pnpm verify:ci`
- Web tests: 81/81
- production build
- readiness returns 503 without a database and 200 against temporary PostgreSQL

Closes #212