### PR TITLE
fix(auth): clarify account recreation after deletion

### DIFF
--- a/apps/web/app/account/page.tsx
+++ b/apps/web/app/account/page.tsx
@@ -49,7 +49,7 @@ async function deleteAccount(formData: FormData) {
   }
 
   await getAuthIdentityRepository().deleteIdentity(user.id);
-  await signOut({ redirectTo: "/" });
+  await signOut({ redirectTo: "/account?deleted=1" });
 }
 
 const messages: Record<string, string> = {
@@ -64,7 +64,7 @@ const messages: Record<string, string> = {
 export default async function AccountPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string; claimed?: string }>;
+  searchParams: Promise<{ error?: string; claimed?: string; deleted?: string }>;
 }) {
   const [params, user, claimableGuestId] = await Promise.all([
     searchParams,
@@ -98,6 +98,11 @@ export default async function AccountPage({
           {params.claimed ? (
             <p className="mt-6 border-l-4 border-[#d7ff00] bg-[#111111] px-4 py-3 text-sm text-white" role="status">
               Claimed {params.claimed} guest run{params.claimed === "1" ? "" : "s"}.
+            </p>
+          ) : null}
+          {params.deleted === "1" ? (
+            <p className="mt-6 border-l-4 border-[#d7ff00] bg-[#111111] px-4 py-3 text-sm text-white" role="status">
+              Account deleted. Signing in again will create a new AgentBench identity.
             </p>
           ) : null}
 
@@ -148,6 +153,7 @@ export default async function AccountPage({
                 <p className="mt-2 text-sm leading-6 text-[#5f594e]">
                   Provider accounts, sessions, and profile data are deleted. Benchmark results are
                   retained without user ownership so public scoring history remains reproducible.
+                  You may sign in again later, but that creates a new AgentBench identity.
                 </p>
                 <label className="mt-4 block max-w-xs text-xs uppercase tracking-[0.18em] text-[#6f685d]">
                   Type DELETE

--- a/packages/database/tests/integration/auth-identity-repository.test.ts
+++ b/packages/database/tests/integration/auth-identity-repository.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { eq } from "drizzle-orm";
 import {
+  authAccounts,
   authSessions,
   authUsers,
   benchmarkCases,
@@ -22,13 +23,22 @@ test("identity repository claims only one guest and anonymizes ownership on dele
   const repository = createAuthIdentityRepository(client.db);
   const firstUserId = crypto.randomUUID();
   const secondUserId = crypto.randomUUID();
+  const replacementUserId = crypto.randomUUID();
   const guestId = crypto.randomUUID();
+  const firstEmail = `first-${crypto.randomUUID()}@example.test`;
+  const providerAccountId = crypto.randomUUID();
 
   try {
     await client.db.insert(authUsers).values([
-      { id: firstUserId, email: `first-${crypto.randomUUID()}@example.test` },
+      { id: firstUserId, email: firstEmail },
       { id: secondUserId, email: `second-${crypto.randomUUID()}@example.test` },
     ]);
+    await client.db.insert(authAccounts).values({
+      userId: firstUserId,
+      type: "oauth",
+      provider: "github",
+      providerAccountId,
+    });
     const [benchmarkCase] = await client.db.insert(benchmarkCases).values({
       slug: `auth-${crypto.randomUUID()}`,
       title: "Auth identity benchmark",
@@ -78,6 +88,10 @@ test("identity repository claims only one guest and anonymizes ownership on dele
 
     assert.deepEqual(await repository.deleteIdentity(firstUserId), { anonymizedRuns: 1 });
     assert.equal((await client.db.select().from(authUsers).where(eq(authUsers.id, firstUserId))).length, 0);
+    assert.equal((await client.db.select().from(authAccounts)
+      .where(eq(authAccounts.userId, firstUserId))).length, 0);
+    assert.equal((await client.db.select().from(authSessions)
+      .where(eq(authSessions.userId, firstUserId))).length, 0);
     const [anonymousRun] = await client.db.select().from(benchmarkRuns).where(eq(benchmarkRuns.id, run.id));
     assert.equal(anonymousRun?.userId, null);
     assert.match(anonymousRun?.guestId ?? "", /^deleted-account:/);
@@ -86,8 +100,19 @@ test("identity repository claims only one guest and anonymizes ownership on dele
     assert.equal(anonymousSession?.createdByUserId, null);
     assert.match(anonymousSession?.createdByGuestId ?? "", /^deleted-account:/);
 
+    await client.db.insert(authUsers).values({ id: replacementUserId, email: firstEmail });
+    await client.db.insert(authAccounts).values({
+      userId: replacementUserId,
+      type: "oauth",
+      provider: "github",
+      providerAccountId,
+    });
+    assert.equal((await client.db.select().from(authUsers)
+      .where(eq(authUsers.id, replacementUserId))).length, 1);
+
     await client.db.delete(benchmarkRuns).where(eq(benchmarkRuns.id, run.id));
     await client.db.delete(benchmarkCases).where(eq(benchmarkCases.id, benchmarkCase.id));
+    await client.db.delete(authUsers).where(eq(authUsers.id, replacementUserId));
     await client.db.delete(authUsers).where(eq(authUsers.id, secondUserId));
   } finally {
     await client.close();


### PR DESCRIPTION
## Summary

- return deleted users to the account page with an explicit success message
- explain that a later GitHub sign-in creates a new AgentBench identity
- verify deletion cascades OAuth accounts and sessions while allowing deliberate re-registration

## Verification

- `pnpm --filter web test`
- `pnpm verify:ci`
- `/account?deleted=1` at 1280x900 and 390x844 with no overflow or browser errors

Refs #217