### PR TITLE
feat(deploy): add isolated development cutover canary

### DIFF
--- a/.github/workflows/deploy-hosted-sites.yml
+++ b/.github/workflows/deploy-hosted-sites.yml
@@ -2,6 +2,15 @@ name: Deploy Hosted Sites
 
 on:
   workflow_dispatch:
+    inputs:
+      canary_action:
+        description: Deploy or remove an isolated feature-branch cutover canary
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - destroy
   push:
     branches:
       - develop
@@ -22,10 +31,12 @@ on:
       - 'infra/docker/web.Dockerfile'
       - 'infra/docker/docker-compose.web.yml'
       - 'infra/docker/docker-compose.server.yml'
+      - 'infra/docker/docker-compose.canary.yml'
       - 'infra/nginx/**'
       - 'infra/scripts/classify-hosted-deploy-changes.sh'
       - 'infra/scripts/deploy-hosted-stack.sh'
       - 'infra/scripts/deploy-web-stack.sh'
+      - 'infra/scripts/deploy-cutover-canary.sh'
       - 'infra/scripts/registry-retry.sh'
       - 'infra/scripts/verify-orchestrator-worker-recovery.sh'
       - 'infra/scripts/validate-orchestrator-partitions.sh'
@@ -51,22 +62,43 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_channel: ${{ steps.environment.outputs.image_channel }}
+      deployment_mode: ${{ steps.environment.outputs.deployment_mode }}
+      canary_action: ${{ steps.environment.outputs.canary_action }}
     steps:
       - name: Select deployment environment
         id: environment
         shell: bash
+        env:
+          REQUESTED_CANARY_ACTION: ${{ inputs.canary_action }}
         run: |
           set -euo pipefail
           case "${GITHUB_REF}" in
             refs/heads/develop)
               echo "image_channel=develop" >> "${GITHUB_OUTPUT}"
+              echo "deployment_mode=standard" >> "${GITHUB_OUTPUT}"
+              echo "canary_action=none" >> "${GITHUB_OUTPUT}"
               ;;
             refs/heads/main)
               echo "image_channel=main" >> "${GITHUB_OUTPUT}"
+              echo "deployment_mode=standard" >> "${GITHUB_OUTPUT}"
+              echo "canary_action=none" >> "${GITHUB_OUTPUT}"
               ;;
             *)
-              echo "Hosted deployment is only allowed from develop or main; received ${GITHUB_REF}." >&2
-              exit 1
+              if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
+                echo "Feature-branch canary deployment requires an explicit workflow dispatch." >&2
+                exit 1
+              fi
+              case "${REQUESTED_CANARY_ACTION}" in
+                deploy | destroy)
+                  ;;
+                *)
+                  echo "Unsupported canary action: ${REQUESTED_CANARY_ACTION}" >&2
+                  exit 1
+                  ;;
+              esac
+              echo "image_channel=canary" >> "${GITHUB_OUTPUT}"
+              echo "deployment_mode=canary" >> "${GITHUB_OUTPUT}"
+              echo "canary_action=${REQUESTED_CANARY_ACTION}" >> "${GITHUB_OUTPUT}"
               ;;
           esac
 
@@ -137,6 +169,7 @@ jobs:
 
   verify:
     needs: validate-ref
+    if: needs.validate-ref.outputs.canary_action != 'destroy'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     services:
@@ -475,6 +508,103 @@ jobs:
           HOSTED_ORCHESTRATOR_URL: ${{ vars.HOSTED_ORCHESTRATOR_PUBLIC_URL }}
           AGENTBENCH_WEB_PORT: ${{ vars.AGENTBENCH_WEB_PORT || '3000' }}
         run: bash infra/scripts/deploy-web-stack.sh
