### PR TITLE
ops(database): automate production migration preflight

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -154,6 +154,34 @@ result.
 
 Never remove the self-hosted PostgreSQL volume as part of application rollback.
 
+### Production migration preflight
+
+Production migration is a separately approved operation under issue #218. Run
+the read-only preflight before any production write freeze, data transfer,
+secret update, deployment, or routing change:
+
+```bash
+SOURCE_DATABASE_URL="$PRODUCTION_SOURCE_DIRECT_URL" \
+TARGET_DATABASE_URL="$PRODUCTION_CANDIDATE_DIRECT_URL" \
+EXPECTED_SOURCE_DATABASE_NAME=postgres \
+EXPECTED_TARGET_DATABASE_NAME=agentbench_production_candidate \
+VERIFIED_BACKUP_FILE=/protected/backups/agentbench-<timestamp>.dump \
+RESTORE_VERIFICATION_FILE=/protected/evidence/restore-<timestamp>.txt \
+  scripts/db-production-preflight.sh | tee /protected/evidence/preflight-<timestamp>.txt
+```
+
+Create `RESTORE_VERIFICATION_FILE` by capturing the output of
+`verify-postgres-backup.sh` after restoring the referenced custom-format dump.
+The receipt includes the dump SHA-256, and preflight rejects evidence produced
+for a different backup.
+The preflight requires explicit database names, refuses an identical endpoint
+or a development/test target, and fails on schema drift, active runs, callback
+backlog, or application rows in the candidate. Its output contains database
+names and counts only; it never prints connection URLs or credentials. Passing
+preflight authorizes no mutation by itself. Provisioning the production target,
+freezing writes, copying data, updating secrets, deploying, and switching
+traffic each remain part of the approved #218 cutover window.
+
 ## Self-hosted Web
 
 The complete Next.js Web control plane can run as a standalone container using

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -105,19 +105,20 @@ Status: In Progress ([#211](https://github.com/Kaiwen0418/agent-benchmark/issues
 | Milestone | Status | Exit criteria |
 | --- | --- | --- |
 | DB.1 Portable persistence foundation | Complete | Domain-owned Drizzle repositories, portable lifecycle functions, clean-PostgreSQL CI, self-hosted PostgreSQL/PgBouncer, transfer validation, and backup/restore verification work without Supabase APIs. |
-| DB.2 Development traffic cutover | In Progress ([#212](https://github.com/Kaiwen0418/agent-benchmark/issues/212)-[#216](https://github.com/Kaiwen0418/agent-benchmark/issues/216)) | Database-aware readiness, provider-neutral smoke, independent Web CD, isolated candidate canary, final write freeze, traffic cutover, observation, and rollback drill pass in development. |
-| DB.3 Application-owned identity | In Progress ([#217](https://github.com/Kaiwen0418/agent-benchmark/issues/217)) | Auth.js owns portable identity/session tables, required historical ownership is migrated, guest behavior remains valid, and development OAuth activation plus end-to-end identity verification pass before Supabase Auth runtime coupling is removed. |
-| DB.4 Production and cloud portability | Planned ([#218](https://github.com/Kaiwen0418/agent-benchmark/issues/218), [#219](https://github.com/Kaiwen0418/agent-benchmark/issues/219)) | Production cutover passes integrity, browser/lifecycle E2E, backup/restore, observation, and rollback; later cloud modules preserve standard image and PostgreSQL contracts. |
+| DB.2 Development traffic cutover | Complete ([#212](https://github.com/Kaiwen0418/agent-benchmark/issues/212)-[#216](https://github.com/Kaiwen0418/agent-benchmark/issues/216)) | Database-aware readiness, provider-neutral smoke, independent Web CD, isolated candidate canary, final write freeze, traffic cutover, observation, and rollback drill pass in development. |
+| DB.3 Application-owned identity | Complete ([#217](https://github.com/Kaiwen0418/agent-benchmark/issues/217)) | Auth.js owns portable identity/session tables, required historical ownership is migrated, guest behavior remains valid, and development OAuth activation plus end-to-end identity verification pass before Supabase Auth runtime coupling is removed. |
+| DB.4 Production and cloud portability | In Progress ([#218](https://github.com/Kaiwen0418/agent-benchmark/issues/218), [#219](https://github.com/Kaiwen0418/agent-benchmark/issues/219), [#239](https://github.com/Kaiwen0418/agent-benchmark/issues/239)) | Production cutover passes integrity, browser/lifecycle E2E, backup/restore, observation, and rollback; later cloud modules preserve standard image and PostgreSQL contracts. |
 
 Completion criteria: a clean standard PostgreSQL deployment can restore and
 serve all application data without Supabase APIs, browsers have no direct
 database access, and development plus production cutovers have validated
 integrity, backup, restore, and rollback procedures.
 
-Current progress: DB.1 and the development database traffic cutover are
-complete. DB.2 follow-up work and DB.3 OAuth activation remain active release
-gates before DB.4 production cutover; Terraform remains non-blocking until the
-runtime topology is stable.
+Current progress: the portable persistence foundation, development traffic
+cutover, and Auth.js identity ownership are complete. DB.4 begins with the
+read-only production migration preflight in #239; production mutation and
+cutover remain separately approved work under #218. Terraform remains
+non-blocking until the runtime topology is stable.
 
 ## P1: Benchmark Quality
 

--- a/infra/scripts/verify-postgres-backup.sh
+++ b/infra/scripts/verify-postgres-backup.sh
@@ -66,4 +66,14 @@ if [ "${result}" != "t" ]; then
   exit 1
 fi
 
+if command -v sha256sum >/dev/null 2>&1; then
+  backup_sha256="$(sha256sum "${BACKUP_FILE}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  backup_sha256="$(shasum -a 256 "${BACKUP_FILE}" | awk '{print $1}')"
+else
+  echo "sha256sum or shasum is required to record restore evidence." >&2
+  exit 1
+fi
+
+echo "backup_sha256=${backup_sha256}"
 echo "PostgreSQL backup restore verification passed."

--- a/scripts/db-production-preflight.sh
+++ b/scripts/db-production-preflight.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATABASE_EXECUTOR="${ROOT_DIR}/scripts/lib/exec-postgres-url.py"
+# shellcheck source=lib/application-tables.sh
+source "${ROOT_DIR}/scripts/lib/application-tables.sh"
+
+SOURCE_DATABASE_URL="${SOURCE_DATABASE_URL:-}"
+TARGET_DATABASE_URL="${TARGET_DATABASE_URL:-}"
+EXPECTED_SOURCE_DATABASE_NAME="${EXPECTED_SOURCE_DATABASE_NAME:-}"
+EXPECTED_TARGET_DATABASE_NAME="${EXPECTED_TARGET_DATABASE_NAME:-}"
+VERIFIED_BACKUP_FILE="${VERIFIED_BACKUP_FILE:-}"
+RESTORE_VERIFICATION_FILE="${RESTORE_VERIFICATION_FILE:-}"
+
+required_variables=(
+  SOURCE_DATABASE_URL
+  TARGET_DATABASE_URL
+  EXPECTED_SOURCE_DATABASE_NAME
+  EXPECTED_TARGET_DATABASE_NAME
+  VERIFIED_BACKUP_FILE
+  RESTORE_VERIFICATION_FILE
+)
+for variable in "${required_variables[@]}"; do
+  if [[ -z "${!variable:-}" ]]; then
+    echo "${variable} is required." >&2
+    exit 1
+  fi
+done
+
+for database_name in "${EXPECTED_SOURCE_DATABASE_NAME}" "${EXPECTED_TARGET_DATABASE_NAME}"; do
+  if [[ ! "${database_name}" =~ ^[a-zA-Z0-9_]+$ ]]; then
+    echo "Expected database names may contain only letters, numbers, and underscores." >&2
+    exit 1
+  fi
+done
+
+if [[ "${SOURCE_DATABASE_URL}" == "${TARGET_DATABASE_URL}" ]] \
+  || [[ "${EXPECTED_SOURCE_DATABASE_NAME}" == "${EXPECTED_TARGET_DATABASE_NAME}" ]]; then
+  echo "Source and target databases must be distinct." >&2
+  exit 1
+fi
+if [[ "${EXPECTED_TARGET_DATABASE_NAME}" != *_candidate ]]; then
+  echo "Production preflight target database must end in _candidate." >&2
+  exit 1
+fi
+target_name_lower="$(printf '%s' "${EXPECTED_TARGET_DATABASE_NAME}" | tr '[:upper:]' '[:lower:]')"
+if [[ "${target_name_lower}" =~ (^|_)(dev|development|test|testing|local)($|_) ]]; then
+  echo "Production preflight refuses a development, test, or local target database." >&2
+  exit 1
+fi
+
+if [[ ! -s "${VERIFIED_BACKUP_FILE}" ]]; then
+  echo "VERIFIED_BACKUP_FILE must identify a non-empty PostgreSQL custom-format backup." >&2
+  exit 1
+fi
+if ! DATABASE_COMMAND_URL="${SOURCE_DATABASE_URL}" "${DATABASE_EXECUTOR}" \
+  pg_restore --list <"${VERIFIED_BACKUP_FILE}" >/dev/null 2>&1; then
+  echo "VERIFIED_BACKUP_FILE is not a readable PostgreSQL custom-format backup." >&2
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  backup_sha256="$(sha256sum "${VERIFIED_BACKUP_FILE}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  backup_sha256="$(shasum -a 256 "${VERIFIED_BACKUP_FILE}" | awk '{print $1}')"
+else
+  echo "sha256sum or shasum is required to validate restore evidence." >&2
+  exit 1
+fi
+if [[ ! -s "${RESTORE_VERIFICATION_FILE}" ]] \
+  || ! grep -Fqx "backup_sha256=${backup_sha256}" "${RESTORE_VERIFICATION_FILE}" \
+  || ! grep -Fqx "PostgreSQL backup restore verification passed." "${RESTORE_VERIFICATION_FILE}"; then
+  echo "RESTORE_VERIFICATION_FILE does not contain successful restore evidence." >&2
+  exit 1
+fi
+
+manifest_values=""
+target_total_query="select "
+for table in "${APPLICATION_TABLES[@]}"; do
+  manifest_values+="('${table}'),"
+  target_total_query+="(select count(*) from public.${table}) + "
+done
+manifest_values="${manifest_values%,}"
+target_total_query="${target_total_query% + };"
+
+database_query() {
+  local url="$1"
+  local query="$2"
+  DATABASE_COMMAND_URL="${url}" "${DATABASE_EXECUTOR}" \
+    psql -X -v ON_ERROR_STOP=1 -Atqc "${query}"
+}
+
+identity_query="select concat_ws('|', current_database(), coalesce(inet_server_addr()::text, 'local'), inet_server_port());"
+source_identity="$(database_query "${SOURCE_DATABASE_URL}" "${identity_query}")"
+target_identity="$(database_query "${TARGET_DATABASE_URL}" "${identity_query}")"
+source_name="${source_identity%%|*}"
+target_name="${target_identity%%|*}"
+
+if [[ "${source_name}" != "${EXPECTED_SOURCE_DATABASE_NAME}" ]]; then
+  echo "Source database identity does not match the expected name." >&2
+  exit 1
+fi
+if [[ "${target_name}" != "${EXPECTED_TARGET_DATABASE_NAME}" ]]; then
+  echo "Target database identity does not match the expected name." >&2
+  exit 1
+fi
+if [[ "${source_identity}" == "${target_identity}" ]]; then
+  echo "Source and target resolve to the same PostgreSQL database." >&2
+  exit 1
+fi
+
+missing_query="with required(table_name) as (values ${manifest_values})
+select count(*)
+from required
+left join information_schema.tables actual
+  on actual.table_schema = 'public'
+ and actual.table_type = 'BASE TABLE'
+ and actual.table_name = required.table_name
+where actual.table_name is null;"
+unexpected_query="with required(table_name) as (values ${manifest_values})
+select count(*)
+from information_schema.tables actual
+left join required
+  on required.table_name = actual.table_name
+where actual.table_schema = 'public'
+  and actual.table_type = 'BASE TABLE'
+  and required.table_name is null;"
+source_missing_tables="$(database_query "${SOURCE_DATABASE_URL}" "${missing_query}")"
+target_missing_tables="$(database_query "${TARGET_DATABASE_URL}" "${missing_query}")"
+source_unexpected_tables="$(database_query "${SOURCE_DATABASE_URL}" "${unexpected_query}")"
+target_unexpected_tables="$(database_query "${TARGET_DATABASE_URL}" "${unexpected_query}")"
+if [[ "${source_missing_tables}" != "0" || "${target_missing_tables}" != "0" \
+  || "${source_unexpected_tables}" != "0" || "${target_unexpected_tables}" != "0" ]]; then
+  echo "Source or target public tables differ from the application transfer manifest." >&2
+  exit 1
+fi
+
+required_objects_query="select (
+  to_regclass('public.public_hosted_run_summaries') is not null
+  and to_regclass('public.public_hosted_run_tasks') is not null
+  and to_regprocedure('public.complete_hosted_attempt_session(uuid,uuid,timestamp with time zone,jsonb,jsonb)') is not null
+  and to_regprocedure('public.timeout_hosted_attempt(uuid,timestamp with time zone,uuid,jsonb)') is not null
+);"
+source_schema_valid="$(database_query "${SOURCE_DATABASE_URL}" "${required_objects_query}")"
+target_schema_valid="$(database_query "${TARGET_DATABASE_URL}" "${required_objects_query}")"
+if [[ "${source_schema_valid}" != "t" || "${target_schema_valid}" != "t" ]]; then
+  echo "Source or target is missing required views or lifecycle functions." >&2
+  exit 1
+fi
+
+active_runs="$(database_query "${SOURCE_DATABASE_URL}" \
+  "select count(*) from public.benchmark_runs where status not in ('completed', 'failed', 'cancelled', 'timeout');")"
+callback_backlog="$(database_query "${SOURCE_DATABASE_URL}" \
+  "select count(*) from public.hosted_callback_outbox where status in ('pending', 'delivering');")"
+target_rows="$(database_query "${TARGET_DATABASE_URL}" "${target_total_query}")"
+
+if [[ "${active_runs}" != "0" ]]; then
+  echo "Production migration preflight is blocked by active benchmark runs." >&2
+  exit 1
+fi
+if [[ "${callback_backlog}" != "0" ]]; then
+  echo "Production migration preflight is blocked by pending callback delivery." >&2
+  exit 1
+fi
+if [[ "${target_rows}" != "0" ]]; then
+  echo "Production migration candidate contains application rows." >&2
+  exit 1
+fi
+
+cat <<EOF
+preflight=passed
+source_database=${source_name}
+target_database=${target_name}
+manifest_tables=${#APPLICATION_TABLES[@]}
+active_runs=${active_runs}
+callback_backlog=${callback_backlog}
+target_application_rows=${target_rows}
+source_schema_valid=true
+target_schema_valid=true
+backup_archive_valid=true
+backup_restore_digest_match=true
+restore_verification_present=true
+checked_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF

--- a/scripts/db-transfer-data.sh
+++ b/scripts/db-transfer-data.sh
@@ -5,6 +5,8 @@ SOURCE_DATABASE_URL="${SOURCE_DATABASE_URL:-}"
 TARGET_DATABASE_URL="${TARGET_DATABASE_URL:-}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DATABASE_EXECUTOR="${ROOT_DIR}/scripts/lib/exec-postgres-url.py"
+# shellcheck source=lib/application-tables.sh
+source "${ROOT_DIR}/scripts/lib/application-tables.sh"
 
 if [ -z "${SOURCE_DATABASE_URL}" ] || [ -z "${TARGET_DATABASE_URL}" ]; then
   echo "SOURCE_DATABASE_URL and TARGET_DATABASE_URL are required." >&2
@@ -31,29 +33,6 @@ else
   done
 fi
 
-tables=(
-  auth_users
-  auth_accounts
-  auth_sessions
-  auth_verification_tokens
-  profiles
-  benchmark_cases
-  benchmark_case_revisions
-  model_catalog
-  model_catalog_sync_runs
-  benchmark_runs
-  run_events
-  artifacts
-  benchmark_attempts
-  hosted_web_sessions
-  hosted_web_results
-  benchmark_attempt_scores
-  hosted_web_events
-  hosted_web_access_logs
-  hosted_callback_outbox
-  orchestrator_command_dead_letters
-)
-
 archive="$(mktemp -t agentbench-data-transfer.XXXXXX)"
 cleanup() {
   rm -f "${archive}"
@@ -63,14 +42,14 @@ trap cleanup EXIT
 count_query() {
   local query=""
   local table
-  for table in "${tables[@]}"; do
+  for table in "${APPLICATION_TABLES[@]}"; do
     query+="select '${table}' as table_name, count(*)::text as row_count from public.${table};"
   done
   printf '%s' "${query}"
 }
 
 target_total_query="select "
-for table in "${tables[@]}"; do
+for table in "${APPLICATION_TABLES[@]}"; do
   target_total_query+="(select count(*) from public.${table}) + "
 done
 target_total_query="${target_total_query% + };"
@@ -97,7 +76,7 @@ dump_args=(
   --no-privileges
   --serializable-deferrable
 )
-for table in "${tables[@]}"; do
+for table in "${APPLICATION_TABLES[@]}"; do
   dump_args+=(--table="public.${table}")
 done
 
@@ -154,7 +133,7 @@ if [ "${source_counts}" != "${target_counts}" ]; then
 fi
 
 analyze_query=""
-for table in "${tables[@]}"; do
+for table in "${APPLICATION_TABLES[@]}"; do
   analyze_query+="analyze public.${table};"
 done
 DATABASE_COMMAND_URL="${TARGET_DATABASE_URL}" "${DATABASE_EXECUTOR}" \

--- a/scripts/lib/application-tables.sh
+++ b/scripts/lib/application-tables.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Durable application tables copied during a full PostgreSQL migration.
+APPLICATION_TABLES=(
+  auth_users
+  auth_accounts
+  auth_sessions
+  auth_verification_tokens
+  profiles
+  benchmark_cases
+  benchmark_case_revisions
+  model_catalog
+  model_catalog_sync_runs
+  benchmark_runs
+  run_events
+  artifacts
+  benchmark_attempts
+  hosted_web_sessions
+  hosted_web_results
+  benchmark_attempt_scores
+  hosted_web_events
+  hosted_web_access_logs
+  hosted_callback_outbox
+  orchestrator_command_dead_letters
+)

--- a/scripts/test-production-migration-preflight.sh
+++ b/scripts/test-production-migration-preflight.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER="agentbench-production-preflight-$RANDOM"
+BACKUP_FILE="$(mktemp -t agentbench-production-preflight.XXXXXX)"
+RESTORE_EVIDENCE_FILE="$(mktemp -t agentbench-production-restore.XXXXXX)"
+
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+  rm -f "${BACKUP_FILE}" "${RESTORE_EVIDENCE_FILE}"
+}
+trap cleanup EXIT
+
+docker run -d --rm --name "${CONTAINER}" \
+  -p 127.0.0.1::5432 \
+  -e POSTGRES_PASSWORD=postgres \
+  postgres:17-alpine >/dev/null
+
+for _ in $(seq 1 30); do
+  if docker exec "${CONTAINER}" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+databases=(agentbench_source agentbench_production_candidate agentbench_nonempty_candidate missing_candidate)
+for database in "${databases[@]}"; do
+  docker exec "${CONTAINER}" createdb -U postgres "${database}"
+done
+
+mapped_address="$(docker port "${CONTAINER}" 5432/tcp)"
+mapped_port="${mapped_address##*:}"
+host_url() {
+  printf 'postgresql://postgres:postgres@127.0.0.1:%s/%s' "${mapped_port}" "$1"
+}
+container_url() {
+  printf 'postgresql://postgres:postgres@127.0.0.1:5432/%s' "$1"
+}
+
+cd "${ROOT_DIR}"
+for database in agentbench_source agentbench_production_candidate agentbench_nonempty_candidate; do
+  DATABASE_DIRECT_URL="$(host_url "${database}")" bash scripts/db-migrate.sh test >/dev/null
+done
+DATABASE_DIRECT_URL="$(host_url agentbench_source)" pnpm catalog:publish >/dev/null
+DATABASE_DIRECT_URL="$(host_url agentbench_nonempty_candidate)" pnpm catalog:publish >/dev/null
+
+docker exec "${CONTAINER}" pg_dump -U postgres -d agentbench_source \
+  --format=custom --no-owner --no-acl >"${BACKUP_FILE}"
+if command -v sha256sum >/dev/null 2>&1; then
+  backup_sha256="$(sha256sum "${BACKUP_FILE}" | awk '{print $1}')"
+else
+  backup_sha256="$(shasum -a 256 "${BACKUP_FILE}" | awk '{print $1}')"
+fi
+printf 'backup_sha256=%s\n%s\n' "${backup_sha256}" \
+  "PostgreSQL backup restore verification passed." >"${RESTORE_EVIDENCE_FILE}"
+
+preflight() {
+  POSTGRES_TOOLS_CONTAINER="${CONTAINER}" \
+  SOURCE_DATABASE_URL="$(container_url agentbench_source)" \
+  TARGET_DATABASE_URL="$(container_url agentbench_production_candidate)" \
+  EXPECTED_SOURCE_DATABASE_NAME=agentbench_source \
+  EXPECTED_TARGET_DATABASE_NAME=agentbench_production_candidate \
+  VERIFIED_BACKUP_FILE="${BACKUP_FILE}" \
+  RESTORE_VERIFICATION_FILE="${RESTORE_EVIDENCE_FILE}" \
+    bash scripts/db-production-preflight.sh
+}
+
+expect_failure() {
+  local description="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "Production preflight accepted ${description}." >&2
+    exit 1
+  fi
+}
+
+output="$(preflight)"
+grep -Fqx "preflight=passed" <<<"${output}"
+grep -Fqx "manifest_tables=20" <<<"${output}"
+grep -Fqx "target_application_rows=0" <<<"${output}"
+if grep -Fq "postgresql://" <<<"${output}"; then
+  echo "Production preflight exposed a database URL." >&2
+  exit 1
+fi
+
+printf '%s\n%s\n' "backup_sha256=invalid" \
+  "PostgreSQL backup restore verification passed." >"${RESTORE_EVIDENCE_FILE}"
+expect_failure "restore evidence for a different backup" preflight
+printf 'backup_sha256=%s\n%s\n' "${backup_sha256}" \
+  "PostgreSQL backup restore verification passed." >"${RESTORE_EVIDENCE_FILE}"
+
+docker exec "${CONTAINER}" psql -U postgres -d agentbench_source -v ON_ERROR_STOP=1 \
+  -c "create table public.untracked_preflight_table (id integer primary key)" >/dev/null
+expect_failure "an untracked public table" preflight
+docker exec "${CONTAINER}" psql -U postgres -d agentbench_source -v ON_ERROR_STOP=1 \
+  -c "drop table public.untracked_preflight_table" >/dev/null
+
+expect_failure "an incorrect source identity" env \
+  POSTGRES_TOOLS_CONTAINER="${CONTAINER}" \
+  SOURCE_DATABASE_URL="$(container_url agentbench_source)" \
+  TARGET_DATABASE_URL="$(container_url agentbench_production_candidate)" \
+  EXPECTED_SOURCE_DATABASE_NAME=wrong_source \
+  EXPECTED_TARGET_DATABASE_NAME=agentbench_production_candidate \
+  VERIFIED_BACKUP_FILE="${BACKUP_FILE}" RESTORE_VERIFICATION_FILE="${RESTORE_EVIDENCE_FILE}" \
+  bash scripts/db-production-preflight.sh
+
+expect_failure "the same source and target" env \
+  POSTGRES_TOOLS_CONTAINER="${CONTAINER}" \
+  SOURCE_DATABASE_URL="$(container_url agentbench_source)" \
+  TARGET_DATABASE_URL="$(container_url agentbench_source)" \
+  EXPECTED_SOURCE_DATABASE_NAME=agentbench_source \
+  EXPECTED_TARGET_DATABASE_NAME=agentbench_source \
+  VERIFIED_BACKUP_FILE="${BACKUP_FILE}" RESTORE_VERIFICATION_FILE="${RESTORE_EVIDENCE_FILE}" \
+  bash scripts/db-production-preflight.sh
+
+expect_failure "a development target" env \
+  SOURCE_DATABASE_URL=postgresql://example/source \
+  TARGET_DATABASE_URL=postgresql://example/target \
+  EXPECTED_SOURCE_DATABASE_NAME=agentbench_source \
+  EXPECTED_TARGET_DATABASE_NAME=agentbench_development_candidate \
+  VERIFIED_BACKUP_FILE="${BACKUP_FILE}" RESTORE_VERIFICATION_FILE="${RESTORE_EVIDENCE_FILE}" \
+  bash scripts/db-production-preflight.sh
+
+expect_failure "a target with missing schema" env \
+  POSTGRES_TOOLS_CONTAINER="${CONTAINER}" \
+  SOURCE_DATABASE_URL="$(container_url agentbench_source)" \
+  TARGET_DATABASE_URL="$(container_url missing_candidate)" \
+  EXPECTED_SOURCE_DATABASE_NAME=agentbench_source \
+  EXPECTED_TARGET_DATABASE_NAME=missing_candidate \
+  VERIFIED_BACKUP_FILE="${BACKUP_FILE}" RESTORE_VERIFICATION_FILE="${RESTORE_EVIDENCE_FILE}" \
+  bash scripts/db-production-preflight.sh
+
+expect_failure "a non-empty target" env \
+  POSTGRES_TOOLS_CONTAINER="${CONTAINER}" \
+  SOURCE_DATABASE_URL="$(container_url agentbench_source)" \
+  TARGET_DATABASE_URL="$(container_url agentbench_nonempty_candidate)" \
+  EXPECTED_SOURCE_DATABASE_NAME=agentbench_source \
+  EXPECTED_TARGET_DATABASE_NAME=agentbench_nonempty_candidate \
+  VERIFIED_BACKUP_FILE="${BACKUP_FILE}" RESTORE_VERIFICATION_FILE="${RESTORE_EVIDENCE_FILE}" \
+  bash scripts/db-production-preflight.sh
+
+docker exec -i "${CONTAINER}" psql -U postgres -d agentbench_source -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+insert into public.benchmark_runs (id, guest_id, case_id, status)
+select '20000000-0000-4000-8000-000000000001', 'preflight-active', id, 'running'
+from public.benchmark_cases order by slug limit 1;
+SQL
+expect_failure "an active run" preflight
+docker exec "${CONTAINER}" psql -U postgres -d agentbench_source -v ON_ERROR_STOP=1 \
+  -c "update public.benchmark_runs set status = 'completed', completed_at = now() where id = '20000000-0000-4000-8000-000000000001'" >/dev/null
+
+docker exec -i "${CONTAINER}" psql -U postgres -d agentbench_source -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+insert into public.benchmark_attempts (
+  id, run_id, case_id, provider, suite_slug, suite_version, status
+)
+select
+  '20000000-0000-4000-8000-000000000002',
+  '20000000-0000-4000-8000-000000000001',
+  case_id,
+  'hosted-web',
+  'preflight-suite',
+  'v1',
+  'completed'
+from public.benchmark_runs
+where id = '20000000-0000-4000-8000-000000000001';
+
+insert into public.hosted_callback_outbox (attempt_id, run_id, payload)
+values (
+  '20000000-0000-4000-8000-000000000002',
+  '20000000-0000-4000-8000-000000000001',
+  '{"type":"preflight"}'
+);
+SQL
+expect_failure "a callback backlog" preflight
+
+echo "Production PostgreSQL migration preflight tests passed"

--- a/scripts/verify-ci.sh
+++ b/scripts/verify-ci.sh
@@ -55,6 +55,9 @@ bash scripts/test-postgres-backup-restore.sh
 echo "== PostgreSQL data transfer =="
 bash scripts/test-postgres-data-transfer.sh
 
+echo "== Production PostgreSQL migration preflight =="
+bash scripts/test-production-migration-preflight.sh
+
 echo "== Auth.js legacy identity migration =="
 bash scripts/test-authjs-legacy-migration.sh
 


### PR DESCRIPTION
Adds a read-only PostgreSQL migration preflight that rejects unexpected database identities, unsafe candidate names, schema/table-manifest drift, active runs, pending callbacks, and non-empty candidates. Transfer and preflight share one application-table manifest; restore receipts include a SHA-256 matched against the supplied backup.

Updates deployment instructions and records completion of development cutover and Auth.js milestones. This is an initial readiness gate: off-host encryption, backup provenance/freshness, writer freeze, Redis drain, integrity validation, and production cutover remain operational requirements under #218. No production migration or routing changes are included.

Verification: local pnpm verify:ci passed before the final backup-receipt change; dedicated preflight and backup/restore tests passed afterward. The push hook reran repository verification. GitHub CI must pass before merge. No frontend behavior changed.

Closes #239

Related: #218, #211