### PR TITLE
feat(deploy): add path-specific self-hosted Web delivery

### DIFF
--- a/.github/workflows/deploy-hosted-sites.yml
+++ b/.github/workflows/deploy-hosted-sites.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install repository verification tools
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+
       - name: Run repository verification
         run: pnpm verify:ci
 

--- a/.github/workflows/deploy-hosted-sites.yml
+++ b/.github/workflows/deploy-hosted-sites.yml
@@ -8,17 +8,24 @@ on:
       - main
     paths:
       - '.github/workflows/deploy-hosted-sites.yml'
+      - 'apps/web/**'
       - 'apps/hosted-sites/**'
       - 'apps/hosted-orchestrator/**'
+      - 'packages/database/**'
+      - 'packages/protocol/**'
       - 'packages/scoring/**'
       - 'packages/shared/**'
+      - 'packages/test-cases/**'
       - 'supabase/migrations/**'
       - 'infra/docker/hosted-sites.Dockerfile'
       - 'infra/docker/hosted-orchestrator.Dockerfile'
+      - 'infra/docker/web.Dockerfile'
+      - 'infra/docker/docker-compose.web.yml'
       - 'infra/docker/docker-compose.server.yml'
       - 'infra/nginx/**'
       - 'infra/scripts/classify-hosted-deploy-changes.sh'
       - 'infra/scripts/deploy-hosted-stack.sh'
+      - 'infra/scripts/deploy-web-stack.sh'
       - 'infra/scripts/registry-retry.sh'
       - 'infra/scripts/verify-orchestrator-worker-recovery.sh'
       - 'infra/scripts/validate-orchestrator-partitions.sh'
@@ -67,6 +74,7 @@ jobs:
     needs: validate-ref
     runs-on: ubuntu-latest
     outputs:
+      web: ${{ steps.changes.outputs.web }}
       hosted_sites: ${{ steps.changes.outputs.hosted_sites }}
       orchestrator: ${{ steps.changes.outputs.orchestrator }}
       infra: ${{ steps.changes.outputs.infra }}
@@ -90,6 +98,7 @@ jobs:
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             printf '%s\n' \
+              'web=true' \
               'hosted_sites=true' \
               'orchestrator=true' \
               'infra=true' \
@@ -104,6 +113,7 @@ jobs:
           fi
 
           cat "${CHANGES_FILE}" >> "${GITHUB_OUTPUT}"
+          web="$(sed -n 's/^web=//p' "${CHANGES_FILE}")"
           hosted_sites="$(sed -n 's/^hosted_sites=//p' "${CHANGES_FILE}")"
           orchestrator="$(sed -n 's/^orchestrator=//p' "${CHANGES_FILE}")"
           infra="$(sed -n 's/^infra=//p' "${CHANGES_FILE}")"
@@ -116,6 +126,7 @@ jobs:
             echo
             echo "| Target | Changed |"
             echo "| --- | --- |"
+            echo "| web | ${web} |"
             echo "| hosted-sites | ${hosted_sites} |"
             echo "| hosted-orchestrator | ${orchestrator} |"
             echo "| nginx | ${infra} |"
@@ -200,6 +211,49 @@ jobs:
         with:
           context: .
           file: infra/docker/hosted-sites.Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ needs.detect-changes.outputs.image_tag }}
+            ${{ steps.meta.outputs.image }}:latest-${{ needs.validate-ref.outputs.image_channel }}
+
+  build-web:
+    needs:
+      - validate-ref
+      - detect-changes
+      - verify
+    if: needs.detect-changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set image metadata
+        id: meta
+        shell: bash
+        run: |
+          OWNER="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          echo "image=${REGISTRY}/${OWNER}/agentbench-web" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Web image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: infra/docker/web.Dockerfile
           push: true
           tags: |
             ${{ steps.meta.outputs.image }}:${{ needs.detect-changes.outputs.image_tag }}
@@ -334,6 +388,10 @@ jobs:
     if: |
       always() &&
       github.ref == 'refs/heads/develop' &&