+
+  deploy-cutover-canary:
+    if: needs.validate-ref.outputs.deployment_mode == 'canary' && needs.validate-ref.outputs.canary_action == 'deploy'
+    runs-on:
+      - self-hosted
+      - linux
+      - agentbench-dev
+    environment: development
+    needs:
+      - validate-ref
+      - detect-changes
+      - verify
+      - build-web
+      - build-hosted-sites
+      - build-orchestrator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Install canary smoke database client
+        run: pnpm install --frozen-lockfile --filter @agentbench/database
+
+      - name: Prepare candidate database URLs
+        env:
+          CANONICAL_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          CANONICAL_DATABASE_DIRECT_URL: ${{ secrets.DATABASE_DIRECT_URL }}
+        run: |
+          set -euo pipefail
+          candidate_url="$(node -e 'const url = new URL(process.env.CANONICAL_DATABASE_URL); url.pathname = "/agentbench_development_candidate"; process.stdout.write(url.toString())')"
+          candidate_direct_url="$(node -e 'const url = new URL(process.env.CANONICAL_DATABASE_DIRECT_URL); url.pathname = "/agentbench_development_candidate"; process.stdout.write(url.toString())')"
+          echo "::add-mask::${candidate_url}"
+          echo "::add-mask::${candidate_direct_url}"
+          echo "DATABASE_CANARY_URL=${candidate_url}" >> "${GITHUB_ENV}"
+          echo "DATABASE_CANARY_DIRECT_URL=${candidate_direct_url}" >> "${GITHUB_ENV}"
+
+      - name: Deploy isolated cutover canary
+        env:
+          CANARY_HOST: ${{ vars.CANARY_HOST || '192.168.1.242' }}
+          GHCR_USERNAME: ${{ vars.GHCR_USERNAME }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          IMAGE_TAG: ${{ needs.detect-changes.outputs.image_tag }}
+          RUNNER_SHARED_SECRET: ${{ secrets.RUNNER_SHARED_SECRET }}
+        run: DATABASE_URL="${DATABASE_CANARY_URL}" bash infra/scripts/deploy-cutover-canary.sh
+
+      - name: Run provider-neutral lifecycle smoke
+        env:
+          START_LOCAL_SERVICES: 'false'
+          HOSTED_SITES_PUBLIC_URL: http://${{ vars.CANARY_HOST || '192.168.1.242' }}:8182
+          HOSTED_ORCHESTRATOR_PUBLIC_URL: http://${{ vars.CANARY_HOST || '192.168.1.242' }}:8182/orchestrator
+          AGENTBENCH_WEB_URL: http://${{ vars.CANARY_HOST || '192.168.1.242' }}:3182
+          RUNNER_SHARED_SECRET: ${{ secrets.RUNNER_SHARED_SECRET }}
+        run: DATABASE_DIRECT_URL="${DATABASE_CANARY_DIRECT_URL}" bash tests/e2e/hosted-lifecycle-full-pass.sh
+
+      - name: Record retained canary
+        env:
+          CANARY_HOST: ${{ vars.CANARY_HOST || '192.168.1.242' }}
+        run: |
+          {
+            echo "## Development cutover canary"
+            echo
+            echo "- Compose project: \`agentbench-cutover-canary\`"
+            echo "- Image tag: \`${GITHUB_SHA::12}\`"
+            echo "- Web: \`http://${CANARY_HOST}:3182\`"
+            echo "- Gateway: \`http://${CANARY_HOST}:8182\`"
+            echo "- Lifecycle smoke: passed"
+            echo "- Teardown: dispatch this feature branch with \`canary_action=destroy\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  destroy-cutover-canary:
+    if: needs.validate-ref.outputs.deployment_mode == 'canary' && needs.validate-ref.outputs.canary_action == 'destroy'
+    runs-on:
+      - self-hosted
+      - linux
+      - agentbench-dev
+    environment: development
+    needs:
+      - validate-ref
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Remove isolated cutover canary
+        env:
+          CANARY_ACTION: destroy
+        run: bash infra/scripts/deploy-cutover-canary.sh
 
   smoke-development:
     if: github.ref == 'refs/heads/develop'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -157,6 +157,32 @@ projects where appropriate. Targeted deploys preserve the currently running
 replica counts, so scaling one service does not restart or resize another. The
 orchestrator API and workers always use the same immutable image tag within one environment.
 
+### Development cutover canary
+
+Dispatch `Deploy Hosted Sites` from the candidate feature branch with
+`canary_action=deploy`. A feature-branch push never deploys the canary. The job
+builds the exact commit images and starts Web, hosted-sites, the orchestrator
+API/workers, Nginx, and two Redis services in the fixed
+`agentbench-cutover-canary` Compose project.
+
+The canary exposes Web on port `3182` and its gateway on port `8182`. Internal
+callbacks use `http://web:3000`, and the project has its own network, Redis
+containers, and volumes. The deployment script rejects mutable image tags and
+any database name that does not end in `_candidate`; it cannot target the
+canonical development or production database.
+
+After readiness, the workflow runs the provider-neutral lifecycle smoke. The
+smoke creates its run through Web, drives lifecycle operations through the
+orchestrator API, and uses the candidate direct PostgreSQL URL only for
+read-only persistence assertions. The successful canary is retained for
+browser inspection and its commit tag, endpoints, and smoke result are recorded
+in the workflow summary.
+
+To remove it, dispatch the same feature branch with
+`canary_action=destroy`. This runs `docker compose down --volumes
+--remove-orphans` only for `agentbench-cutover-canary`; active development and
+production projects are not addressed.
+
 Before replacing any running service, the deploy script authenticates to GHCR and pulls every required target image with bounded exponential-backoff retries. Transient registry/network failures such as timeouts, DNS failures, connection resets, 429s, and 5xx responses retry. Permanent authentication failures and missing manifests fail promptly. If the retry budget is exhausted, the script exits before `docker compose up`, leaving the previous healthy stack serving traffic.
 
 ## Production Topology
@@ -183,12 +209,16 @@ Relevant workflows:
 - [`.github/workflows/deploy-hosted-sites.yml`](../.github/workflows/deploy-hosted-sites.yml)
 - [`.github/workflows/model-catalog-sync.yml`](../.github/workflows/model-catalog-sync.yml)
 
-Hosted CD only accepts `develop` and `main`:
+Automatic hosted CD only accepts `develop` and `main`:
 
 - `develop` automatically deploys through the GitHub `development` Environment, the `agentbench-dev` runner, `latest-develop` images, the `agentbench-development` Compose project, and gateway port `8081` by default.
 - `main` deploys only through the GitHub `production` Environment, the `agentbench-prod` runner, `latest-main` images, the `agentbench-production` Compose project, and gateway port `8080` by default.
 
-Manual dispatches from any other branch fail before accessing a self-hosted runner. Required CI also rejects pull requests to `main` unless their source is `develop` or `hotfix/*`. The `production` Environment should require approval and allow deployments only from `main`.
+Manual dispatches from another branch can only deploy or destroy the isolated
+cutover canary. They never migrate or address development/production Compose
+projects. Required CI also rejects pull requests to `main` unless their source
+is `develop` or `hotfix/*`. The `production` Environment should require approval
+and allow deployments only from `main`.
 
 The hosted deployment workflow builds images, pushes them to GHCR, and runs the server deployment through a self-hosted GitHub Actions runner on Linux. This infrastructure agent is unrelated to the removed benchmark execution runner. The server pulls the requested image tag and recreates the Compose services.
 
@@ -212,6 +242,7 @@ Required variables in each GitHub Environment:
 - `HOSTED_ORCHESTRATOR_PUBLIC_URL`
 - `GATEWAY_HTTP_PORT`
 - optional `AGENTBENCH_WEB_PORT` (development self-hosted Web, default `3000`)
+- optional `CANARY_HOST` (self-hosted runner LAN address; defaults to `192.168.1.242`)
 
 Required secrets in each GitHub Environment:
 

--- a/infra/docker/docker-compose.canary.yml
+++ b/infra/docker/docker-compose.canary.yml
@@ -1,0 +1,44 @@
+services:
+  web:
+    image: ${AGENTBENCH_WEB_IMAGE}:${IMAGE_TAG}
+    environment:
+      DATABASE_POOL_MAX: ${DATABASE_POOL_MAX:-3}
+      DATABASE_URL: ${DATABASE_URL}
+      GUEST_RUN_LIMIT: 999
+      HOSTED_ORCHESTRATOR_URL: http://hosted-orchestrator:3004
+      HOSTED_SITES_URL: ${HOSTED_SITES_PUBLIC_URL}
+      NODE_ENV: production
+      RUN_CONNECT_RATE_LIMIT: 30
+      RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET}
+    ports:
+      - "3182:3000"
+    depends_on:
+      - hosted-orchestrator
+      - hosted-sites
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - fetch('http://127.0.0.1:3000/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 20s
+    restart: unless-stopped
+
+  hosted-orchestrator:
+    environment:
+      AGENTBENCH_WEB_URL: http://web:3000
+
+  hosted-orchestrator-worker-0:
+    environment:
+      AGENTBENCH_WEB_URL: http://web:3000
+
+  hosted-orchestrator-worker-1:
+    environment:
+      AGENTBENCH_WEB_URL: http://web:3000
+
+  hosted-sites:
+    environment:
+      AGENTBENCH_WEB_URL: http://web:3000

--- a/infra/scripts/deploy-cutover-canary.sh
+++ b/infra/scripts/deploy-cutover-canary.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CANARY_ACTION="${CANARY_ACTION:-deploy}"
+COMPOSE_PROJECT="agentbench-cutover-canary"
+BASE_COMPOSE_FILE="${ROOT_DIR}/infra/docker/docker-compose.server.yml"
+CANARY_COMPOSE_FILE="${ROOT_DIR}/infra/docker/docker-compose.canary.yml"
+ENV_FILE="${RUNNER_TEMP:-/tmp}/agentbench-cutover-canary.env"
+
+case "${CANARY_ACTION}" in
+  deploy | destroy)
+    ;;
+  *)
+    echo "CANARY_ACTION must be deploy or destroy." >&2
+    exit 1
+    ;;
+esac
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "docker compose plugin or docker-compose is required on the self-hosted runner." >&2
+  exit 127
+fi
+
+cleanup() {
+  rm -f "${ENV_FILE}"
+}
+trap cleanup EXIT
+
+if [[ "${CANARY_ACTION}" == "destroy" ]]; then
+  cat > "${ENV_FILE}" <<EOF
+COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT}
+AGENTBENCH_WEB_IMAGE=unused
+HOSTED_SITES_IMAGE=unused
+HOSTED_ORCHESTRATOR_IMAGE=unused
+IMAGE_TAG=unused
+HOSTED_SITES_IMAGE_TAG=unused
+HOSTED_ORCHESTRATOR_IMAGE_TAG=unused
+HOSTED_SITES_PUBLIC_URL=http://canary.invalid
+HOSTED_ORCHESTRATOR_PUBLIC_URL=http://canary.invalid/orchestrator
+HOSTED_ORCHESTRATOR_URL=http://hosted-orchestrator:3004
+AGENTBENCH_WEB_URL=http://web:3000
+HOSTED_SESSION_REDIS_URL=redis://session-redis:6379
+ORCHESTRATOR_REDIS_URL=redis://orchestrator-redis:6379
+RUNNER_SHARED_SECRET=unused
+DATABASE_URL=postgresql://unused/unused_candidate
+EOF
+  "${COMPOSE[@]}" --project-name "${COMPOSE_PROJECT}" --env-file "${ENV_FILE}" \
+    -f "${BASE_COMPOSE_FILE}" -f "${CANARY_COMPOSE_FILE}" \
+    down --volumes --remove-orphans
+  echo "Removed the isolated ${COMPOSE_PROJECT} containers, network, and volumes."
+  exit 0
+fi
+
+required_variables=(
+  CANARY_HOST
+  DATABASE_URL
+  GHCR_PAT
+  GHCR_USERNAME
+  GITHUB_REPOSITORY_OWNER
+  IMAGE_TAG
+  RUNNER_SHARED_SECRET
+)
+
+for variable in "${required_variables[@]}"; do
+  if [[ -z "${!variable:-}" ]]; then
+    echo "Required canary deployment variable ${variable} is not set." >&2
+    exit 1
+  fi
+done
+
+database_name="${DATABASE_URL%%\?*}"
+database_name="${database_name##*/}"
+if [[ -z "${database_name}" || "${database_name}" != *_candidate ]]; then
+  echo "Canary DATABASE_URL must target a database ending in _candidate." >&2
+  exit 1
+fi
+
+if [[ ! "${IMAGE_TAG}" =~ ^[0-9a-f]{12}$ ]]; then
+  echo "Canary IMAGE_TAG must be an immutable 12-character commit tag." >&2
+  exit 1
+fi
+
+OWNER="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+# shellcheck source=registry-retry.sh
+source "${ROOT_DIR}/infra/scripts/registry-retry.sh"
+
+cat > "${ENV_FILE}" <<EOF
+COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT}
+AGENTBENCH_WEB_IMAGE=ghcr.io/${OWNER}/agentbench-web
+HOSTED_SITES_IMAGE=ghcr.io/${OWNER}/agentbench-hosted-sites
+HOSTED_ORCHESTRATOR_IMAGE=ghcr.io/${OWNER}/agentbench-hosted-orchestrator
+HOSTED_SITES_IMAGE_TAG=${IMAGE_TAG}
+HOSTED_ORCHESTRATOR_IMAGE_TAG=${IMAGE_TAG}
+IMAGE_TAG=${IMAGE_TAG}
+DATABASE_URL=${DATABASE_URL}
+RUNNER_SHARED_SECRET=${RUNNER_SHARED_SECRET}
+AGENTBENCH_WEB_URL=http://web:3000
+HOSTED_SITES_PUBLIC_URL=http://${CANARY_HOST}:8182
+HOSTED_ORCHESTRATOR_URL=http://hosted-orchestrator:3004
+HOSTED_ORCHESTRATOR_PUBLIC_URL=http://${CANARY_HOST}:8182/orchestrator
+HOSTED_SESSION_REDIS_URL=redis://session-redis:6379
+ORCHESTRATOR_REDIS_URL=redis://orchestrator-redis:6379
+ORCHESTRATOR_PARTITION_COUNT=16
+ORCHESTRATOR_WORKER_0_PARTITIONS=0,1,2,3,4,5,6,7
+ORCHESTRATOR_WORKER_1_PARTITIONS=8,9,10,11,12,13,14,15
+GATEWAY_HTTP_PORT=8182
+EOF
+chmod 600 "${ENV_FILE}"
+
+compose() {
+  "${COMPOSE[@]}" --project-name "${COMPOSE_PROJECT}" --env-file "${ENV_FILE}" \
+    -f "${BASE_COMPOSE_FILE}" -f "${CANARY_COMPOSE_FILE}" "$@"
+}
+
+registry_retry_command "ghcr-login" bash -c 'printf "%s" "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin'
+registry_retry_command "canary-pull" compose pull \
+  web hosted-sites hosted-orchestrator hosted-orchestrator-worker-0 hosted-orchestrator-worker-1
+compose up -d --remove-orphans
+
+ready=false
+for _ in $(seq 1 45); do
+  if curl -fsS "http://127.0.0.1:3182/api/health" >/dev/null \
+    && curl -fsS "http://127.0.0.1:8182/health" >/dev/null \
+    && curl -fsS "http://127.0.0.1:8182/orchestrator" >/dev/null; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${ready}" != "true" ]]; then
+  compose ps -a
+  compose logs --tail=160
+  exit 1
+fi
+
+compose ps
+echo "Cutover canary passed health checks: project=${COMPOSE_PROJECT} image_tag=${IMAGE_TAG} web_port=3182 gateway_port=8182."

