### PR TITLE
docs(auth): align migration status with implementation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,14 +2,16 @@
 
 ## Authentication
 
-Public Web requests currently use an HTTP-only guest cookie. The
-`getCurrentUser()` seam remains guest-only until Auth.js is integrated.
-Service-to-service writes require
+Public Web requests use either an Auth.js database session or a signed,
+HTTP-only guest cookie. Signing in does not implicitly transfer guest runs;
+authenticated users must explicitly claim a run created by their current guest
+identity. Service-to-service writes require
 `x-runner-secret: <RUNNER_SHARED_SECRET>`. The header and environment variable
 retain a legacy name; they now authenticate hosted services, not a runner
 component.
 
-Hosted task requests use an opaque session token in `?session=<token>` or in the telemetry body. Only the SHA-256 token hash is stored in Supabase.
+Hosted task requests use an opaque session token in `?session=<token>` or in the
+telemetry body. Only the SHA-256 token hash is stored in PostgreSQL.
 
 ## Web API (`apps/web`)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,9 @@ This roadmap starts from the architecture that is already running. Completed wor
 - `apps/web` runs on Vercel and owns run creation, quota, live observability, replay, and artifacts.
 - The hosted stack runs behind Nginx and Cloudflare Tunnel on a private Linux host.
 - Redis is split into a hosted-session cache endpoint and an orchestrator command-Streams endpoint.
-- PostgreSQL is the durable lifecycle, audit, and scoring store. A self-hosted development candidate is provisioned behind PgBouncer with a validated data snapshot, but application traffic cutover is pending; production remains on Supabase-hosted PostgreSQL.
+- PostgreSQL is the durable lifecycle, audit, and scoring store. Development
+  application traffic uses self-hosted PostgreSQL behind PgBouncer; production
+  remains on Supabase-hosted PostgreSQL until its separately approved cutover.
 - Hosted-orchestrator is the sole hosted lifecycle database owner; hosted-sites has no database credential and Web uses orchestrator APIs or public read models for hosted data.
 - Complete private suite manifests live only in immutable `benchmark_case_revisions`; public case metadata is display-safe.
 - Hosted attempts store only revision identity, generation seed, active-session pointer, sequence pointer, and completed session ids; generated per-session task config lives on `hosted_web_sessions.metadata`.
@@ -104,7 +106,7 @@ Status: In Progress ([#211](https://github.com/Kaiwen0418/agent-benchmark/issues
 | --- | --- | --- |
 | DB.1 Portable persistence foundation | Complete | Domain-owned Drizzle repositories, portable lifecycle functions, clean-PostgreSQL CI, self-hosted PostgreSQL/PgBouncer, transfer validation, and backup/restore verification work without Supabase APIs. |
 | DB.2 Development traffic cutover | In Progress ([#212](https://github.com/Kaiwen0418/agent-benchmark/issues/212)-[#216](https://github.com/Kaiwen0418/agent-benchmark/issues/216)) | Database-aware readiness, provider-neutral smoke, independent Web CD, isolated candidate canary, final write freeze, traffic cutover, observation, and rollback drill pass in development. |
-| DB.3 Application-owned identity | Planned ([#217](https://github.com/Kaiwen0418/agent-benchmark/issues/217)) | Auth.js owns portable identity/session tables, required historical ownership is migrated, guest behavior remains valid, and Supabase Auth runtime coupling is removable. |
+| DB.3 Application-owned identity | In Progress ([#217](https://github.com/Kaiwen0418/agent-benchmark/issues/217)) | Auth.js owns portable identity/session tables, required historical ownership is migrated, guest behavior remains valid, and development OAuth activation plus end-to-end identity verification pass before Supabase Auth runtime coupling is removed. |
 | DB.4 Production and cloud portability | Planned ([#218](https://github.com/Kaiwen0418/agent-benchmark/issues/218), [#219](https://github.com/Kaiwen0418/agent-benchmark/issues/219)) | Production cutover passes integrity, browser/lifecycle E2E, backup/restore, observation, and rollback; later cloud modules preserve standard image and PostgreSQL contracts. |
 
 Completion criteria: a clean standard PostgreSQL deployment can restore and
@@ -112,9 +114,10 @@ serve all application data without Supabase APIs, browsers have no direct
 database access, and development plus production cutovers have validated
 integrity, backup, restore, and rollback procedures.
 
-Current progress: DB.1 and the development candidate snapshot are complete.
-DB.2 is the active release gate. DB.3 must complete before DB.4 production
-cutover; Terraform remains non-blocking until the runtime topology is stable.
+Current progress: DB.1 and the development database traffic cutover are
+complete. DB.2 follow-up work and DB.3 OAuth activation remain active release
+gates before DB.4 production cutover; Terraform remains non-blocking until the
+runtime topology is stable.
 
 ## P1: Benchmark Quality
 


### PR DESCRIPTION
## Summary

- describe Auth.js database sessions and explicit guest run claims in the API reference
- replace the stale Supabase token-hash storage reference with PostgreSQL
- record the completed development database cutover and in-progress OAuth activation in the roadmap

## Verification

- `pnpm verify:ci`
- development `/account` at 1280x900 and 390x844
- disabled GitHub sign-in while environment credentials are absent
- `/api/auth/session` returns 503 with `Cache-Control: no-store` in frozen configuration

Refs #217