+      (needs.detect-changes.outputs.hosted_sites == 'true' ||
+       needs.detect-changes.outputs.orchestrator == 'true' ||
+       needs.detect-changes.outputs.infra == 'true' ||
+       needs.detect-changes.outputs.topology == 'true') &&
       needs.detect-changes.result == 'success' &&
       needs.migrate-development.result == 'success' &&
       (needs.build-hosted-sites.result == 'success' || needs.build-hosted-sites.result == 'skipped') &&
@@ -375,6 +433,45 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GATEWAY_HTTP_PORT: ${{ vars.GATEWAY_HTTP_PORT || '8081' }}
         run: bash infra/scripts/deploy-hosted-stack.sh
+
+  deploy-web-development:
+    if: |
+      always() &&
+      github.ref == 'refs/heads/develop' &&
+      needs.detect-changes.outputs.web == 'true' &&
+      needs.detect-changes.result == 'success' &&
+      needs.migrate-development.result == 'success' &&
+      needs.build-web.result == 'success'
+    runs-on:
+      - self-hosted
+      - linux
+      - agentbench-dev
+    environment: development
+    needs:
+      - detect-changes
+      - build-web
+      - migrate-development
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Deploy development Web
+        env:
+          DEPLOYMENT_ENVIRONMENT: development
+          WEB_COMPOSE_PROJECT_NAME: agentbench-development-web
+          IMAGE_CHANNEL: develop
+          IMAGE_TAG: ${{ needs.detect-changes.outputs.image_tag }}
+          WEB_CHANGED: 'true'
+          GHCR_USERNAME: ${{ vars.GHCR_USERNAME }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RUNNER_SHARED_SECRET: ${{ secrets.RUNNER_SHARED_SECRET }}
+          HOSTED_SITES_URL: ${{ vars.HOSTED_SITES_PUBLIC_URL }}
+          HOSTED_ORCHESTRATOR_URL: ${{ vars.HOSTED_ORCHESTRATOR_PUBLIC_URL }}
+          AGENTBENCH_WEB_PORT: ${{ vars.AGENTBENCH_WEB_PORT || '3000' }}
+        run: bash infra/scripts/deploy-web-stack.sh
 
   smoke-development:
     if: github.ref == 'refs/heads/develop'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,13 +145,17 @@ Do not publish a fixed host port for each hosted-sites replica. Nginx should rea
 
 `deploy-hosted-sites.yml` classifies each push before building or pulling images:
 
+- `apps/web/**` builds and deploys only the standalone Web image and Compose project.
 - `apps/hosted-sites/**` builds, pulls, and recreates only hosted-sites and the session-cache client path.
 - `apps/hosted-orchestrator/**` builds one image, then pulls and recreates only the orchestrator API and both command workers.
-- shared scoring/runtime packages rebuild both images.
+- shared packages rebuild only their actual image consumers; database changes rebuild Web and orchestrator but not hosted-sites.
 - Nginx changes recreate only the gateway.
 - Compose topology changes pre-pull every required target image, then reconcile all services.
 
-Hosted-sites and orchestrator use independent image tags. Targeted deploys preserve the currently running replica counts, so scaling one service does not restart or resize the other. The orchestrator API and workers always use the same immutable image tag within one environment.
+Web, hosted-sites, and orchestrator use independent image tags and Compose
+projects where appropriate. Targeted deploys preserve the currently running
+replica counts, so scaling one service does not restart or resize another. The
+orchestrator API and workers always use the same immutable image tag within one environment.
 
 Before replacing any running service, the deploy script authenticates to GHCR and pulls every required target image with bounded exponential-backoff retries. Transient registry/network failures such as timeouts, DNS failures, connection resets, 429s, and 5xx responses retry. Permanent authentication failures and missing manifests fail promptly. If the retry budget is exhausted, the script exits before `docker compose up`, leaving the previous healthy stack serving traffic.
 
@@ -207,6 +211,7 @@ Required variables in each GitHub Environment:
 - `HOSTED_SITES_PUBLIC_URL`
 - `HOSTED_ORCHESTRATOR_PUBLIC_URL`
 - `GATEWAY_HTTP_PORT`
+- optional `AGENTBENCH_WEB_PORT` (development self-hosted Web, default `3000`)
 
 Required secrets in each GitHub Environment:
 

--- a/infra/scripts/classify-hosted-deploy-changes.sh
+++ b/infra/scripts/classify-hosted-deploy-changes.sh
@@ -15,7 +15,6 @@ matches_any() {
 
 common_patterns=(
   '^\.github/workflows/deploy-hosted-sites\.yml$'
-  '^packages/(scoring|shared)/'
   '^package\.json$'
   '^pnpm-lock\.yaml$'
   '^pnpm-workspace\.yaml$'
@@ -23,15 +22,23 @@ common_patterns=(
   '^turbo\.json$'
 )
 
+web=false
 hosted_sites=false
 orchestrator=false
 infra=false
 topology=false
 
-if matches_any '^apps/hosted-sites/' '^infra/docker/hosted-sites\.Dockerfile$' "${common_patterns[@]}"; then
+if matches_any '^apps/web/' '^infra/docker/web\.Dockerfile$' \
+  '^infra/docker/docker-compose\.web\.yml$' '^infra/scripts/deploy-web-stack\.sh$' \
+  '^packages/(database|protocol|shared|test-cases)/' "${common_patterns[@]}"; then
+  web=true
+fi
+if matches_any '^apps/hosted-sites/' '^infra/docker/hosted-sites\.Dockerfile$' \
+  '^packages/(protocol|scoring|shared|test-cases)/' "${common_patterns[@]}"; then
   hosted_sites=true
 fi
-if matches_any '^apps/hosted-orchestrator/' '^infra/docker/hosted-orchestrator\.Dockerfile$' "${common_patterns[@]}"; then
+if matches_any '^apps/hosted-orchestrator/' '^infra/docker/hosted-orchestrator\.Dockerfile$' \
+  '^packages/(database|protocol|scoring|shared|test-cases)/' "${common_patterns[@]}"; then
   orchestrator=true
 fi
 if matches_any '^infra/nginx/'; then
@@ -45,6 +52,7 @@ if matches_any '^infra/docker/docker-compose\.server\.yml$' \
   topology=true
 fi
 
+printf 'web=%s\n' "$web"
 printf 'hosted_sites=%s\n' "$hosted_sites"
 printf 'orchestrator=%s\n' "$orchestrator"
 printf 'infra=%s\n' "$infra"

--- a/infra/scripts/deploy-web-stack.sh
+++ b/infra/scripts/deploy-web-stack.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_variables=(
+  AGENTBENCH_WEB_PORT
+  DATABASE_URL
+  DEPLOYMENT_ENVIRONMENT
+  GHCR_PAT
+  GHCR_USERNAME
+  GITHUB_REPOSITORY_OWNER
+  HOSTED_ORCHESTRATOR_URL
+  HOSTED_SITES_URL
+  IMAGE_CHANNEL
+  IMAGE_TAG
+  RUNNER_SHARED_SECRET
+  WEB_COMPOSE_PROJECT_NAME
+)
+
+for variable in "${required_variables[@]}"; do
+  if [[ -z "${!variable:-}" ]]; then
+    echo "Required Web deployment variable ${variable} is not set." >&2
+    exit 1
+  fi
+done
+
+case "${DEPLOYMENT_ENVIRONMENT}:${WEB_COMPOSE_PROJECT_NAME}:${IMAGE_CHANNEL}" in
+  development:agentbench-development-web:develop | production:agentbench-production-web:main)
+    ;;
+  *)
+    echo "Invalid Web deployment mapping: ${DEPLOYMENT_ENVIRONMENT}:${WEB_COMPOSE_PROJECT_NAME}:${IMAGE_CHANNEL}." >&2
+    exit 1
+    ;;
+esac
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "docker compose plugin or docker-compose is required on the self-hosted runner." >&2
+  exit 127
+fi
+
+OWNER="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+WEB_IMAGE="ghcr.io/${OWNER}/agentbench-web"
+WEB_IMAGE_TAG="latest-${IMAGE_CHANNEL}"
+if [[ "${WEB_CHANGED:-false}" == "true" ]]; then
+  WEB_IMAGE_TAG="${IMAGE_TAG}"
+fi
+
+ENV_FILE="${RUNNER_TEMP:-/tmp}/agentbench-${DEPLOYMENT_ENVIRONMENT}.env.web"
+COMPOSE_FILE="infra/docker/docker-compose.web.yml"
+# shellcheck source=registry-retry.sh
+source "infra/scripts/registry-retry.sh"
+
+cat > "${ENV_FILE}" <<EOF
+WEB_COMPOSE_PROJECT_NAME=${WEB_COMPOSE_PROJECT_NAME}
+AGENTBENCH_WEB_IMAGE=${WEB_IMAGE}
+AGENTBENCH_WEB_IMAGE_TAG=${WEB_IMAGE_TAG}
+AGENTBENCH_WEB_PORT=${AGENTBENCH_WEB_PORT}
+DATABASE_URL=${DATABASE_URL}
+DATABASE_POOL_MAX=${DATABASE_POOL_MAX:-3}
+GUEST_RUN_LIMIT=${GUEST_RUN_LIMIT:-3}
+RUN_CONNECT_RATE_LIMIT=${RUN_CONNECT_RATE_LIMIT:-30}
+HOSTED_ORCHESTRATOR_URL=${HOSTED_ORCHESTRATOR_URL}
+HOSTED_SITES_URL=${HOSTED_SITES_URL}
+RUNNER_SHARED_SECRET=${RUNNER_SHARED_SECRET}
+EOF
+chmod 600 "${ENV_FILE}"
+
+compose() {
+  "${COMPOSE[@]}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" "$@"
+}
+
+cleanup() {
+  rm -f "${ENV_FILE}"
+}
+trap cleanup EXIT
+
+registry_retry_command "ghcr-login" bash -c 'printf "%s" "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin'
+registry_retry_command "web-pull" compose pull web
+compose up -d --remove-orphans --no-deps web
+
+ready=false
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${AGENTBENCH_WEB_PORT}/api/health" >/dev/null; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${ready}" != "true" ]]; then
+  compose ps -a
+  compose logs --tail=160 web
+  exit 1
+fi
+
+compose ps
+echo "Web deployment passed: environment=${DEPLOYMENT_ENVIRONMENT} image=${WEB_IMAGE}:${WEB_IMAGE_TAG} port=${AGENTBENCH_WEB_PORT}"