--- a/scripts/test-cutover-canary.sh
+++ b/scripts/test-cutover-canary.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/deploy-hosted-sites.yml"
+DEPLOY_SCRIPT="${ROOT_DIR}/infra/scripts/deploy-cutover-canary.sh"
+COMPOSE_FILE="${ROOT_DIR}/infra/docker/docker-compose.canary.yml"
+
+require_text() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file}"; then
+    printf 'expected %s to contain: %s\n' "${file}" "${expected}" >&2
+    exit 1
+  fi
+}
+
+bash -n "${DEPLOY_SCRIPT}"
+require_text "${WORKFLOW}" "deployment_mode: \${{ steps.environment.outputs.deployment_mode }}"
+require_text "${WORKFLOW}" "if: needs.validate-ref.outputs.deployment_mode == 'canary'"
+require_text "${WORKFLOW}" "CANARY_ACTION: destroy"
+require_text "${WORKFLOW}" "DATABASE_CANARY_URL"
+require_text "${WORKFLOW}" "DATABASE_DIRECT_URL=\"\${DATABASE_CANARY_DIRECT_URL}\""
+require_text "${DEPLOY_SCRIPT}" 'COMPOSE_PROJECT="agentbench-cutover-canary"'
+require_text "${DEPLOY_SCRIPT}" 'down --volumes --remove-orphans'
+require_text "${DEPLOY_SCRIPT}" '"${database_name}" != *_candidate'
+require_text "${DEPLOY_SCRIPT}" '^[0-9a-f]{12}$'
+require_text "${COMPOSE_FILE}" '"3182:3000"'
+require_text "${COMPOSE_FILE}" 'AGENTBENCH_WEB_URL: http://web:3000'
+
+set +e
+canonical_output="$({
+  CANARY_HOST=canary.invalid \
+    DATABASE_URL=postgresql://test:test@db.invalid:5432/agentbench_development \
+    GHCR_PAT=test-only \
+    GHCR_USERNAME=test-only \
+    GITHUB_REPOSITORY_OWNER=test-only \
+    IMAGE_TAG=0123456789ab \
+    RUNNER_SHARED_SECRET=test-only \
+    bash "${DEPLOY_SCRIPT}"
+} 2>&1)"
+canonical_status=$?
+
+mutable_tag_output="$({
+  CANARY_HOST=canary.invalid \
+    DATABASE_URL=postgresql://test:test@db.invalid:5432/agentbench_development_candidate \
+    GHCR_PAT=test-only \
+    GHCR_USERNAME=test-only \
+    GITHUB_REPOSITORY_OWNER=test-only \
+    IMAGE_TAG=latest-develop \
+    RUNNER_SHARED_SECRET=test-only \
+    bash "${DEPLOY_SCRIPT}"
+} 2>&1)"
+mutable_tag_status=$?
+set -e
+
+if [[ "${canonical_status}" -eq 0 || "${canonical_output}" != *"ending in _candidate"* ]]; then
+  echo "Canary deployment did not reject the canonical database." >&2
+  exit 1
+fi
+
+if [[ "${mutable_tag_status}" -eq 0 || "${mutable_tag_output}" != *"immutable 12-character commit tag"* ]]; then
+  echo "Canary deployment did not reject a mutable image tag." >&2
+  exit 1
+fi
+
+echo "Cutover canary contract tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -16,6 +16,9 @@ bash scripts/test-deploy-classifier.sh
 echo "== Web deployment workflow =="
 bash scripts/test-web-deploy-workflow.sh
 
+echo "== Cutover canary =="
+bash scripts/test-cutover-canary.sh
+
 echo "== Registry retry helper =="
 bash scripts/test-registry-retry.sh
 


### PR DESCRIPTION
## Summary
- add an isolated development canary for PostgreSQL cutover validation
- verify migrations, catalog publication, readiness, lifecycle behavior, and rollback controls
- keep canary state separate from active development traffic

## Verification
- `pnpm verify:ci`
- cutover canary contract tests
- Compose, workflow, and rollback-control validation

Closes #215