### PR TITLE
fix(deploy): include database package in orchestrator image

### DIFF
--- a/infra/docker/hosted-orchestrator.Dockerfile
+++ b/infra/docker/hosted-orchestrator.Dockerfile
@@ -7,12 +7,14 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.js
 COPY scripts ./scripts
 COPY apps/hosted-orchestrator ./apps/hosted-orchestrator
 COPY apps/hosted-sites ./apps/hosted-sites
+COPY packages/database ./packages/database
 COPY packages/protocol ./packages/protocol
 COPY packages/scoring ./packages/scoring
 COPY packages/shared ./packages/shared
 COPY packages/test-cases ./packages/test-cases
 
 RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @agentbench/database build:runtime
 RUN pnpm --filter @agentbench/scoring build
 RUN pnpm --filter @agentbench/test-cases build
 RUN pnpm --filter hosted-orchestrator build
@@ -25,15 +27,17 @@ RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.json ./
 COPY scripts ./scripts
 COPY apps/hosted-orchestrator ./apps/hosted-orchestrator
+COPY packages/database ./packages/database
 COPY packages/protocol ./packages/protocol
 COPY packages/scoring ./packages/scoring
 COPY packages/shared ./packages/shared
 COPY packages/test-cases ./packages/test-cases
 COPY --from=build /app/apps/hosted-orchestrator/dist ./apps/hosted-orchestrator/dist
+COPY --from=build /app/packages/database/dist ./packages/database/dist
 COPY --from=build /app/packages/scoring/dist ./packages/scoring/dist
 COPY --from=build /app/packages/test-cases/dist ./packages/test-cases/dist
 
 RUN pnpm install --prod --frozen-lockfile
 
 EXPOSE 3004
-CMD ["pnpm", "--filter", "hosted-orchestrator", "start"]
+CMD ["node", "--conditions=agentbench-runtime", "apps/hosted-orchestrator/dist/apps/hosted-orchestrator/src/server.js"]

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,15 +6,34 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./benchmark-cases": "./src/benchmark-cases/index.ts",
-    "./hosted-orchestrator": "./src/hosted-orchestrator/index.ts",
-    "./model-catalog": "./src/model-catalog/index.ts",
-    "./public-results": "./src/public-results/index.ts",
-    "./web-control-plane": "./src/web-control-plane/index.ts"
+    ".": {
+      "agentbench-runtime": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./benchmark-cases": {
+      "agentbench-runtime": "./dist/benchmark-cases/index.js",
+      "default": "./src/benchmark-cases/index.ts"
+    },
+    "./hosted-orchestrator": {
+      "agentbench-runtime": "./dist/hosted-orchestrator/index.js",
+      "default": "./src/hosted-orchestrator/index.ts"
+    },
+    "./model-catalog": {
+      "agentbench-runtime": "./dist/model-catalog/index.js",
+      "default": "./src/model-catalog/index.ts"
+    },
+    "./public-results": {
+      "agentbench-runtime": "./dist/public-results/index.js",
+      "default": "./src/public-results/index.ts"
+    },
+    "./web-control-plane": {
+      "agentbench-runtime": "./dist/web-control-plane/index.js",
+      "default": "./src/web-control-plane/index.ts"
+    }
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:runtime": "esbuild src/index.ts src/benchmark-cases/index.ts src/hosted-orchestrator/index.ts src/model-catalog/index.ts src/public-results/index.ts src/web-control-plane/index.ts --bundle --platform=node --format=esm --packages=external --outdir=dist --outbase=src",
     "test": "pnpm run build && node --import tsx --test tests/unit/*.test.ts",
     "test:integration": "node --import tsx --test tests/integration/*.test.ts"
   },
@@ -26,6 +45,7 @@
     "@types/node": "^22.20.0",
     "@types/pg": "^8.21.0",
     "drizzle-kit": "^0.31.10",
+    "esbuild": "^0.28.1",
     "tsx": "^4.23.0",
     "typescript": "^5.7.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       tsx:
         specifier: ^4.23.0
         version: 4.23.0

--- a/scripts/test-service-dockerfiles.sh
+++ b/scripts/test-service-dockerfiles.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORCHESTRATOR_DOCKERFILE="${ROOT_DIR}/infra/docker/hosted-orchestrator.Dockerfile"
+
+database_copy_count="$(grep -c '^COPY packages/database ./packages/database$' "${ORCHESTRATOR_DOCKERFILE}")"
+if [[ "${database_copy_count}" != "2" ]]; then
+  echo "hosted-orchestrator image must copy packages/database into build and runtime stages." >&2
+  exit 1
+fi
+
+required_lines=(
+  'RUN pnpm --filter @agentbench/database build:runtime'
+  'COPY --from=build /app/packages/database/dist ./packages/database/dist'
+  'CMD ["node", "--conditions=agentbench-runtime", "apps/hosted-orchestrator/dist/apps/hosted-orchestrator/src/server.js"]'
+)
+for required_line in "${required_lines[@]}"; do
+  if ! grep -Fqx "${required_line}" "${ORCHESTRATOR_DOCKERFILE}"; then
+    echo "hosted-orchestrator image is missing: ${required_line}" >&2
+    exit 1
+  fi
+done
+
+echo "Service Dockerfile tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -16,6 +16,9 @@ bash scripts/test-deploy-classifier.sh
 echo "== Web deployment workflow =="
 bash scripts/test-web-deploy-workflow.sh
 
+echo "== Service Dockerfiles =="
+bash scripts/test-service-dockerfiles.sh
+
 echo "== Cutover canary =="
 bash scripts/test-cutover-canary.sh
 


### PR DESCRIPTION
## Summary
- include `packages/database` in orchestrator build and runtime stages
- bundle provider-neutral database entrypoints for pure Node runtime loading
- use a service-specific export condition without changing Web or local development resolution
- add Dockerfile contract coverage

## Verification
- `pnpm verify:ci`
- clean hosted-orchestrator Docker image build
- runtime imports for `@agentbench/database` and `@agentbench/database/hosted-orchestrator`
- production Web build

Closes #228

Blocks #216 until this fix deploys successfully.