--- a/scripts/test-deploy-classifier.sh
+++ b/scripts/test-deploy-classifier.sh
@@ -16,16 +16,19 @@ assert_classification() {
   fi
 }
 
-assert_classification 'apps/hosted-sites/src/server.ts' $'hosted_sites=true\norchestrator=false\ninfra=false\ntopology=false'
-assert_classification 'apps/hosted-orchestrator/src/server.ts' $'hosted_sites=false\norchestrator=true\ninfra=false\ntopology=false'
-assert_classification 'packages/shared/src/index.ts' $'hosted_sites=true\norchestrator=true\ninfra=false\ntopology=false'
-assert_classification '.github/workflows/deploy-hosted-sites.yml' $'hosted_sites=true\norchestrator=true\ninfra=false\ntopology=false'
-assert_classification 'infra/nginx/hosted-sites.conf' $'hosted_sites=false\norchestrator=false\ninfra=true\ntopology=false'
-assert_classification 'infra/docker/docker-compose.server.yml' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
-assert_classification 'infra/scripts/deploy-hosted-stack.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
-assert_classification 'infra/scripts/registry-retry.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
-assert_classification 'infra/scripts/verify-orchestrator-worker-recovery.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
-assert_classification 'infra/scripts/validate-orchestrator-partitions.sh' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
-assert_classification 'docs/deployment.md' $'hosted_sites=false\norchestrator=false\ninfra=false\ntopology=false'
+assert_classification 'apps/web/app/page.tsx' $'web=true\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=false'
+assert_classification 'infra/docker/docker-compose.web.yml' $'web=true\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=false'
+assert_classification 'apps/hosted-sites/src/server.ts' $'web=false\nhosted_sites=true\norchestrator=false\ninfra=false\ntopology=false'
+assert_classification 'apps/hosted-orchestrator/src/server.ts' $'web=false\nhosted_sites=false\norchestrator=true\ninfra=false\ntopology=false'
+assert_classification 'packages/database/src/client.ts' $'web=true\nhosted_sites=false\norchestrator=true\ninfra=false\ntopology=false'
+assert_classification 'packages/shared/src/index.ts' $'web=true\nhosted_sites=true\norchestrator=true\ninfra=false\ntopology=false'
+assert_classification '.github/workflows/deploy-hosted-sites.yml' $'web=true\nhosted_sites=true\norchestrator=true\ninfra=false\ntopology=false'
+assert_classification 'infra/nginx/hosted-sites.conf' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=true\ntopology=false'
+assert_classification 'infra/docker/docker-compose.server.yml' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
+assert_classification 'infra/scripts/deploy-hosted-stack.sh' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
+assert_classification 'infra/scripts/registry-retry.sh' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
+assert_classification 'infra/scripts/verify-orchestrator-worker-recovery.sh' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
+assert_classification 'infra/scripts/validate-orchestrator-partitions.sh' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=true'
+assert_classification 'docs/deployment.md' $'web=false\nhosted_sites=false\norchestrator=false\ninfra=false\ntopology=false'
 
 echo "deployment classifier tests passed"

--- a/scripts/test-web-deploy-workflow.sh
+++ b/scripts/test-web-deploy-workflow.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/deploy-hosted-sites.yml"
+DEPLOY_SCRIPT="${ROOT_DIR}/infra/scripts/deploy-web-stack.sh"
+
+require_text() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file}"; then
+    printf 'expected %s to contain: %s\n' "${file}" "${expected}" >&2
+    exit 1
+  fi
+}
+
+bash -n "${DEPLOY_SCRIPT}"
+require_text "${WORKFLOW}" "web: \${{ steps.changes.outputs.web }}"
+require_text "${WORKFLOW}" "if: needs.detect-changes.outputs.web == 'true'"
+require_text "${WORKFLOW}" "file: infra/docker/web.Dockerfile"
+require_text "${WORKFLOW}" "WEB_COMPOSE_PROJECT_NAME: agentbench-development-web"
+require_text "${WORKFLOW}" "run: bash infra/scripts/deploy-web-stack.sh"
+require_text "${DEPLOY_SCRIPT}" 'COMPOSE_FILE="infra/docker/docker-compose.web.yml"'
+require_text "${DEPLOY_SCRIPT}" 'compose up -d --remove-orphans --no-deps web'
+
+set +e
+invalid_output="$({
+  AGENTBENCH_WEB_PORT=3000 \
+    DATABASE_URL=postgresql://test-only \
+    DEPLOYMENT_ENVIRONMENT=production \
+    GHCR_PAT=test-only \
+    GHCR_USERNAME=test-only \
+    GITHUB_REPOSITORY_OWNER=test-only \
+    HOSTED_ORCHESTRATOR_URL=http://orchestrator.invalid \
+    HOSTED_SITES_URL=http://sites.invalid \
+    IMAGE_CHANNEL=develop \
+    IMAGE_TAG=test-only \
+    RUNNER_SHARED_SECRET=test-only \
+    WEB_COMPOSE_PROJECT_NAME=agentbench-development-web \
+    bash "${DEPLOY_SCRIPT}"
+} 2>&1)"
+invalid_status=$?
+set -e
+
+if [[ "${invalid_status}" -eq 0 || "${invalid_output}" != *"Invalid Web deployment mapping"* ]]; then
+  echo "Web deployment script did not reject a mixed environment mapping." >&2
+  exit 1
+fi
+
+echo "Web deployment workflow tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -13,6 +13,9 @@ bash scripts/test-model-catalog-sync-workflow.sh
 echo "== Deployment classifier =="
 bash scripts/test-deploy-classifier.sh
 
+echo "== Web deployment workflow =="
+bash scripts/test-web-deploy-workflow.sh
+
 echo "== Registry retry helper =="
 bash scripts/test-registry-retry.sh
 


### PR DESCRIPTION
## Summary
- classify Web changes independently from hosted services
- build and deploy the self-hosted Next.js image only when its paths change
- add deployment workflow and script contract tests
- ensure workflow runners install repository boundary-check tooling

## Verification
- `pnpm verify:ci`
- deployment classifier and workflow tests
- clean Web Docker image build

Closes #214